### PR TITLE
[#42] refactor: 토큰 기반 사용자 조회하도록 테스트 코드 수정

### DIFF
--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -4,7 +4,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.fixture.Auth;
-import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
 
@@ -93,7 +92,7 @@ public class AcceptanceTest {
                 .body(requestBody)
         // when
         .when()
-                .post("/api/users/{userId}/projects", user.getId())
+                .post("/api/users/projects")
         // then
         .then()
                 .statusCode(HttpStatus.OK.value())
@@ -118,38 +117,13 @@ public class AcceptanceTest {
                 .body(requestBody)
         // when
         .when()
-                .post("/api/users/{userId}/projects", user.getId())
+                .post("/api/users/projects")
 
         // then
         .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(400))
                 .body("message", equalTo("name : 공백일 수 없습니다"));
-    }
-
-    @Test
-    void 사용자_프로젝트_생성_시_없는_사용자_아이디_요청에_에러_반환한다(){
-        // given
-        String accessToken = auth.로그인(user.getId());
-        String name = "프로젝트 이름", desc = "프로젝트 설명";
-        Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("name", name);
-        requestBody.put("description",desc);
-
-        given()
-                .contentType(ContentType.JSON)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .cookie("accessToken", accessToken)
-                .body(requestBody)
-        // when
-        .when()
-                .post("/api/users/{userId}/projects",123123)
-
-        // then
-        .then().log().all()
-            .statusCode(HttpStatus.NOT_FOUND.value())
-            .body("status", equalTo(404))
-            .body("message", equalTo(new UserNotFoundException().getMessage()));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -43,7 +43,7 @@ public class AcceptanceTest {
 
     private Auth auth;
     private User user;
-
+    private String accessToken;
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -55,13 +55,13 @@ public class AcceptanceTest {
                 .avatar("github_content")
                 .build();
         userRepository.save(user);
+
+        accessToken = auth.로그인(user.getId());
     }
 
     @Test
     void 로그인한_사용자의_프로필을_조회한다() {
         // given
-        String accessToken = auth.로그인(user.getId());
-
         given()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .cookie("accessToken", accessToken)
@@ -79,7 +79,6 @@ public class AcceptanceTest {
     @Test
     void 사용자_프로젝트_생성_성공_후_반환한다() {
         // given
-        String accessToken = auth.로그인(user.getId());
         String name = "프로젝트 이름", desc = "프로젝트 설명";
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("name", name);
@@ -105,7 +104,6 @@ public class AcceptanceTest {
     @Test
     void 사용자_프로젝트_생성_시_요청이_잘못돼_에러를_반환한다() throws Exception {
         // given
-        String accessToken = auth.로그인(user.getId());
         String name = "프로젝트 이름", desc = "프로젝트 설명";
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("description", desc);
@@ -129,7 +127,6 @@ public class AcceptanceTest {
     @Test
     void 사용자는_이름을_변경할_수_있다() {
         // given
-        String accessToken = auth.로그인(user.getId());
         String newDisplayName = "new-name";
         UpdateUserNameRequest updateUserNameRequest = new UpdateUserNameRequest(newDisplayName);
 

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -115,7 +115,7 @@ class UserControllerTest {
 
         given(userService.findUserById(loginUser.getId()))
                 .willReturn(user);
-        given(projectService.createProject(any(), any(CreateProjectRequest.class)))
+        given(projectService.createProject(eq(loginUser.getId()), any(CreateProjectRequest.class)))
                 .willReturn(project);
 
         // when

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -153,6 +153,7 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("name : must not be blank"));
+        verify(projectService, times(0)).createProject(any(), any());
     }
 
     @Test


### PR DESCRIPTION
### 🔨 작업 내용 설명

토큰 내의 사용자 아이디를 사용해서 깨졌던 테스트 복구했습니다!

테스트에서 인증을 위한 accessToken을 `setUp()`시에 발급받도록 했는데,
인증 안했을 때나 권한에 따른 다른 경우는 미리 발급 받은 accessToken이 아닌 
상황에 따라 다른 accessToken을 쿠키로 넣어주면 (혹은 아예 넣어주지 않으면) 될 것 같다고 판단해서 옮겼습니다.
혹시 문제가 될 케이스가 있으면 이야기해주세요 😀

### 📑 구현한 내용 목록

- [x] 테스트 복구 및 수정
- [x] 인증 로직 `setUp()`으로 분리

### 🚧 논의 사항

- close #42 
