### PR TITLE
[#44] feat: 사이드바 구현

### DIFF
--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import {
+    ProjectIcon,
+    VerticalBar,
+    ProjectContainer,
+    MenuContainer,
+    Project,
+    Menu,
+    ProjectWrapper,
+    MenuWrapper,
+} from './style';
+
+interface project {
+    name: string;
+}
+
+interface Props {
+    props: Array<project> | Array<string>;
+    delimiter: boolean;
+}
+
+export const SideBar = ({ props, delimiter }: Props) => (
+    <>
+        <VerticalBar />
+        {delimiter ? (
+            <ProjectContainer>
+                <ProjectWrapper>
+                    {props.map((el, idx) => (
+                        <Project key={idx}>
+                            <ProjectIcon />
+                            <span>{(el as project).name}</span>
+                        </Project>
+                    ))}
+                </ProjectWrapper>
+            </ProjectContainer>
+        ) : (
+            <MenuContainer>
+                <MenuWrapper>
+                    {props.map((el) => (
+                        <>
+                            <Menu>{el}</Menu>
+                        </>
+                    ))}
+                </MenuWrapper>
+            </MenuContainer>
+        )}
+    </>
+);

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -11,25 +11,25 @@ import {
     MenuWrapper,
 } from './style';
 
-interface project {
+interface Project {
     name: string;
 }
 
 interface Props {
-    props: Array<project> | Array<string>;
-    delimiter: boolean;
+    props: Array<Project | string>;
+    project?: boolean;
 }
 
-export const SideBar = ({ props, delimiter }: Props) => (
+export const SideBar = ({ props, project }: Props) => (
     <>
         <VerticalBar />
-        {delimiter ? (
+        {project ? (
             <ProjectContainer>
                 <ProjectWrapper>
                     {props.map((el, idx) => (
                         <Project key={idx}>
                             <ProjectIcon />
-                            <span>{(el as project).name}</span>
+                            <span>{(el as Project).name}</span>
                         </Project>
                     ))}
                 </ProjectWrapper>

--- a/frontend/src/components/SideBar/style.ts
+++ b/frontend/src/components/SideBar/style.ts
@@ -1,0 +1,87 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { GREEN } from '../../styles/color';
+
+export const VerticalBar = styled.div`
+    position: absolute;
+    height: 85vh;
+    margin: -10px 0 0 30px;
+    border: 2px solid ${GREEN};
+    background-color: ${GREEN};
+`;
+
+export const ProjectContainer = styled.div`
+    position: absolute;
+    height: 770px;
+    overflow-y: scroll;
+    padding-top: 10px;
+
+    ::-webkit-scrollbar {
+        display: none;
+    }
+`;
+
+export const Wrapper = css`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+`;
+
+const SideBarComponent = css`
+    cursor: pointer;
+
+    :hover {
+        animation: lift-up 0.2s forwards;
+    }
+
+    @keyframes lift-up {
+        0% {
+            transform: translateY(0);
+        }
+        100% {
+            transform: translateY(-6px);
+        }
+    }
+`;
+
+export const ProjectWrapper = styled.div`
+    ${Wrapper}
+`;
+
+export const Project = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin: 0 0 15px 50px;
+
+    ${SideBarComponent}
+`;
+
+export const ProjectIcon = styled.div`
+    width: 70px;
+    height: 70px;
+    background-color: black;
+    border-radius: 10px;
+    margin-right: 10px;
+`;
+
+export const MenuContainer = styled.div`
+    position: absolute;
+    height: 770px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+`;
+
+export const MenuWrapper = styled.div`
+    height: 400px;
+
+    ${Wrapper}
+`;
+
+export const Menu = styled.div`
+    font-size: 20px;
+    margin: 0 0 15px 50px;
+
+    ${SideBarComponent}
+`;

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -44,7 +44,7 @@ const Home = () => {
     return (
         <>
             <Header />
-            <SideBar props={projects} delimiter={true} />
+            <SideBar props={projects} project />
             <Container>
                 <HomeImage src={HomeImageSrc} />
                 <ProjectNotice onClick={setModal}>프로젝트를 추가해보세요!</ProjectNotice>

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -6,18 +6,28 @@ import HomeImageSrc from '../../../public/assets/images/home-image.png';
 import { createProject } from '../../apis/user';
 import Header from '../../components/Header';
 import ProjectModal from '../../components/Modal/Project';
+import { SideBar } from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { projectDescState, projectNameState } from '../../stores/projectState';
 import { Container, HomeImage, ProjectNotice } from './style';
+
+const projects = [
+    {
+        name: '프로젝트 1',
+    },
+    {
+        name: '프로젝트 2',
+    },
+];
 
 const Home = () => {
     const setProjectName = useSetRecoilState(projectNameState);
     const setProjectDesc = useSetRecoilState(projectDescState);
     const history = useHistory();
 
-    const sendRequest = async (userId: number, name: string, desc: string) => {
+    const sendRequest = async (name: string, desc: string) => {
         try {
-            const response = await createProject(userId, name, desc);
+            const response = await createProject(name, desc);
             const { name: projectName, description: projectDesc } = response.data;
             setProjectName(projectName);
             setProjectDesc(projectDesc);
@@ -34,6 +44,7 @@ const Home = () => {
     return (
         <>
             <Header />
+            <SideBar props={projects} delimiter={true} />
             <Container>
                 <HomeImage src={HomeImageSrc} />
                 <ProjectNotice onClick={setModal}>프로젝트를 추가해보세요!</ProjectNotice>

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -4,14 +4,17 @@ import { useRecoilValue } from 'recoil';
 
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
+import { SideBar } from '../../components/SideBar';
 import { projectNameState } from '../../stores/projectState';
-import { Wrapper, KanbanAddButton, KanbanAdditional } from './style';
+import { Wrapper, KanbanAddButton, KanbanAdditional, Container } from './style';
 
 const statuses = ['To Do', 'Progress', 'Done'];
 
 const Kanban = () => {
     const history = useHistory();
+    const menu = ['로드맵', '백로그', '대시보드', '지도'];
     const projectName = useRecoilValue(projectNameState);
+
     if (!projectName) {
         history.push('/');
     }
@@ -19,14 +22,17 @@ const Kanban = () => {
     return (
         <>
             <Header />
-            <Wrapper>
-                {statuses.map((value) => (
-                    <KanbanCol key={value} status={value} />
-                ))}
-                <KanbanAdditional>
-                    <KanbanAddButton />
-                </KanbanAdditional>
-            </Wrapper>
+            <SideBar props={menu} delimiter={false} />
+            <Container>
+                <Wrapper>
+                    {statuses.map((value) => (
+                        <KanbanCol key={value} status={value} />
+                    ))}
+                    <KanbanAdditional>
+                        <KanbanAddButton />
+                    </KanbanAdditional>
+                </Wrapper>
+            </Container>
         </>
     );
 };

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -22,7 +22,7 @@ const Kanban = () => {
     return (
         <>
             <Header />
-            <SideBar props={menu} delimiter={false} />
+            <SideBar props={menu} />
             <Container>
                 <Wrapper>
                     {statuses.map((value) => (

--- a/frontend/src/pages/Kanban/style.tsx
+++ b/frontend/src/pages/Kanban/style.tsx
@@ -1,6 +1,13 @@
 import styled from '@emotion/styled';
 import plusIcon from '../../../public/assets/images/plus-circle.svg';
 import { LIGHT_GRAY } from '../../styles/color';
+import { Center } from '../../styles/common';
+
+export const Container = styled.div`
+    flex-direction: column;
+
+    ${Center}
+`;
 
 export const Wrapper = styled.div`
     display: flex;


### PR DESCRIPTION
### 🔨 작업 내용 설명
프로젝트 목록과 메뉴를 위한 사이드바 구현

### 📑 구현한 내용 목록
- [x] 프로젝트 목록 사이드바 구현
- [x] 메뉴 사이드바 구현

### 🚧 논의 사항
- 페이지에 따라서 사이드바 내용을 프로젝트 목록 혹은 메뉴로 구성하였습니다.
- 현재는 프로젝트 목록에 더미 데이터가 들어가 있지만 프로젝트 썸네일 저장 API와 조회 API 개발 후 이름 및 썸네일을 추가하도록 하겠습니다!

- close #44
