### PR TITLE
[#32] feat: 프로젝트 생성시 프로젝트 멤버에 사용자 추가

### DIFF
--- a/backend/src/main/java/kr/kro/colla/comment/domain/Comment.java
+++ b/backend/src/main/java/kr/kro/colla/comment/domain/Comment.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.comment.domain;
 
 import kr.kro.colla.user.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @Entity
 public class Comment {

--- a/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.exception;
 
+import kr.kro.colla.exception.exception.NotFoundException;
 import kr.kro.colla.exception.exception.auth.UnauthorizedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,7 @@ import org.springframework.web.client.HttpClientErrorException;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ExceptionHandleResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+    public ResponseEntity<ExceptionHandleResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         FieldError fieldError = e.getFieldError();
         ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.BAD_REQUEST.value(), fieldError.getField() + " : " + fieldError.getDefaultMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -21,7 +22,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
-    public ResponseEntity<ExceptionHandleResponse> handleHttpClientErrorException(HttpClientErrorException e){
+    public ResponseEntity<ExceptionHandleResponse> handleHttpClientErrorException(HttpClientErrorException e) {
         ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(response);
@@ -34,4 +35,15 @@ public class GlobalExceptionHandler {
                 .body(response);
     }
 
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionHandleResponse> handleNotFoundException(NotFoundException e) {
+        ExceptionHandleResponse response = new ExceptionHandleResponse(e.getStatusCode().value(), e.getMessage());
+        return ResponseEntity.status(e.getStatusCode()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionHandleResponse> handleException(Exception e){
+        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
@@ -41,9 +41,5 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(e.getStatusCode()).body(response);
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ExceptionHandleResponse> handleException(Exception e){
-        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
-    }
+
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/NotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/NotFoundException.java
@@ -1,0 +1,14 @@
+package kr.kro.colla.exception.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class NotFoundException extends RuntimeException {
+    private HttpStatus statusCode;
+
+    public NotFoundException(String message){
+        super(message);
+        this.statusCode = HttpStatus.NOT_FOUND;
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotFoundException.java
@@ -1,6 +1,8 @@
 package kr.kro.colla.exception.exception.user;
 
-public class UserNotFoundException extends RuntimeException {
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class UserNotFoundException extends NotFoundException {
 
     public UserNotFoundException() {
         super("해당하는 사용자를 찾을 수 없습니다.");

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -59,4 +59,8 @@ public class Project {
         this.name = name;
         this.description = description;
     }
+
+    public void addStatus(TaskStatus taskStatus){
+        this.taskStatuses.add(taskStatus);
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -4,10 +4,10 @@ import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.user_project.domain.UserProject;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Project {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -60,6 +60,13 @@ public class Project {
         this.description = description;
     }
 
+    @PrePersist
+    private void setDefaultTaskStatus(){
+        this.taskStatuses.add(TaskStatus.builder().name("To Do").build());
+        this.taskStatuses.add(TaskStatus.builder().name("In Progress").build());
+        this.taskStatuses.add(TaskStatus.builder().name("Done").build());
+    }
+
     public void addStatus(TaskStatus taskStatus){
         this.taskStatuses.add(taskStatus);
     }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -2,6 +2,7 @@ package kr.kro.colla.project.project.service;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,10 @@ public class ProjectService {
                 .name(createProjectRequest.getName())
                 .description(createProjectRequest.getDescription())
                 .build();
+
+        project.addStatus(TaskStatus.builder().name("To do").build());
+        project.addStatus(TaskStatus.builder().name("In progress").build());
+        project.addStatus(TaskStatus.builder().name("Done").build());
 
         return projectRepository.save(project);
     }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -19,10 +19,6 @@ public class ProjectService {
                 .description(createProjectRequest.getDescription())
                 .build();
 
-        project.addStatus(TaskStatus.builder().name("To do").build());
-        project.addStatus(TaskStatus.builder().name("In progress").build());
-        project.addStatus(TaskStatus.builder().name("Done").build());
-
         return projectRepository.save(project);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.project.task_status.domain;
 
 import kr.kro.colla.task.task.domain.Task;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @Getter
 @Entity
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TaskStatus {
 
     @Id

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -1,10 +1,13 @@
 package kr.kro.colla.project.task_status.domain;
 
+import kr.kro.colla.task.task.domain.Task;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -17,6 +20,10 @@ public class TaskStatus {
 
     @Column
     private String name;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status_id")
+    private List<Task> tasks = new ArrayList<>();
 
     @Builder
     public TaskStatus(String name){

--- a/backend/src/main/java/kr/kro/colla/user/user/domain/User.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/domain/User.java
@@ -2,6 +2,7 @@ package kr.kro.colla.user.user.domain;
 
 import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user_project.domain.UserProject;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class User {
 

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
@@ -2,8 +2,12 @@ package kr.kro.colla.user.user.presentation;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectResponse;
+import kr.kro.colla.user.user.service.UserService;
+import kr.kro.colla.user_project.domain.UserProject;
+import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,11 +19,15 @@ import javax.validation.Valid;
 @RequestMapping("/users")
 public class UserController {
     private final ProjectService projectService;
-
+    private final UserProjectService userProjectService;
+    private final UserService userService;
 
     @PostMapping("/{userId}/projects")
     public ResponseEntity<CreateProjectResponse> createProject(@PathVariable("userId") Long userId, @RequestBody @Valid CreateProjectRequest createProjectRequest){
+        User user = userService.findUserById(userId);
         Project project = projectService.createProject(userId, createProjectRequest);
+        userProjectService.addUserToProject(user, project);
+
         return ResponseEntity.ok(new CreateProjectResponse(project));
     }
 

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/CreateProjectRequest.java
@@ -2,6 +2,8 @@ package kr.kro.colla.user.user.presentation.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -1,10 +1,13 @@
 package kr.kro.colla.user.user.service;
 
 import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
+import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -22,5 +25,14 @@ public class UserService {
                                         .build()
                         )
                 );
+    }
+
+    public User findUserById(Long id){
+        Optional<User> isUser = userRepository.findById(id);
+        if (isUser.isEmpty()) {
+            throw new UserNotFoundException();
+        }
+
+        return isUser.get();
     }
 }

--- a/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
@@ -2,12 +2,17 @@ package kr.kro.colla.user_project.domain;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.user.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserProject {
 
     @Id
@@ -22,4 +27,9 @@ public class UserProject {
     @JoinColumn(name = "project_id")
     private Project project;
 
+    @Builder
+    UserProject(User user, Project project){
+        this.user = user;
+        this.project = project;
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/domain/UserProject.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 
 @Getter
 @Entity
@@ -28,7 +27,7 @@ public class UserProject {
     private Project project;
 
     @Builder
-    UserProject(User user, Project project){
+    public UserProject(User user, Project project){
         this.user = user;
         this.project = project;
     }

--- a/backend/src/main/java/kr/kro/colla/user_project/domain/repository/UserProjectRepository.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/domain/repository/UserProjectRepository.java
@@ -1,0 +1,7 @@
+package kr.kro.colla.user_project.domain.repository;
+
+import kr.kro.colla.user_project.domain.UserProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserProjectRepository extends JpaRepository<UserProject, Long> {
+}

--- a/backend/src/main/java/kr/kro/colla/user_project/service/UserProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/service/UserProjectService.java
@@ -1,0 +1,22 @@
+package kr.kro.colla.user_project.service;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user_project.domain.UserProject;
+import kr.kro.colla.user_project.domain.repository.UserProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserProjectService {
+    private final UserProjectRepository userProjectRepository;
+
+    public void addUserToProject(User user, Project project){
+        UserProject userProject = UserProject.builder()
+                .user(user)
+                .project(project).build();
+
+        userProjectRepository.save(userProject);
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/user_project/service/UserProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/user_project/service/UserProjectService.java
@@ -12,11 +12,11 @@ import org.springframework.stereotype.Service;
 public class UserProjectService {
     private final UserProjectRepository userProjectRepository;
 
-    public void addUserToProject(User user, Project project){
+    public UserProject addUserToProject(User user, Project project){
         UserProject userProject = UserProject.builder()
                 .user(user)
                 .project(project).build();
 
-        userProjectRepository.save(userProject);
+        return userProjectRepository.save(userProject);
     }
 }

--- a/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
@@ -48,7 +48,6 @@ public class AcceptanceTest {
 
         // then
         .then().log().all()
-                .assertThat()
                 .statusCode(HttpStatus.OK.value())
                 .cookie("accessToken", notNullValue());
     }
@@ -69,7 +68,6 @@ public class AcceptanceTest {
 
         // then
         .then()
-                .assertThat()
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 

--- a/backend/src/test/java/kr/kro/colla/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/service/AuthServiceTest.java
@@ -43,7 +43,7 @@ class AuthServiceTest {
         String oAuthAccessToken = "oauth-access-token";
         String jwtAccessToken = "jwt-access-token";
         String jwtRefreshToken = "jwt-refresh-token";
-        User user = new User();
+        User user = User.builder().build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
         GithubUserProfileResponse githubUserProfileResponse = new GithubUserProfileResponse("user", "github-id", "avatar");

--- a/backend/src/test/java/kr/kro/colla/common/fixture/Auth.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/Auth.java
@@ -2,11 +2,11 @@ package kr.kro.colla.common.fixture;
 
 import kr.kro.colla.auth.service.JwtProvider;
 
-public class User {
+public class Auth {
 
     private JwtProvider jwtProvider;
 
-    public User(JwtProvider jwtProvider) {
+    public Auth(JwtProvider jwtProvider) {
         this.jwtProvider = jwtProvider;
     }
 

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -83,6 +83,6 @@ public class AcceptanceTest {
         .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(400))
-                .body("message", equalTo("name : 널이어서는 안됩니다"));
+                .body("message", equalTo("name : 공백일 수 없습니다"));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -4,6 +4,10 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.exception.exception.user.UserNotFoundException;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,18 +32,28 @@ public class AcceptanceTest {
     @Autowired
     private JwtProvider jwtProvider;
 
+    @Autowired
+    private UserRepository userRepository;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
         auth = new Auth(jwtProvider);
+
+        User user = User.builder()
+                .githubId("binimini")
+                .name("subin")
+                .avatar("github_content").build();
+        userRepository.save(user);
+        managerId = user.getId();
     }
 
-    private Long managerId = 3L;
+    static Long managerId;
     private String name = "프로젝트 이름", desc = "프로젝트 설명";
     private Auth auth;
 
     @Test
-    void 사용자_프로젝트_생성_후_반환한다() {
+    void 사용자_프로젝트_생성_성공_후_반환한다() {
         // given
         String accessToken = auth.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
@@ -64,7 +78,7 @@ public class AcceptanceTest {
     }
 
     @Test
-    void 사용자_프로젝트_생성_실패_시_에러를_반환한다() throws Exception {
+    void 사용자_프로젝트_생성_시_요청이_잘못돼_에러를_반환한다() throws Exception {
         // given
         String accessToken = auth.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
@@ -84,5 +98,29 @@ public class AcceptanceTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(400))
                 .body("message", equalTo("name : 공백일 수 없습니다"));
+    }
+
+    @Test
+    void 사용자_프로젝트_생성_시_없는_사용자_아이디_요청에_에러_반환한다(){
+        // given
+        String accessToken = auth.로그인(managerId);
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("name", name);
+        requestBody.put("description",desc);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(requestBody)
+        // when
+        .when()
+                .post("/api/users/{userId}/projects",123123)
+
+        // then
+        .then().log().all()
+            .statusCode(HttpStatus.NOT_FOUND.value())
+            .body("status", equalTo(404))
+            .body("message", equalTo(new UserNotFoundException().getMessage()));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -3,7 +3,7 @@ package kr.kro.colla.project.project;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
-import kr.kro.colla.common.fixture.User;
+import kr.kro.colla.common.fixture.Auth;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,17 +31,17 @@ public class AcceptanceTest {
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
-        user = new User(jwtProvider);
+        auth = new Auth(jwtProvider);
     }
 
     private Long managerId = 3L;
     private String name = "프로젝트 이름", desc = "프로젝트 설명";
-    private User user;
+    private Auth auth;
 
     @Test
     void 사용자_프로젝트_생성_후_반환한다() {
         // given
-        String accessToken = user.로그인(managerId);
+        String accessToken = auth.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", name);
         requestBody.put("description",desc);
@@ -66,7 +66,7 @@ public class AcceptanceTest {
     @Test
     void 사용자_프로젝트_생성_실패_시_에러를_반환한다() throws Exception {
         // given
-        String accessToken = user.로그인(managerId);
+        String accessToken = auth.로그인(managerId);
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("description",desc);
 

--- a/backend/src/test/java/kr/kro/colla/project/project/domain/repository/ProjectRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/domain/repository/ProjectRepositoryTest.java
@@ -8,6 +8,9 @@ import org.springframework.test.context.ActiveProfiles;
 
 import javax.validation.ConstraintViolationException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.*;
 
 @ActiveProfiles("test")
@@ -35,6 +38,7 @@ class ProjectRepositoryTest {
         // then
         assertThat(result.getId()).isNotNull();
         assertThat(result.getName()).isEqualTo(name);
+        assertThat(result.getTaskStatuses().size()).isEqualTo(3);
 
     }
 

--- a/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.project.project.service;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -9,6 +10,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -38,6 +43,7 @@ class ProjectServiceTest {
                 .description(desc)
                 .build();
         ReflectionTestUtils.setField(sample, "id", id);
+        ReflectionTestUtils.setField(sample, "taskStatuses", new ArrayList<>(Arrays.asList("To do", "In progress", "Done")));
 
         given(projectRepository.save(any(Project.class))).willReturn(sample);
 
@@ -49,6 +55,8 @@ class ProjectServiceTest {
         assertThat(project.getManagerId()).isEqualTo(managerId);
         assertThat(project.getName()).isEqualTo(name);
         assertThat(project.getDescription()).isEqualTo(desc);
+        assertThat(project.getTaskStatuses().size()).isEqualTo(3);
+
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -1,11 +1,17 @@
 package kr.kro.colla.user.user.presentation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.auth.presentation.interceptor.AuthInterceptor;
 import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
+import kr.kro.colla.user.user.service.UserService;
+import kr.kro.colla.user_project.service.UserProjectService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -18,9 +24,12 @@ import org.springframework.test.web.servlet.ResultActions;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.net.UnknownServiceException;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -33,19 +42,28 @@ class UserControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
+    private AuthInterceptor authInterceptor;
+    @MockBean
     private AuthService authService;
 
     @MockBean
     private ProjectService projectService;
-
     @MockBean
-    private AuthInterceptor authInterceptor;
+    private UserProjectService userProjectService;
+    @MockBean
+    private UserService userService;
 
     private Long managerId = 3L;
     private String name = "프로젝트 이름", desc = "프로젝트 설명";
 
+    @BeforeEach
+    void setUp() throws Exception {
+        given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
+                .willReturn(true);
+    }
+
     @Test
-    void 사용자_프로젝트_생성_후_반환한다() throws Exception {
+    void 사용자의_프로젝트를_생성한_후_반환한다() throws Exception {
         // given
         CreateProjectRequest createProjectRequest = CreateProjectRequest.builder()
                 .name(name)
@@ -56,13 +74,16 @@ class UserControllerTest {
                 .name(name)
                 .description(desc)
                 .build();
+        User user = User.builder()
+                .githubId("binimini")
+                .name("subin")
+                .avatar("github_content").build();
+        String content = new ObjectMapper().writeValueAsString(createProjectRequest);
 
-        given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
-                .willReturn(true);
+        given(userService.findUserById(managerId))
+                .willReturn(user);
         given(projectService.createProject(eq(managerId), any(CreateProjectRequest.class)))
                 .willReturn(project);
-
-        String content = new ObjectMapper().writeValueAsString(createProjectRequest);
 
         // when
         ResultActions perform = mockMvc.perform(post("/users/" + managerId + "/projects")
@@ -78,15 +99,19 @@ class UserControllerTest {
     }
 
     @Test
-    void 사용자_프로젝트_생성_실패_시_에러를_반환한다() throws Exception {
+    void 프로젝트_생성_시_필수_속성이_없을_경우_에러를_반환한다() throws Exception {
         // given
         CreateProjectRequest createProjectRequest = CreateProjectRequest.builder()
                 .description(desc)
                 .build();
+        User user = User.builder()
+                .githubId("binimini")
+                .name("subin")
+                .avatar("github_content").build();
         String content = new ObjectMapper().writeValueAsString(createProjectRequest);
 
-        given(authInterceptor.preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any(Object.class)))
-                .willReturn(true);
+        given(userService.findUserById(managerId))
+                .willReturn(user);
 
         // when
         ResultActions perform = mockMvc.perform(post("/users/" + managerId + "/projects")
@@ -100,4 +125,25 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("name : must not be blank"));
     }
 
+    @Test
+    void 프로젝트_생성_시_해당_사용자가_없을_경우_에러를_반환한다() throws Exception {
+        // given
+        CreateProjectRequest createProjectRequest = CreateProjectRequest.builder()
+                .name(name)
+                .description(desc)
+                .build();
+        String content = new ObjectMapper().writeValueAsString(createProjectRequest);
+
+        given(userService.findUserById(managerId)).willThrow(new UserNotFoundException());
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/users/" + managerId + "/projects")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content));
+
+        // then
+        perform.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(new UserNotFoundException().getStatusCode().value()))
+                .andExpect(jsonPath("$.message").value(new UserNotFoundException().getMessage()));
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -97,7 +97,7 @@ class UserControllerTest {
         perform.andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
-                .andExpect(jsonPath("$.message").value("name : must not be null"));
+                .andExpect(jsonPath("$.message").value("name : must not be blank"));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/user_project/domain/repository/UserProjectRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/user_project/domain/repository/UserProjectRepositoryTest.java
@@ -1,0 +1,62 @@
+package kr.kro.colla.user_project.domain.repository;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import kr.kro.colla.user_project.domain.UserProject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class UserProjectRepositoryTest {
+    @Autowired
+    private UserProjectRepository userProjectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @BeforeEach
+    void setUp(){
+        User user = User.builder()
+                .githubId("binimini")
+                .name("subin")
+                .avatar("github_avatar").build();
+        userRepository.save(user);
+
+        Project project = Project.builder()
+                .managerId(123L)
+                .name("project_name").build();
+        projectRepository.save(project);
+
+        UserProject userProject = UserProject.builder()
+                .user(user)
+                .project(project)
+                .build();
+        userProjectRepository.save(userProject);
+    }
+
+    @Test
+    void 사용자_프로젝트_연결_저장에_성공한다(){
+        // given
+        UserProject result = userProjectRepository.findAll().get(0);
+
+        // when
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getProject().getName()).isEqualTo("project_name");
+        assertThat(result.getUser().getGithubId()).isEqualTo("binimini");
+
+    }
+}

--- a/backend/src/test/java/kr/kro/colla/user_project/service/UserProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user_project/service/UserProjectServiceTest.java
@@ -1,0 +1,54 @@
+package kr.kro.colla.user_project.service;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user_project.domain.UserProject;
+import kr.kro.colla.user_project.domain.repository.UserProjectRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserProjectServiceTest {
+    @Mock
+    private UserProjectRepository userProjectRepository;
+
+    @InjectMocks
+    private UserProjectService userProjectService;
+
+    @Test
+    void 프로젝트의_사용자_추가에_성공한다(){
+        User user = User.builder()
+                .githubId("binimini")
+                .name("subin")
+                .avatar("githubcontent").build();
+        Project project = Project.builder()
+                .name("project_name")
+                .managerId(345L)
+                .build();
+        UserProject userProject = UserProject.builder()
+                .user(user)
+                .project(project).build();
+        ReflectionTestUtils.setField(userProject, "id", 234L);
+        // given
+        given(userProjectRepository.save(any(UserProject.class))).willReturn(userProject);
+
+        // when
+        UserProject result = userProjectService.addUserToProject(user, project);
+
+        // then
+        verify(userProjectRepository, times(1)).save(any(UserProject.class));
+        assertThat(result.getId()).isEqualTo(234);
+        assertThat(result.getUser()).isEqualTo(user);
+        assertThat(result.getProject()).isEqualTo(project);
+    }
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
기존에 작업하던 것도 머지했던 dev 기반으로 체리픽해서 작업했습니다~

논의했던 대로 테스크와 상태값의 연관을 맺었습니다.
프로젝트 생성시에 프로젝트 멤버에 관리자를 추가하도록 
UserProjectService의 함수와 연동하고 요청하는 사용자를 검증하도록 구현했습니다!

UI만 만들면 사용자 초대도 금방 할 것 같네요 😁
자잘하게 고친 게 꽤 있는데 이해 안가면 얼마든지 코멘트 남겨주세요~ 
어쩌다보니 주말에 작업하게 됐네요 😅😅
### 📑 구현한 내용 목록

- [x] 프로젝트 - 사용자 연관관계 맺기
- [x] 테스크 상태값 - 테스크 연관관계 맺기
- [x] 프로젝트 - 사용자 연관관계 테스트
- [x] 프로젝트 생성시 사용자 추가하도록 구현
- [x] 프로젝트 생성시 사용자 추가 테스트
- [x] 프로젝트 생성시 기본 상태값 넣기

### 🚧 논의 사항
- UserProject의 Service에서 User와 Project 정보를 저장할 때 Project 객체의 검증이 필요할까요?
- 공통 에러 핸들러를 처리하고 싶었는데 그럴 경우 Spring 자체?에서 또는 다른 기반에서 던져지는 에러를 공통적으로 500 처리하게 되는 문제가 있네요! 공통 에러 핸들러를 어떻게 해야할지 의견이 필요합니다 🤔🤔

Close #32  
