### PR TITLE
[#13] feat: JWT 구현 및 로그인 관련 테스트 코드 작성

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured'
+
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 test {

--- a/backend/src/main/java/kr/kro/colla/BackendApplication.java
+++ b/backend/src/main/java/kr/kro/colla/BackendApplication.java
@@ -2,9 +2,7 @@ package kr.kro.colla;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/kr/kro/colla/auth/infrastructure/GithubOAuthManager.java
+++ b/backend/src/main/java/kr/kro/colla/auth/infrastructure/GithubOAuthManager.java
@@ -1,0 +1,63 @@
+package kr.kro.colla.auth.infrastructure;
+
+import kr.kro.colla.auth.service.dto.GithubAccessTokenRequest;
+import kr.kro.colla.auth.service.dto.GithubAccessTokenResponse;
+import kr.kro.colla.auth.service.dto.GithubUserProfileResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GithubOAuthManager {
+
+    @Value("${github.client_id}")
+    private String clientId;
+
+    @Value("${github.client_secret}")
+    private String clientSecret;
+
+    @Value("${github.access_token_url}")
+    private String accessTokenUrl;
+
+    @Value("${github.user_profile_url}")
+    private String userProfileUrl;
+
+    public String getOAuthAccessToken(String code) {
+        GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(clientId, clientSecret, code);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<GithubAccessTokenRequest> httpEntity = new HttpEntity<>(githubAccessTokenRequest, headers);
+
+        GithubAccessTokenResponse response = new RestTemplate().exchange(
+                accessTokenUrl,
+                HttpMethod.POST,
+                httpEntity,
+                GithubAccessTokenResponse.class
+        ).getBody();
+
+        return response.getAccessToken();
+    }
+
+    public GithubUserProfileResponse getUserProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        GithubUserProfileResponse response = new RestTemplate().exchange(
+                userProfileUrl,
+                HttpMethod.GET,
+                httpEntity,
+                GithubUserProfileResponse.class
+        ).getBody();
+
+        return response;
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
@@ -2,7 +2,6 @@ package kr.kro.colla.auth.presentation;
 
 import kr.kro.colla.auth.presentation.dto.GithubLoginResponse;
 import kr.kro.colla.auth.service.AuthService;
-import kr.kro.colla.auth.service.dto.GithubUserProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,9 +16,9 @@ public class AuthController {
 
     @GetMapping("/login")
     public ResponseEntity<GithubLoginResponse> githubLogin(@RequestParam String code) {
-        GithubUserProfileResponse userProfile = this.authService.githubLogin(code);
+        String accessToken = this.authService.githubLogin(code);
 
-        return ResponseEntity.ok(new GithubLoginResponse(userProfile.getName(), userProfile.getAvatar(), "accessToken"));
+        return ResponseEntity.ok(new GithubLoginResponse(accessToken));
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/dto/GithubLoginResponse.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/dto/GithubLoginResponse.java
@@ -7,10 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class GithubLoginResponse {
 
-    private String name;
-
-    private String avatar;
-
     private String accessToken;
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
@@ -1,67 +1,24 @@
 package kr.kro.colla.auth.service;
 
-import kr.kro.colla.auth.service.dto.GithubAccessTokenRequest;
-import kr.kro.colla.auth.service.dto.GithubAccessTokenResponse;
+import kr.kro.colla.auth.infrastructure.GithubOAuthManager;
 import kr.kro.colla.auth.service.dto.GithubUserProfileResponse;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
+@RequiredArgsConstructor
 @Service
 public class AuthService {
 
-    @Value("${github.client_id}")
-    private String clientId;
+    private final GithubOAuthManager githubOAuthManager;
+    private final JwtProvider jwtProvider;
 
-    @Value("${github.client_secret}")
-    private String clientSecret;
+    public String githubLogin(String code) {
+        String oAuthAccessToken = this.githubOAuthManager.getOAuthAccessToken(code);
+        GithubUserProfileResponse userProfile = this.githubOAuthManager.getUserProfile(oAuthAccessToken);
 
-    @Value("${github.access_token_url}")
-    private String accessTokenUrl;
+        String jwtAccessToken = this.jwtProvider.createToken(userProfile.getGithubId());
 
-    @Value("${github.user_profile_url}")
-    private String userProfileUrl;
-
-    public GithubUserProfileResponse githubLogin(String code) {
-        String accessToken = getAccessToken(code);
-        GithubUserProfileResponse userProfile = getUserProfile(accessToken);
-
-        return userProfile;
-    }
-
-    public String getAccessToken(String code) {
-        GithubAccessTokenRequest githubAccessTokenRequest = new GithubAccessTokenRequest(clientId, clientSecret, code);
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
-        HttpEntity<GithubAccessTokenRequest> httpEntity = new HttpEntity<>(githubAccessTokenRequest, headers);
-
-        GithubAccessTokenResponse response = new RestTemplate().exchange(
-                accessTokenUrl,
-                HttpMethod.POST,
-                httpEntity,
-                GithubAccessTokenResponse.class
-        ).getBody();
-
-        return response.getAccessToken();
-    }
-
-    public GithubUserProfileResponse getUserProfile(String accessToken) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken);
-
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-
-        GithubUserProfileResponse response = new RestTemplate().exchange(
-                userProfileUrl,
-                HttpMethod.GET,
-                httpEntity,
-                GithubUserProfileResponse.class
-        ).getBody();
-
-        return response;
+        return jwtAccessToken;
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
@@ -10,16 +10,11 @@ import java.util.Date;
 @Component
 public class JwtProvider {
 
-    private final String secretKey;
-    private final long accessTokenExpirationTime;
+    @Value("${jwt.secret_key}")
+    private String secretKey;
 
-    public JwtProvider(
-            @Value("${jwt.secret_key}") String secretKey,
-            @Value("${jwt.access_token_expiration_time}") long accessTokenExpirationTime
-    ) {
-        this.secretKey = secretKey;
-        this.accessTokenExpirationTime = accessTokenExpirationTime;
-    }
+    @Value("${jwt.access_token_expiration_time}")
+    private long accessTokenExpirationTime;
 
     public String createToken(String userId) {
         Date now = new Date();

--- a/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
@@ -1,0 +1,35 @@
+package kr.kro.colla.auth.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final String secretKey;
+    private final long accessTokenExpirationTime;
+
+    public JwtProvider(
+            @Value("${jwt.secret_key}") String secretKey,
+            @Value("${jwt.access_token_expiration_time}") long accessTokenExpirationTime
+    ) {
+        this.secretKey = secretKey;
+        this.accessTokenExpirationTime = accessTokenExpirationTime;
+    }
+
+    public String createToken(String userId) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .claim("userId", userId)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + accessTokenExpirationTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/auth/service/dto/GithubUserProfileResponse.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/dto/GithubUserProfileResponse.java
@@ -1,9 +1,13 @@
 package kr.kro.colla.auth.service.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GithubUserProfileResponse {
 
     @JsonProperty("name")

--- a/backend/src/main/java/kr/kro/colla/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/kr/kro/colla/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package kr.kro.colla.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,12 +6,13 @@ spring:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy
     properties:
       hibernate:
         format_sql: true
+    open-in-view: false
 
 server:
   servlet:

--- a/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
@@ -1,0 +1,56 @@
+package kr.kro.colla.auth;
+
+import io.restassured.RestAssured;
+import kr.kro.colla.auth.infrastructure.GithubOAuthManager;
+import kr.kro.colla.auth.service.dto.GithubUserProfileResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @MockBean
+    private GithubOAuthManager githubOAuthManager;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    void 로그인_성공_시_Jwt토큰이_반환된다() {
+        // given
+        String oauthCode = "oauth-code";
+        String oAuthAccessToken = "oauth-access-token";
+        GithubUserProfileResponse githubUserProfileResponse = new GithubUserProfileResponse("name", "github-id", "avatar");
+
+        given(githubOAuthManager.getOAuthAccessToken(oauthCode)).willReturn(oAuthAccessToken);
+        given(githubOAuthManager.getUserProfile(oAuthAccessToken)).willReturn(githubUserProfileResponse);
+
+        RestAssured
+                .given()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+
+        // when
+        .when()
+                .get("/api/auth/login?code=" + oauthCode)
+
+        // then
+        .then().log().all()
+                .assertThat()
+                .statusCode(HttpStatus.OK.value())
+                .body("accessToken", notNullValue());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
@@ -1,0 +1,40 @@
+package kr.kro.colla.auth.presentation;
+
+import kr.kro.colla.auth.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void 로그인_성공_시_Jwt토큰이_반환된다() throws Exception {
+        // given
+        String oauthCode = "oauth-code";
+        String jwtAccessToken = "jwt-access-token";
+        given(authService.githubLogin(oauthCode)).willReturn(jwtAccessToken);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/auth/login?code=" + oauthCode));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("accessToken").value(jwtAccessToken));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/service/AuthServiceTest.java
@@ -1,0 +1,45 @@
+package kr.kro.colla.auth.service;
+
+import kr.kro.colla.auth.infrastructure.GithubOAuthManager;
+import kr.kro.colla.auth.service.dto.GithubUserProfileResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private GithubOAuthManager githubOAuthManager;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void 로그인_요청_시_OAuth토큰을_반환한다() {
+        // given
+        String oauthCode = "oauth-code";
+        String oAuthAccessToken = "oauth-access-token";
+        String jwtAccessToken = "jwt-access-token";
+        GithubUserProfileResponse githubUserProfileResponse = new GithubUserProfileResponse("user", "github-id", "avatar");
+
+        given(githubOAuthManager.getOAuthAccessToken(oauthCode)).willReturn(oAuthAccessToken);
+        given(githubOAuthManager.getUserProfile(oAuthAccessToken)).willReturn(githubUserProfileResponse);
+        given(jwtProvider.createToken(githubUserProfileResponse.getGithubId())).willReturn(jwtAccessToken);
+
+        // when
+        String accessToken = authService.githubLogin(oauthCode);
+
+        // then
+        assertThat(accessToken).isEqualTo(jwtAccessToken);
+    }
+
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
JWT 구현 및 로그인 관련 테스트 코드 작성

### 📑 구현한 내용 목록
- [x]  JWT 구현
- [x]  로그인 성공 관련 테스트 코드 작성
- [ ]  첫 로그인 시 회원 가입
- [ ]  로그인 실패 관련 테스트 코드 작성

### 🚧 논의 사항
- 기존 service 계층에 함께 있었던 third party 통신에 속하는 github oauth 관련 로직을 하나의 레이어로 분리하였습니다!
- JWT 구현 및 로그인 성공 관련 service, controller, 인수 테스트 작성하였고 첫 로그인 시 회원가입 로직과 실패 테스트 코드는 이어서 작성하도록 하겠습니다 ~~!

- #13 
