### PR TITLE
[#1] feat: 엔티티 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,9 +21,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+
     runtimeOnly 'mysql:mysql-connector-java'
+    runtimeOnly 'com.h2database:h2'
+
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/backend/src/main/java/kr/kro/colla/BackendApplication.java
+++ b/backend/src/main/java/kr/kro/colla/BackendApplication.java
@@ -2,7 +2,9 @@ package kr.kro.colla;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
@@ -1,0 +1,40 @@
+package kr.kro.colla.meeting_place.meeting_place.domain;
+
+import kr.kro.colla.meeting_place.mentioned_post.domain.MentionedPost;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+public class MeetingPlace {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    private String image;
+
+    @Column
+    private String review;
+
+    @Column
+    private String longitude;
+
+    @Column
+    private String latitude;
+
+    @Column
+    private String address;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_place_id")
+    private List<MentionedPost> mentionedPosts = new ArrayList<>();
+
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/converter/BooleanToIntegerConverter.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/converter/BooleanToIntegerConverter.java
@@ -1,0 +1,16 @@
+package kr.kro.colla.meeting_place.meeting_place.domain.converter;
+
+import javax.persistence.AttributeConverter;
+
+public class BooleanToIntegerConverter implements AttributeConverter<Boolean, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(Boolean attribute) {
+        return (attribute != null && attribute) ? 1 : 0;
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(Integer dbData) {
+        return dbData == 1;
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/mentioned_post/domain/MentionedPost.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/mentioned_post/domain/MentionedPost.java
@@ -1,0 +1,15 @@
+package kr.kro.colla.meeting_place.mentioned_post.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class MentionedPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String mentionedUrl;
+
+}

--- a/backend/src/main/java/kr/kro/colla/notice/domain/Notice.java
+++ b/backend/src/main/java/kr/kro/colla/notice/domain/Notice.java
@@ -1,0 +1,26 @@
+package kr.kro.colla.notice.domain;
+
+import kr.kro.colla.meeting_place.meeting_place.domain.converter.BooleanToIntegerConverter;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class Notice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.ORDINAL)
+    private NoticeType noticeType;
+
+    @Column
+    private String mentionedUrl;
+
+    @Convert(converter = BooleanToIntegerConverter.class)
+    @Column
+    private boolean isChecked;
+
+}

--- a/backend/src/main/java/kr/kro/colla/notice/domain/NoticeType.java
+++ b/backend/src/main/java/kr/kro/colla/notice/domain/NoticeType.java
@@ -1,0 +1,6 @@
+package kr.kro.colla.notice.domain;
+
+public enum NoticeType {
+
+    INVITE_USER, MENTION_USER;
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -1,0 +1,49 @@
+package kr.kro.colla.project.project.domain;
+
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.user_project.domain.UserProject;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private Long managerId;
+
+    @Column
+    private String name;
+
+    @Column
+    private String description;
+
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
+    private List<UserProject> members = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private List<Task> tasks = new ArrayList<>();
+
+    @OneToMany(
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.PERSIST,
+            orphanRemoval = true
+    )
+    @JoinColumn(name = "project_id")
+    private List<TaskStatus> taskStatuses = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private List<Story> stories = new ArrayList<>();
+
+}

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -1,0 +1,18 @@
+package kr.kro.colla.project.task_status.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class TaskStatus {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+}

--- a/backend/src/main/java/kr/kro/colla/story/domain/Story.java
+++ b/backend/src/main/java/kr/kro/colla/story/domain/Story.java
@@ -1,0 +1,30 @@
+package kr.kro.colla.story.domain;
+
+import kr.kro.colla.task.task.domain.Task;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity
+public class Story {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column
+    private String description;
+
+    @Column
+    private String preStories;
+
+    @OneToMany(mappedBy = "story", fetch = FetchType.LAZY)
+    private List<Task> tasks = new ArrayList<>();
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/comment/domain/Comment.java
+++ b/backend/src/main/java/kr/kro/colla/task/comment/domain/Comment.java
@@ -1,0 +1,43 @@
+package kr.kro.colla.task.comment.domain;
+
+import kr.kro.colla.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column
+    private String contents;
+
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Comment(User user, String contents) {
+        this.user = user;
+        this.contents = contents;
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package kr.kro.colla.task.comment.domain.repository;
+
+import kr.kro.colla.task.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/backend/src/main/java/kr/kro/colla/task/history/domain/History.java
+++ b/backend/src/main/java/kr/kro/colla/task/history/domain/History.java
@@ -1,0 +1,25 @@
+package kr.kro.colla.task.history.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class History {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String contents;
+
+    @CreatedDate
+    private LocalDateTime createAt;
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/tag/domain/Tag.java
+++ b/backend/src/main/java/kr/kro/colla/task/tag/domain/Tag.java
@@ -1,0 +1,18 @@
+package kr.kro.colla.task.tag.domain;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -1,0 +1,63 @@
+package kr.kro.colla.task.task.domain;
+
+import kr.kro.colla.task.comment.domain.Comment;
+import kr.kro.colla.task.history.domain.History;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.task.task_tag.domain.TaskTag;
+import org.springframework.data.annotation.CreatedDate;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@EntityListeners(EntityListeners.class)
+@Entity
+public class Task {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "story_id")
+    private Story story;
+
+    @Column
+    private String title;
+
+    @Column
+    private String description;
+
+    @Column
+    private String images;
+
+    @Column
+    private String status;
+
+    @Column
+    private String managerName;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column
+    private String preTasks;
+
+    @Column
+    private Integer priority;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "task", fetch = FetchType.LAZY)
+    private List<TaskTag> taskTags = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id")
+    private List<History> histories = new ArrayList<>();
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task_tag/domain/TaskTag.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_tag/domain/TaskTag.java
@@ -1,0 +1,23 @@
+package kr.kro.colla.task.task_tag.domain;
+
+import kr.kro.colla.task.tag.domain.Tag;
+import kr.kro.colla.task.task.domain.Task;
+
+import javax.persistence.*;
+
+@Entity
+public class TaskTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @ManyToOne
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+}

--- a/backend/src/main/java/kr/kro/colla/user/domain/User.java
+++ b/backend/src/main/java/kr/kro/colla/user/domain/User.java
@@ -1,0 +1,45 @@
+package kr.kro.colla.user.domain;
+
+import kr.kro.colla.notice.domain.Notice;
+import kr.kro.colla.user_project.domain.UserProject;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String githubId;
+
+    @Column
+    private String name;
+
+    @Column
+    private String avatar;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
+    private List<UserProject> projects = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private List<Notice> notices = new ArrayList<>();
+
+    @Builder
+    public User(String name, String githubId, String avatar) {
+        this.name = name;
+        this.githubId = githubId;
+        this.avatar = avatar;
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
@@ -1,0 +1,25 @@
+package kr.kro.colla.user_project.domain;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.user.domain.User;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class UserProject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+}

--- a/backend/src/main/resources/application-test.yml
+++ b/backend/src/main/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true

--- a/backend/src/test/java/kr/kro/colla/task/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/comment/domain/repository/CommentRepositoryTest.java
@@ -1,0 +1,42 @@
+package kr.kro.colla.task.comment.domain.repository;
+
+import kr.kro.colla.task.comment.domain.Comment;
+import kr.kro.colla.user.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static java.time.LocalDateTime.now;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    void 댓글_등록_성공() {
+        // given
+        User user = User.builder()
+                .githubId("id")
+                .name("name")
+                .avatar("avatar")
+                .build();
+        Comment comment = Comment.builder()
+                .user(user)
+                .contents("contents")
+                .build();
+
+        // when
+        Comment result = commentRepository.save(comment);
+
+        // then
+        assertThat(result.getCreateAt()).isNotNull();
+        assertThat(result.getCreateAt()).isBefore(now());
+        assertThat(result.getUpdatedAt()).isBefore(now());
+    }
+
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 엔티티 구현

### 📑 구현한 내용 목록
- [x]  user
- [x]  project
- [x]  status
- [x]  notice
- [x]  comment
- [x]  history
- [x]  story
- [x]  task
- [x]  tag
- [x]  meeting_place

### 🚧 논의 사항
**1. Project 엔티티와 User 엔티티 간 관리자 관계의 연관 관계를 제거한 이유**
이미 Project 테이블과 User 테이블 간의 조인 테이블로 참여중인 프로젝트를 가져올 수 있고, 여기서 사용자의 기본 키와 관리자 아이디만 비교해줘도 관리자인지 아닌지를 식별할 수 있다고 생각했습니다. 따라서 또 하나의 연관 관계를 맺는 것이 불필요하다고 생각하여 제거해주었습니다.

**2. Notice 엔티티에서 enum을 사용한 이유**
int 타입으로 구성하기엔 코드 상에서 어떤 목적인지 파악하지 힘들 것 같아 enum으로 구성해보았습니다. 기존 정수로 저장하기로 하였기에 EnumType.ORDINAL로 설정하여 DB에는 정수값이 저장되도록 하였습니다.
🔥 EnumType.ORDINAL은 DB에 담기는 데이터의 크기가 작다는 장점이 있지만, 저장된 enum 순서를 변경할 수 없다는 단점이 있습니다. 

**3. Notice 엔티티(알림 테이블)에 check 필드가 DB 예약어와 겹쳐 isChecked로 수정하였습니다.**

**4. 엔티티 간 방향 관계 피드백 부탁드립니다!**

**5. build.gradle 의존성에 h2 DB를 넣은 이유** 
repository 계층 테스트 코드 작성 시 `@DataJpaTest` 어노테이션이 사용되는데, 해당 어노테이션은 테스트용 DB로 인메모리 DB를 사용합니다. 따라서 인메모리 DB에 대한 설정이 필요하여 h2 DB를 추가하여 테스트하였습니다.

**6. 엔티티 클래스의 데이터 주입**
현재 엔티티 클래스에 setter를 열어두지 않았습니다. setter를 모두 열어놓게 되면 인스턴스의 값이 의도치 않게 변경될 가능성이 존재하기 때문에 사용하지 않았습니다. 그리고 테스트 코드에서 확인하실 수 있듯이 builder 패턴을 사용하고자 하였는데, builder 패턴을 사용하는 것에 대해 어떻게 생각하시는지 의견 부탁드립니다!
builder 패턴 장점: 생성 시점에 값을 채울 때 채워야 하는 필드가 무엇인지 명확하게 파악 가능하고, 불변성을 보장할 수 있다.

**7. 커밋 메세지를 쪼개고 싶었는데, 연관 관계 맺다보니 어느새 하나가 되었습니다...**

- close #1 
