### PR TITLE
[#30] feat: JWT 로직 및 테스트 코드 개선

### DIFF
--- a/backend/src/main/java/kr/kro/colla/auth/domain/LoginUser.java
+++ b/backend/src/main/java/kr/kro/colla/auth/domain/LoginUser.java
@@ -1,16 +1,14 @@
 package kr.kro.colla.auth.domain;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class LoginUser {
 
-    private String githubId;
+    private Long id;
 
-    @Builder
-    public LoginUser(String githubId) {
-        this.githubId = githubId;
+    public LoginUser(Long id) {
+        this.id = id;
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/infrastructure/RedisManager.java
+++ b/backend/src/main/java/kr/kro/colla/auth/infrastructure/RedisManager.java
@@ -18,14 +18,20 @@ public class RedisManager {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void saveRefreshToken(CreateTokenResponse createTokenResponse) {
+    public void saveRefreshToken(Long id, String refreshToken) {
         ValueOperations<String, String> valueOperations = this.redisTemplate.opsForValue();
         valueOperations.set(
-                createTokenResponse.getAccessToken(),
-                createTokenResponse.getRefreshToken(),
+                id.toString(),
+                refreshToken,
                 refreshTokenExpirationTime,
                 TimeUnit.MILLISECONDS
         );
+    }
+
+    public String findValue(String key) {
+        ValueOperations<String, String> valueOperations = this.redisTemplate.opsForValue();
+
+        return valueOperations.get(key);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
@@ -2,7 +2,6 @@ package kr.kro.colla.auth.presentation;
 
 import kr.kro.colla.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
@@ -13,29 +12,16 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class AuthController {
 
-    @Value("${cookie.domain}")
-    private String credentialDomain;
-
-    @Value("${cookie.expiration_time}")
-    private long expirationTime;
-
     private final AuthService authService;
+    private final CookieManager cookieManager;
 
     @GetMapping("/login")
     public ResponseEntity githubLogin(@RequestParam String code) {
         String accessToken = this.authService.githubLogin(code);
-        ResponseCookie cookie = createCookie(accessToken);
+        ResponseCookie cookie = this.cookieManager.createCookie("accessToken", accessToken);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .build();
-    }
-
-    private ResponseCookie createCookie(String value) {
-        return ResponseCookie.from("accessToken", value)
-                .maxAge(expirationTime)
-                .domain(credentialDomain)
-                .path("/")
                 .build();
     }
 

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
@@ -1,6 +1,9 @@
 package kr.kro.colla.auth.presentation;
 
+import kr.kro.colla.auth.domain.LoginUser;
+import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.utils.CookieManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -23,6 +26,11 @@ public class AuthController {
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
                 .build();
+    }
+
+    @GetMapping("/log")
+    public ResponseEntity Log(@Authenticated LoginUser loginUser) {
+        return ResponseEntity.ok(loginUser);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/CookieManager.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/CookieManager.java
@@ -1,0 +1,38 @@
+package kr.kro.colla.auth.presentation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.Cookie;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Component
+public class CookieManager {
+
+    @Value("${cookie.domain}")
+    private String credentialDomain;
+
+    @Value("${cookie.expiration_time}")
+    private long expirationTime;
+
+    public ResponseCookie createCookie(String name, String value) {
+        return ResponseCookie.from(name, value)
+                .maxAge(expirationTime)
+                .domain(credentialDomain)
+                .path("/")
+                .build();
+    }
+
+    public Cookie parseCookies(Cookie[] cookies, String name) {
+        return Optional.ofNullable(cookies)
+                .map(Arrays::stream)
+                .orElse(Stream.empty())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findAny()
+                .orElse(null);
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
@@ -30,11 +30,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String accessToken = (String) request.getAttribute("accessToken");
-
-        Long id = jwtProvider.parseToken(accessToken);
-        if(id == null) {
-            return null;
-        }
+        Long id = this.jwtProvider.parseToken(accessToken);
 
         return new LoginUser(id);
     }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
@@ -1,10 +1,9 @@
 package kr.kro.colla.auth.presentation.argument_resolver;
 
 import kr.kro.colla.auth.domain.LoginUser;
-import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -13,10 +12,9 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import javax.servlet.http.HttpServletRequest;
 
 @RequiredArgsConstructor
-@Component
 public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private final JwtProvider jwtProvider;
+    private final AuthService authService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -30,7 +28,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String accessToken = (String) request.getAttribute("accessToken");
-        Long id = this.jwtProvider.parseToken(accessToken);
+        Long id = this.authService.extractIdFromToken(accessToken);
 
         return new LoginUser(id);
     }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
@@ -31,13 +31,11 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String accessToken = (String) request.getAttribute("accessToken");
 
-        String userId = jwtProvider.parseToken(accessToken);
-        if(userId == null) {
+        Long id = jwtProvider.parseToken(accessToken);
+        if(id == null) {
             return null;
         }
 
-        return LoginUser.builder()
-                .githubId(userId)
-                .build();
+        return new LoginUser(id);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
@@ -1,10 +1,10 @@
 package kr.kro.colla.auth.presentation.interceptor;
 
 import kr.kro.colla.auth.infrastructure.RedisManager;
-import kr.kro.colla.auth.presentation.CookieManager;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.exception.exception.auth.InvalidTokenException;
 import kr.kro.colla.exception.exception.auth.TokenNotFoundException;
+import kr.kro.colla.utils.CookieManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
@@ -3,6 +3,8 @@ package kr.kro.colla.auth.presentation.interceptor;
 import kr.kro.colla.auth.infrastructure.RedisManager;
 import kr.kro.colla.auth.presentation.CookieManager;
 import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.exception.exception.auth.InvalidTokenException;
+import kr.kro.colla.exception.exception.auth.TokenNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -27,7 +29,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         Cookie accessToken = this.cookieManager.parseCookies(cookies, "accessToken");
 
         if(accessToken == null) {
-            return false;
+            throw new TokenNotFoundException();
         }
 
         boolean isValid = this.jwtProvider.validateToken(accessToken.getValue());
@@ -50,8 +52,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         boolean isValid = this.jwtProvider.validateToken(refreshToken);
 
         if(!isValid) {
-            // TODO : refreshToken도 유효하지 않기 때문에 권한이 없다는 예외를 던져야 한다.
-            return null;
+            throw new InvalidTokenException();
         }
 
         return this.jwtProvider.createAccessToken(id);

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
@@ -1,39 +1,60 @@
 package kr.kro.colla.auth.presentation.interceptor;
 
+import kr.kro.colla.auth.infrastructure.RedisManager;
+import kr.kro.colla.auth.presentation.CookieManager;
 import kr.kro.colla.auth.service.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
 
+    private final CookieManager cookieManager;
     private final JwtProvider jwtProvider;
+    private final RedisManager redisManager;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         Cookie[] cookies = request.getCookies();
-        Cookie accessToken = parseCookies(cookies, "accessToken");
+        Cookie accessToken = this.cookieManager.parseCookies(cookies, "accessToken");
 
-        if(accessToken == null || jwtProvider.validateToken(accessToken.getValue())) {
+        if(accessToken == null) {
             return false;
+        }
+
+        boolean isValid = this.jwtProvider.validateToken(accessToken.getValue());
+
+        if(!isValid) {
+            String newAccessToken = validateRefreshToken(accessToken.getValue());
+            ResponseCookie cookie = this.cookieManager.createCookie("accessToken", newAccessToken);
+
+            response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+            accessToken.setValue(newAccessToken);
         }
 
         request.setAttribute("accessToken", accessToken.getValue());
         return true;
     }
 
-    private Cookie parseCookies(Cookie[] cookies, String name) {
-        return Arrays.stream(cookies)
-                .filter(cookie -> cookie.getName().equals(name))
-                .findAny()
-                .orElse(null);
+    private String validateRefreshToken(String accessToken) {
+        Long id = this.jwtProvider.parseToken(accessToken);
+        String refreshToken = this.redisManager.findValue(id.toString());
+        boolean isValid = this.jwtProvider.validateToken(refreshToken);
+
+        if(!isValid) {
+            // TODO : refreshToken도 유효하지 않기 때문에 권한이 없다는 예외를 던져야 한다.
+            return null;
+        }
+
+        return this.jwtProvider.createAccessToken(id);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
 
         User user = this.userService.createUserIfNotExist(userProfile);
         CreateTokenResponse createTokenResponse = this.jwtProvider.createTokens(user.getId());
-        this.redisManager.saveRefreshToken(createTokenResponse);
+        this.redisManager.saveRefreshToken(user.getId(), createTokenResponse.getRefreshToken());
 
         return createTokenResponse.getAccessToken();
     }

--- a/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import kr.kro.colla.auth.infrastructure.GithubOAuthManager;
 import kr.kro.colla.auth.infrastructure.RedisManager;
 import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
 import kr.kro.colla.auth.service.dto.CreateTokenResponse;
+import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,8 @@ public class AuthService {
         String oAuthAccessToken = this.githubOAuthManager.getOAuthAccessToken(code);
         GithubUserProfileResponse userProfile = this.githubOAuthManager.getUserProfile(oAuthAccessToken);
 
-        this.userService.createUserIfNotExist(userProfile);
-        CreateTokenResponse createTokenResponse = this.jwtProvider.createTokens(userProfile.getGithubId());
+        User user = this.userService.createUserIfNotExist(userProfile);
+        CreateTokenResponse createTokenResponse = this.jwtProvider.createTokens(user.getId());
         this.redisManager.saveRefreshToken(createTokenResponse);
 
         return createTokenResponse.getAccessToken();

--- a/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import kr.kro.colla.auth.infrastructure.GithubOAuthManager;
 import kr.kro.colla.auth.infrastructure.RedisManager;
 import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
 import kr.kro.colla.auth.service.dto.CreateTokenResponse;
+import kr.kro.colla.exception.exception.auth.InvalidTokenException;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,26 @@ public class AuthService {
         this.redisManager.saveRefreshToken(user.getId(), createTokenResponse.getRefreshToken());
 
         return createTokenResponse.getAccessToken();
+    }
+
+    public boolean validateAccessToken(String accessToken) {
+        return this.jwtProvider.validateToken(accessToken);
+    }
+
+    public String validateRefreshToken(String accessToken) {
+        Long id = this.jwtProvider.findIdFromToken(accessToken);
+        String refreshToken = this.redisManager.findValue(id.toString());
+        boolean isValid = this.jwtProvider.validateToken(refreshToken);
+
+        if(!isValid) {
+            throw new InvalidTokenException();
+        }
+
+        return this.jwtProvider.createAccessToken(id);
+    }
+
+    public Long extractIdFromToken(String token) {
+        return this.jwtProvider.findIdFromToken(token);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
@@ -60,7 +60,7 @@ public class JwtProvider {
         }
     }
 
-    public Long parseToken(String token) {
+    public Long findIdFromToken(String token) {
         try {
             Jws<Claims> claimsJws = Jwts.parser()
                     .setSigningKey(secretKey)

--- a/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
@@ -2,6 +2,7 @@ package kr.kro.colla.auth.service;
 
 import io.jsonwebtoken.*;
 import kr.kro.colla.auth.service.dto.CreateTokenResponse;
+import kr.kro.colla.exception.exception.auth.InvalidTokenException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -76,6 +77,8 @@ public class JwtProvider {
                             .get("id")
                             .toString()
             );
+        } catch(Exception e) {
+            throw new InvalidTokenException();
         }
     }
 

--- a/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/JwtProvider.java
@@ -19,17 +19,17 @@ public class JwtProvider {
     @Value("${jwt.refresh_token_expiration_time}")
     private long refreshTokenExpirationTime;
 
-    public CreateTokenResponse createTokens(String userId) {
+    public CreateTokenResponse createTokens(Long id) {
         Date now = new Date();
-        String accessToken = createToken(userId, now, accessTokenExpirationTime);
-        String refreshToken = createToken(userId, now, refreshTokenExpirationTime);
+        String accessToken = createToken(id, now, accessTokenExpirationTime);
+        String refreshToken = createToken(id, now, refreshTokenExpirationTime);
 
         return new CreateTokenResponse(accessToken, refreshToken);
     }
 
-    public String createToken(String value, Date now, long expirationTime) {
+    public String createToken(Long value, Date now, long expirationTime) {
         return Jwts.builder()
-                .claim("userId", value)
+                .claim("id", value)
                 .setIssuedAt(now)
                 .setExpiration(new Date(now.getTime() + expirationTime))
                 .signWith(SignatureAlgorithm.HS256, secretKey)
@@ -50,14 +50,17 @@ public class JwtProvider {
         }
     }
 
-    public String parseToken(String token) {
+    public Long parseToken(String token) {
         try {
             Jws<Claims> claimsJws = Jwts.parser()
                     .setSigningKey(secretKey)
                     .parseClaimsJws(token);
 
-            return (String) claimsJws.getBody()
-                    .get("userId");
+            return Long.parseLong(
+                    claimsJws.getBody()
+                            .get("id")
+                            .toString()
+            );
         } catch (Exception e) {
             return null;
         }

--- a/backend/src/main/java/kr/kro/colla/config/WebConfig.java
+++ b/backend/src/main/java/kr/kro/colla/config/WebConfig.java
@@ -2,8 +2,11 @@ package kr.kro.colla.config;
 
 import kr.kro.colla.auth.presentation.argument_resolver.AuthArgumentResolver;
 import kr.kro.colla.auth.presentation.interceptor.AuthInterceptor;
+import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.utils.CookieManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -19,8 +22,22 @@ public class WebConfig implements WebMvcConfigurer {
     @Value("${cors.allowed_origin}")
     private String origin;
 
-    private final AuthInterceptor authInterceptor;
-    private final AuthArgumentResolver authArgumentResolver;
+    private final AuthService authService;
+
+    @Bean
+    public CookieManager cookieManager() {
+        return new CookieManager();
+    }
+
+    @Bean
+    public AuthInterceptor authInterceptor() {
+        return new AuthInterceptor(authService, cookieManager());
+    }
+
+    @Bean
+    public AuthArgumentResolver authArgumentResolver() {
+        return new AuthArgumentResolver(authService);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -31,7 +48,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(authInterceptor)
+        registry.addInterceptor(authInterceptor())
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/auth/login");
@@ -39,6 +56,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(authArgumentResolver);
+        resolvers.add(authArgumentResolver());
     }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.exception;
 
+import kr.kro.colla.exception.exception.auth.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -14,14 +15,23 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionHandleResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         FieldError fieldError = e.getFieldError();
-        ExceptionHandleResponse response = new ExceptionHandleResponse(400, fieldError.getField() + " : " + fieldError.getDefaultMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.BAD_REQUEST.value(), fieldError.getField() + " : " + fieldError.getDefaultMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(response);
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<ExceptionHandleResponse> handleHttpClientErrorException(HttpClientErrorException e){
-        ExceptionHandleResponse response = new ExceptionHandleResponse(401, e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(response);
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ExceptionHandleResponse> handleUnauthorizedException(UnauthorizedException e) {
+        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(response);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/InvalidTokenException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.auth;
+
+public class InvalidTokenException extends UnauthorizedException {
+
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/TokenNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/TokenNotFoundException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.auth;
+
+public class TokenNotFoundException extends UnauthorizedException {
+
+    public TokenNotFoundException() {
+        super("토큰이 존재하지 않습니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/UnauthorizedException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.auth;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
@@ -6,9 +6,11 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+@NoArgsConstructor
 @Getter
 @Builder
 public class CreateProjectRequest {
+
     @NotNull
     private String name;
 

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -12,8 +12,8 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public void createUserIfNotExist(GithubUserProfileResponse userProfile) {
-        this.userRepository.findByGithubId(userProfile.getGithubId())
+    public User createUserIfNotExist(GithubUserProfileResponse userProfile) {
+        return this.userRepository.findByGithubId(userProfile.getGithubId())
                 .orElseGet(() -> this.userRepository.save(
                                 User.builder()
                                         .name(userProfile.getName())

--- a/backend/src/main/java/kr/kro/colla/utils/CookieManager.java
+++ b/backend/src/main/java/kr/kro/colla/utils/CookieManager.java
@@ -2,14 +2,12 @@ package kr.kro.colla.utils;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
-import org.springframework.stereotype.Component;
 
 import javax.servlet.http.Cookie;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-@Component
 public class CookieManager {
 
     @Value("${cookie.domain}")

--- a/backend/src/main/java/kr/kro/colla/utils/CookieManager.java
+++ b/backend/src/main/java/kr/kro/colla/utils/CookieManager.java
@@ -1,4 +1,4 @@
-package kr.kro.colla.auth.presentation;
+package kr.kro.colla.utils;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;

--- a/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
@@ -1,13 +1,15 @@
 package kr.kro.colla.auth.presentation;
 
 import kr.kro.colla.auth.service.AuthService;
-import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.utils.CookieManager;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseCookie;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.client.HttpClientErrorException;
 
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -20,33 +22,40 @@ class AuthControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private AuthService authService;
+    private CookieManager cookieManager;
 
     @MockBean
-    private JwtProvider jwtProvider;
+    private AuthService authService;
 
     @Test
     void 로그인_성공_시_Jwt토큰이_반환된다() throws Exception {
         // given
         String oauthCode = "oauth-code";
         String jwtAccessToken = "jwt-access-token";
-        int twoHour = 2 * 60 * 60;
-        given(authService.githubLogin(oauthCode)).willReturn(jwtAccessToken);
+        ResponseCookie cookie = ResponseCookie.from("accessToken", jwtAccessToken)
+                .build();
+
+        given(authService.githubLogin(oauthCode))
+                .willReturn(jwtAccessToken);
+        given(cookieManager.createCookie("accessToken", jwtAccessToken))
+                .willReturn(cookie);
+
 
         // when
         ResultActions perform = mockMvc.perform(get("/auth/login?code=" + oauthCode));
 
         // then
         perform.andExpect(status().isOk())
-                .andExpect(cookie().value("accessToken", jwtAccessToken))
-                .andExpect(cookie().maxAge("accessToken", twoHour));
+                .andExpect(cookie().value("accessToken", jwtAccessToken));
     }
 
     @Test
     void 올바르지_않은_OAuth코드가_올_경우_로그인에_실패한다() throws Exception {
         // given
         String unauthorizedCode = "unauthorized-code";
-        given(authService.githubLogin(unauthorizedCode)).willReturn(null);
+
+        given(authService.githubLogin(unauthorizedCode))
+                .willThrow(HttpClientErrorException.class);
 
         // when
         ResultActions perform = mockMvc.perform(get("/auth/login?code=" + unauthorizedCode));

--- a/backend/src/test/java/kr/kro/colla/common/fixture/User.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/User.java
@@ -1,0 +1,17 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.auth.service.JwtProvider;
+
+public class User {
+
+    private JwtProvider jwtProvider;
+
+    public User(JwtProvider jwtProvider) {
+        this.jwtProvider = jwtProvider;
+    }
+
+    public String 로그인(Long id) {
+        return jwtProvider.createAccessToken(id);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -2,8 +2,11 @@ package kr.kro.colla.project.project;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.common.fixture.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -18,20 +21,27 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
+
     @LocalServerPort
     int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+        user = new User(jwtProvider);
     }
 
     private Long managerId = 3L;
     private String name = "프로젝트 이름", desc = "프로젝트 설명";
+    private User user;
 
     @Test
     void 사용자_프로젝트_생성_후_반환한다() {
         // given
+        String accessToken = user.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", name);
         requestBody.put("description",desc);
@@ -39,10 +49,11 @@ public class AcceptanceTest {
         given()
                 .contentType(ContentType.JSON)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
                 .body(requestBody)
         // when
         .when()
-                .post("/api/users/{userId}/projects",managerId)
+                .post("/api/users/{userId}/projects", managerId)
         // then
         .then()
                 .statusCode(HttpStatus.OK.value())
@@ -55,13 +66,14 @@ public class AcceptanceTest {
     @Test
     void 사용자_프로젝트_생성_실패_시_에러를_반환한다() throws Exception {
         // given
+        String accessToken = user.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("description",desc);
-
 
         given()
                 .contentType(ContentType.JSON)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
                 .body(requestBody)
         // when
         .when()

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -1,6 +1,8 @@
 package kr.kro.colla.user.user.presentation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.kro.colla.auth.presentation.interceptor.AuthInterceptor;
+import kr.kro.colla.auth.service.AuthService;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
@@ -8,9 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -25,8 +31,15 @@ class UserControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
     @MockBean
     private ProjectService projectService;
+
+    @MockBean
+    private AuthInterceptor authInterceptor;
 
     private Long managerId = 3L;
     private String name = "프로젝트 이름", desc = "프로젝트 설명";
@@ -43,12 +56,16 @@ class UserControllerTest {
                 .name(name)
                 .description(desc)
                 .build();
-        given(projectService.createProject(eq(managerId), any(CreateProjectRequest.class))).willReturn(project);
+
+        given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
+                .willReturn(true);
+        given(projectService.createProject(eq(managerId), any(CreateProjectRequest.class)))
+                .willReturn(project);
 
         String content = new ObjectMapper().writeValueAsString(createProjectRequest);
 
         // when
-        ResultActions perform = mockMvc.perform(post("/users/"+managerId+"/projects")
+        ResultActions perform = mockMvc.perform(post("/users/" + managerId + "/projects")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content));
 
@@ -68,15 +85,19 @@ class UserControllerTest {
                 .build();
         String content = new ObjectMapper().writeValueAsString(createProjectRequest);
 
+        given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
+                .willReturn(true);
+
         // when
-        ResultActions perform = mockMvc.perform(post("/users/"+managerId+"/projects")
+        ResultActions perform = mockMvc.perform(post("/users/" + managerId + "/projects")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content));
 
         // then
         perform.andDo(print())
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("name : must not be null"));
     }
+
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/service/UserServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/service/UserServiceTest.java
@@ -1,0 +1,82 @@
+package kr.kro.colla.user.user.service;
+
+import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void 첫_로그인_시_회원가입을_진행한다() {
+        // given
+        GithubUserProfileResponse githubUserProfileResponse = new GithubUserProfileResponse("user", "kykapple", "avatar");
+        User user = User.builder()
+                .name("user")
+                .githubId("githubId")
+                .avatar("avatar")
+                .build();
+
+        given(userRepository.findByGithubId(githubUserProfileResponse.getGithubId()))
+                .willReturn(Optional.empty());
+        given(userRepository.save(any(User.class)))
+                .willReturn(user);
+
+        // when
+        User result = userService.createUserIfNotExist(githubUserProfileResponse);
+
+        // then
+        verify(userRepository, times(1)).findByGithubId(any(String.class));
+        verify(userRepository, times(1)).save(any(User.class));
+        assertThat(result.getName()).isEqualTo(user.getName());
+        assertThat(result.getGithubId()).isEqualTo(user.getGithubId());
+        assertThat(result.getAvatar()).isEqualTo(user.getAvatar());
+    }
+
+    @Test
+    void 기존_사용자일_경우_회원가입을_진행하지_않는다() {
+        // given
+        GithubUserProfileResponse githubUserProfileResponse = new GithubUserProfileResponse("user", "kykapple", "avatar");
+        User user = User.builder()
+                .name("user")
+                .githubId("githubId")
+                .avatar("avatar")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        given(userRepository.findByGithubId(githubUserProfileResponse.getGithubId()))
+                .willReturn(Optional.of(user));
+
+        // when
+        User result = userService.createUserIfNotExist(githubUserProfileResponse);
+
+        // then
+        verify(userRepository, times(1)).findByGithubId(any(String.class));
+        verify(userRepository, times(0)).save(any(User.class));
+        assertThat(result.getId()).isEqualTo(user.getId());
+        assertThat(result.getName()).isEqualTo(user.getName());
+        assertThat(result.getGithubId()).isEqualTo(user.getGithubId());
+        assertThat(result.getAvatar()).isEqualTo(user.getAvatar());
+    }
+
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- jwt payload 기본 키로 수정
- accessToken 만료 시 재발급 로직 구현
- createUser 메서드 네이밍 변경 및 userService로 이동
- 테스트 코드 깨지는 거 복구

### 📑 구현한 내용 목록
- [x]  jwt payload 기본 키로 수정
- [x]  accessToken 재발급 로직 구현
- [x]  테스트 코드 깨지는 거 복구
- [ ]  인터셉터 및 레디스 테스트 코드 작성

### 🚧 논의 사항
- 인터셉터에서 예외를 던지고 응답값을 보면 `@ControllerAdvice`의 `@ExceptionHanlder`가 잡아주는 것 같기는 한데, 인터셉터 예외에 대해서 조금 더 학습해봐야 할 것 같습니다ㅠ
- 테스트 코드를 작성하면서 인터셉터와 `WebConfig`, `Argument Resolver`에 불필요한 의존성이 많다고 느껴져 불필요한 부분은 제거해주었습니다! (사실 다 제가 작성한 부분이지만 ㅎ..)
- 인수 테스트 진행 시 인터셉터를 통과하려면 로그인이 되어 있어야 해서 `common/fixture`에 로그인 함수를 구현해보았습니다!
- 분명 인터셉터 및 레디스 테스트 코드 작성이 오늘 목표였는데, jwt 로직 개선하고 테스트 코드 복구하니 하루가 사라졌어요..😂 (리팩토링만 한 기분 😂😂)

- close #30 
