### PR TITLE
[#31] feat: 프로젝트 정보 전역 상태값 설정

### DIFF
--- a/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
@@ -18,6 +18,10 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (request.getMethod().equals("OPTIONS")){
+            return true;
+        }
+
         Cookie[] cookies = request.getCookies();
         Cookie accessToken = parseCookies(cookies, "accessToken");
 

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
@@ -2,14 +2,12 @@ package kr.kro.colla.user.user.presentation.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotEmpty;
 
 @Getter
 @Builder
 public class CreateProjectRequest {
-    @NotNull
+    @NotEmpty
     private String name;
 
     private String description;

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
     presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
-    plugins: ['@babel/plugin-transform-runtime'],
+    plugins: ['@babel/plugin-transform-runtime', '@emotion'],
 };

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0",
-        "react-spinners": "^0.11.0"
+        "react-spinners": "^0.11.0",
+        "recoil": "^0.5.2"
       },
       "devDependencies": {
         "@babel/core": "^7.16.5",
@@ -5202,6 +5203,11 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "node_modules/hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -7343,6 +7349,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/recoil": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.5.2.tgz",
+      "integrity": "sha512-Edibzpu3dbUMLy6QRg73WL8dvMl9Xqhp+kU+f2sJtXxsaXvAlxU/GcnDE8HXPkprXrhHF2e6SZozptNvjNF5fw==",
+      "dependencies": {
+        "hamt_plus": "1.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/regenerate": {
@@ -12800,6 +12825,11 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
+    "hamt_plus": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hamt_plus/-/hamt_plus-1.0.2.tgz",
+      "integrity": "sha1-4hwlKWjH4zsg9qGwlM2FeHomVgE="
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -14367,6 +14397,14 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "recoil": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.5.2.tgz",
+      "integrity": "sha512-Edibzpu3dbUMLy6QRg73WL8dvMl9Xqhp+kU+f2sJtXxsaXvAlxU/GcnDE8HXPkprXrhHF2e6SZozptNvjNF5fw==",
+      "requires": {
+        "hamt_plus": "1.0.2"
       }
     },
     "regenerate": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,6 +26,7 @@
         "@babel/preset-env": "^7.16.5",
         "@babel/preset-react": "^7.16.5",
         "@babel/preset-typescript": "^7.16.5",
+        "@emotion/babel-plugin": "^11.7.2",
         "@types/js-cookie": "^3.0.1",
         "@types/react": "^17.0.37",
         "@types/react-dom": "^17.0.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
-    "react-spinners": "^0.11.0"
+    "react-spinners": "^0.11.0",
+    "recoil": "^0.5.2"
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-env": "^7.16.5",
     "@babel/preset-react": "^7.16.5",
     "@babel/preset-typescript": "^7.16.5",
+    "@emotion/babel-plugin": "^11.7.2",
     "@types/js-cookie": "^3.0.1",
     "@types/react": "^17.0.37",
     "@types/react-dom": "^17.0.11",

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -2,5 +2,5 @@ import { client } from './common';
 
 export const createProject = async (userId: number, projectName: string, projectDesc: string) => {
     const response = await client.post(`/users/${userId}/projects`, { name: projectName, description: projectDesc });
-    return response.data;
+    return response;
 };

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { useRecoilValue } from 'recoil';
 
+import { projectInfoState } from '../../stores/atom';
 import UserIcon from '../Icon/User';
 import { Container, LeftNav, RightNav } from './style';
 
@@ -7,13 +9,19 @@ const userName = 'user';
 const userProfileImg = undefined;
 const userGithubId = 'user_github_id';
 
-const Header = () => (
-    <Container>
-        <LeftNav></LeftNav>
-        <RightNav>
-            <UserIcon userName={userName} githubId={userGithubId} image={userProfileImg} size="small" />
-        </RightNav>
-    </Container>
-);
+const Header = () => {
+    const projectInfo = useRecoilValue(projectInfoState);
+    return (
+        <Container>
+            <LeftNav>
+                <div>{projectInfo.name}</div>
+                <div>{projectInfo.desc}</div>
+            </LeftNav>
+            <RightNav>
+                <UserIcon userName={userName} githubId={userGithubId} image={userProfileImg} size="small" />
+            </RightNav>
+        </Container>
+    );
+};
 
 export default Header;

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -3,7 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { projectInfoState } from '../../stores/atom';
 import UserIcon from '../Icon/User';
-import { Container, LeftNav, RightNav } from './style';
+import { Container, LeftNav, ProjectDesc, ProjectInfo, ProjectTitle, RightNav } from './style';
 
 const userName = 'user';
 const userProfileImg = undefined;
@@ -14,8 +14,10 @@ const Header = () => {
     return (
         <Container>
             <LeftNav>
-                <div>{projectInfo.name}</div>
-                <div>{projectInfo.desc}</div>
+                <ProjectInfo>
+                    <ProjectTitle>{projectInfo.name}</ProjectTitle>
+                    <ProjectDesc>{projectInfo.desc}</ProjectDesc>
+                </ProjectInfo>
             </LeftNav>
             <RightNav>
                 <UserIcon userName={userName} githubId={userGithubId} image={userProfileImg} size="small" />

--- a/frontend/src/components/Header/style.tsx
+++ b/frontend/src/components/Header/style.tsx
@@ -1,10 +1,31 @@
 import styled from '@emotion/styled';
-import { Center } from '../../styles/common';
+import { Center, WidthCenter } from '../../styles/common';
 
 export const Container = styled.div`
     display: flex;
     width: 85vw;
     height: 100px;
+`;
+
+export const ProjectTitle = styled.div`
+    font-size: 36px;
+`;
+
+export const ProjectDesc = styled.div`
+    position: absolute;
+    top: 40px;
+    font-size: 24px;
+    text-shadow: #303030;
+    visibility: hidden;
+`;
+
+export const ProjectInfo = styled.div`
+    position: relative;
+    &:hover ${ProjectDesc} {
+        visibility: visible;
+    }
+
+    ${WidthCenter}
 `;
 
 export const LeftNav = styled.div`

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { RecoilRoot } from 'recoil';
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+    <RecoilRoot>
+        <App />
+    </RecoilRoot>,
+    document.getElementById('root'),
+);

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,21 +1,35 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import HomeImageSrc from '../../../public/assets/images/home-image.png';
+import { isResponseSuccess } from '../../apis/common';
 import { createProject } from '../../apis/user';
 import Header from '../../components/Header';
 import ProjectModal from '../../components/Modal/Project';
+import { projectDescState, projectNameState } from '../../stores/atom';
 import { Container, HomeImage, ProjectNotice } from './style';
 
 const Home = () => {
     const [projectModal, setProjectModal] = useState(false);
+    const setProjectName = useSetRecoilState(projectNameState);
+    const setProjectDesc = useSetRecoilState(projectDescState);
     const history = useHistory();
 
     const handleModal = () => setProjectModal(!projectModal);
 
     const sendRequest = async (userId: number, name: string, desc: string) => {
         const response = await createProject(userId, name, desc);
-        history.push('/kanban', response.data);
+
+        if (isResponseSuccess(response.status)) {
+            const { name: projectName, description: projectDesc } = response.data;
+            setProjectName(projectName);
+            setProjectDesc(projectDesc);
+            history.push('/kanban', response.data);
+        } else {
+            // eslint-disable-next-line no-alert
+            alert('프로젝트 생성에 실패했습니다.');
+        }
     };
 
     return (

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -1,23 +1,34 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
+import { projectNameState } from '../../stores/atom';
 import { Wrapper, KanbanAddButton, KanbanAdditional } from './style';
 
 const statuses = ['To Do', 'Progress', 'Done'];
 
-const Kanban = () => (
-    <>
-        <Header />
-        <Wrapper>
-            {statuses.map((value) => (
-                <KanbanCol key={value} status={value} />
-            ))}
-            <KanbanAdditional>
-                <KanbanAddButton />
-            </KanbanAdditional>
-        </Wrapper>
-    </>
-);
+const Kanban = () => {
+    const history = useHistory();
+    const projectName = useRecoilValue(projectNameState);
+    if (!projectName) {
+        history.push('/');
+    }
+
+    return (
+        <>
+            <Header />
+            <Wrapper>
+                {statuses.map((value) => (
+                    <KanbanCol key={value} status={value} />
+                ))}
+                <KanbanAdditional>
+                    <KanbanAddButton />
+                </KanbanAdditional>
+            </Wrapper>
+        </>
+    );
+};
 
 export default Kanban;

--- a/frontend/src/stores/atom.ts
+++ b/frontend/src/stores/atom.ts
@@ -1,0 +1,19 @@
+import { atom, selector } from 'recoil';
+
+export const projectNameState = atom({
+    key: 'projectName',
+    default: null,
+});
+
+export const projectDescState = atom({
+    key: 'projectDesc',
+    default: null,
+});
+
+export const projectInfoState = selector({
+    key: 'project',
+    get: ({ get }) => ({
+        name: get(projectNameState),
+        desc: get(projectDescState),
+    }),
+});


### PR DESCRIPTION
### 🔨 작업 내용 설명
백엔드 작업 먼저 하려고 했는데 연관관계 관련해서 이야기해봐야할 게 있는 것 같아서 
프론트엔드 작업 먼저 진행했습니다 😎
백엔드 작업은 논의하고 정해지면 마저 진행할께요!

Recoil 사용해서 프로젝트 정보 전역 상태값으로 설정 및 페이지에 상태값 적용

### 📑 구현한 내용 목록
- [x] Recoil 도입
- [x] 프로젝트 전역 상태값 설정
- [x] 페이지 프로젝트 정보와 연동
- [x] preflight 허용하도록 interceptor 수정

### 🚧 논의 사항
- OPTIONS로 요청되는 CORS preflight도 인터셉터에 막혀서 CORS 에러로 처리되길래 
  OPTIONS 메소드는 interceptor에서 허용하도록 변경했습니다~
- 바벨 설정 때문에 아래 같은 scss에서 컴포넌트 선택자 적용이 에러 발생했는데 @emotion/babel-plugin 추가해서 해결했습니다
```
export const ProjectDesc = styled.div`
`;

export const ProjectInfo = styled.div`
    &:hover ${ProjectDesc} {
    }
`;
```

- close #31 
