### PR TITLE
[#51] feat: 프로젝트 조회 API 구현 및 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -65,9 +65,9 @@ public class Project {
 
     @PrePersist
     private void setDefaultTaskStatus(){
-        this.taskStatuses.add(TaskStatus.builder().name("To Do").build());
-        this.taskStatuses.add(TaskStatus.builder().name("In Progress").build());
-        this.taskStatuses.add(TaskStatus.builder().name("Done").build());
+        this.taskStatuses.add(new TaskStatus("To Do"));
+        this.taskStatuses.add(new TaskStatus("In Progress"));
+        this.taskStatuses.add(new TaskStatus("Done"));
     }
 
     public void addStatus(TaskStatus taskStatus){

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -5,6 +5,7 @@ import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberResponse;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
@@ -22,6 +23,13 @@ public class ProjectController {
     private final ProjectService projectService;
     private final UserService userService;
     private final UserProjectService userProjectService;
+
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectResponse> getProject(@PathVariable long projectId) {
+        ProjectResponse projectResponse = projectService.getProject(projectId);
+
+        return ResponseEntity.ok(projectResponse);
+    }
 
     @PostMapping("/{projectId}/members")
     public ResponseEntity joinMember(@Authenticated LoginUser loginUser,

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
@@ -1,0 +1,28 @@
+package kr.kro.colla.project.project.presentation.dto;
+
+import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
+import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ProjectResponse {
+
+    private Long id;
+
+    private Long managerId;
+
+    private String name;
+
+    private String description;
+
+    private String thumbnail;
+
+    private List<UserProfileResponse> members;
+
+    private List<ProjectTaskResponse> tasks;
+
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Map;
 
 @Builder
 @Getter
@@ -23,6 +24,6 @@ public class ProjectResponse {
 
     private List<UserProfileResponse> members;
 
-    private List<ProjectTaskResponse> tasks;
+    private Map<String, List<ProjectTaskResponse>> tasks;
 
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
@@ -2,16 +2,13 @@ package kr.kro.colla.project.project.presentation.dto;
 
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 import java.util.Map;
 
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor
 @Getter
 public class ProjectResponse {

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectResponse.java
@@ -2,13 +2,17 @@ package kr.kro.colla.project.project.presentation.dto;
 
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
 
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ProjectResponse {
 

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -36,6 +39,17 @@ public class ProjectService {
 
     public ProjectResponse getProject(Long projectId) {
         Project project = findProjectById(projectId);
+        Map<String, List<ProjectTaskResponse>> tasks = new HashMap<>();
+        project.getTaskStatuses()
+                .stream()
+                .forEach(taskStatus -> {
+                    List<ProjectTaskResponse> taskList = taskStatus.getTasks()
+                            .stream()
+                            .map(ProjectTaskResponse::new)
+                            .collect(Collectors.toList());
+                    tasks.put(taskStatus.getName(), taskList);
+                });
+
 
         return ProjectResponse.builder()
                 .id(project.getId())
@@ -47,10 +61,7 @@ public class ProjectService {
                         .stream()
                         .map(userProject -> new UserProfileResponse(userProject.getUser()))
                         .collect(Collectors.toList()))
-                .tasks(project.getTasks()
-                        .stream()
-                        .map(task -> new ProjectTaskResponse(task))
-                        .collect(Collectors.toList()))
+                .tasks(tasks)
                 .build();
     }
 

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -26,7 +26,9 @@ public class ProjectService {
     private final ProjectProfileStorage projectProfileStorage;
 
     public Project createProject(Long managerId, CreateProjectRequest createProjectRequest) {
-        String thumbnailUrl = projectProfileStorage.upload(createProjectRequest.getThumbnail());
+        String thumbnailUrl = createProjectRequest.getThumbnail() != null
+                ? projectProfileStorage.upload(createProjectRequest.getThumbnail())
+                : null;
         Project project = Project.builder()
                 .managerId(managerId)
                 .name(createProjectRequest.getName())

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -4,11 +4,18 @@ import kr.kro.colla.exception.exception.project.ProjectNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
+import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
+import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class ProjectService {
 
@@ -27,8 +34,29 @@ public class ProjectService {
         return projectRepository.save(project);
     }
 
+    public ProjectResponse getProject(Long projectId) {
+        Project project = findProjectById(projectId);
+
+        return ProjectResponse.builder()
+                .id(project.getId())
+                .managerId(project.getManagerId())
+                .name(project.getName())
+                .description(project.getDescription())
+                .thumbnail(project.getThumbnail())
+                .members(project.getMembers()
+                        .stream()
+                        .map(userProject -> new UserProfileResponse(userProject.getUser()))
+                        .collect(Collectors.toList()))
+                .tasks(project.getTasks()
+                        .stream()
+                        .map(task -> new ProjectTaskResponse(task))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
     public Project findProjectById(Long projectId){
         return projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
     }
+
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/dto/ProjectTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/dto/ProjectTaskResponse.java
@@ -1,0 +1,24 @@
+package kr.kro.colla.project.project.service.dto;
+
+import kr.kro.colla.task.task.domain.Task;
+import lombok.Getter;
+
+@Getter
+public class ProjectTaskResponse {
+
+    private Long id;
+
+    private String title;
+
+    private String managerName;
+
+    private Integer priority;
+
+    public ProjectTaskResponse(Task task) {
+        this.id = task.getId();
+        this.title = task.getTitle();
+        this.managerName = task.getManagerName();
+        this.priority = task.getPriority();
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/service/dto/ProjectTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/dto/ProjectTaskResponse.java
@@ -2,7 +2,9 @@ package kr.kro.colla.project.project.service.dto;
 
 import kr.kro.colla.task.task.domain.Task;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class ProjectTaskResponse {
 

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -21,7 +21,8 @@ public class TaskStatus {
     @Column
     private String name;
 
-    @OneToMany(mappedBy = "taskStatus", fetch = FetchType.EAGER)
+    @OneToMany(fetch = FetchType.EAGER)
+    @JoinColumn(name = "task_status_id")
     private List<Task> tasks = new ArrayList<>();
 
     public TaskStatus(String name){

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -2,7 +2,6 @@ package kr.kro.colla.project.task_status.domain;
 
 import kr.kro.colla.task.task.domain.Task;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,8 +21,7 @@ public class TaskStatus {
     @Column
     private String name;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "status_id")
+    @OneToMany(mappedBy = "taskStatus", fetch = FetchType.EAGER)
     private List<Task> tasks = new ArrayList<>();
 
     public TaskStatus(String name){

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -26,7 +26,6 @@ public class TaskStatus {
     @JoinColumn(name = "status_id")
     private List<Task> tasks = new ArrayList<>();
 
-    @Builder
     public TaskStatus(String name){
         this.name = name;
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.task.task.domain;
 
 import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.history.domain.History;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
@@ -31,9 +32,6 @@ public class Task {
     private String images;
 
     @Column
-    private String status;
-
-    @Column
     private String managerName;
 
     @CreatedDate
@@ -44,6 +42,10 @@ public class Task {
 
     @Column
     private Integer priority;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_status_id")
+    private TaskStatus taskStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "story_id")

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -44,10 +44,6 @@ public class Task {
     private Integer priority;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "task_status_id")
-    private TaskStatus taskStatus;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "story_id")
     private Story story;
 

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -21,10 +21,6 @@ public class Task {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "story_id")
-    private Story story;
-
     @Column
     private String title;
 
@@ -48,6 +44,10 @@ public class Task {
 
     @Column
     private Integer priority;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "story_id")
+    private Story story;
 
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id")

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserProfileResponse.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserProfileResponse.java
@@ -2,7 +2,9 @@ package kr.kro.colla.user.user.presentation.dto;
 
 import kr.kro.colla.user.user.domain.User;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class UserProfileResponse {
 

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -1,0 +1,104 @@
+package kr.kro.colla.project.project;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import kr.kro.colla.user_project.service.UserProjectService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserProjectService userProjectService;
+
+    private Auth auth;
+    private User user;
+    private Project project;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        user = User.builder()
+                .githubId("kykapple")
+                .name("kyk")
+                .avatar("github_content")
+                .build();
+        userRepository.save(user);
+        project = Project.builder()
+                .managerId(user.getId())
+                .name("project name")
+                .description("project description")
+                .thumbnail("s3_content")
+                .build();
+        projectRepository.save(project);
+        userProjectService.joinProject(user, project);
+
+        auth = new Auth(jwtProvider);
+        accessToken = auth.로그인(1L);
+    }
+
+    @Test
+    void 프로젝트_목록에서_클릭한_프로젝트를_조회한다() {
+        // given
+        Long projectId = 1L;
+
+        ProjectResponse response = given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + projectId)
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", notNullValue())
+                .body("name", equalTo(project.getName()))
+                .body("description", equalTo(project.getDescription()))
+                .body("members.size()", is(1))
+                .extract()
+                .body()
+                .as(ProjectResponse.class);
+        assertThat(response.getMembers().get(0).getGithubId()).isEqualTo(user.getGithubId());
+        assertThat(response.getTasks().size()).isEqualTo(3);
+        assertThat(response.getTasks().containsKey("To Do")).isTrue();
+        assertThat(response.getTasks().containsKey("In Progress")).isTrue();
+        assertThat(response.getTasks().containsKey("Done")).isTrue();
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -1,0 +1,114 @@
+package kr.kro.colla.project.project.presentation;
+
+import kr.kro.colla.auth.domain.LoginUser;
+import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
+import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
+import kr.kro.colla.user.user.service.UserService;
+import kr.kro.colla.user_project.service.UserProjectService;
+import kr.kro.colla.utils.CookieManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.Cookie;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ProjectController.class)
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private CookieManager cookieManager;
+
+    @MockBean
+    private ProjectService projectService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserProjectService userProjectService;
+
+    private String accessToken = "token";
+    private LoginUser loginUser;
+
+    @BeforeEach
+    void setUp() {
+        String accessToken = "token";
+        loginUser = new LoginUser(345234L);
+
+        given(cookieManager.parseCookies(any(Cookie[].class), eq("accessToken")))
+                .willReturn(new Cookie("accessToken", accessToken));
+        given(authService.validateAccessToken(eq(accessToken)))
+                .willReturn(true);
+        given(authService.findUserFromToken(accessToken))
+                .willReturn(loginUser);
+    }
+
+    @Test
+    void projectId에_해당하는_프로젝트를_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        Map<String, List<ProjectTaskResponse>> tasks = new HashMap<>();
+        tasks.put("To Do", new ArrayList<>());
+        tasks.put("In Progress", new ArrayList<>());
+        tasks.put("Done", new ArrayList<>());
+        User user = User.builder()
+                .name("kykapple")
+                .githubId("kykapple")
+                .avatar("github_content")
+                .build();
+        ProjectResponse projectResponse = ProjectResponse.builder()
+                .id(projectId)
+                .managerId(loginUser.getId())
+                .name("project name")
+                .description("project description")
+                .thumbnail("s3_content")
+                .members(List.of(new UserProfileResponse(user)))
+                .tasks(tasks)
+                .build();
+
+        given(projectService.getProject(eq(projectId)))
+                .willReturn(projectResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId)
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(projectResponse.getName()))
+                .andExpect(jsonPath("$.description").value(projectResponse.getDescription()))
+                .andExpect(jsonPath("$.members").isArray())
+                .andExpect(jsonPath("$.tasks").isMap())
+                .andExpect(jsonPath("$.tasks.Done").isEmpty());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
@@ -4,7 +4,11 @@ import kr.kro.colla.common.fixture.FileProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
+import kr.kro.colla.user_project.domain.UserProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -14,9 +18,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,7 +38,7 @@ class ProjectServiceTest {
     private ProjectService projectService;
 
     private Long id = 1L, managerId = 1L;
-    private String name = "생성할 프로젝트 이름", desc = "생성할 프로젝트 설명";
+    private String name = "프로젝트 이름", desc = "프로젝트 설명";
 
     @Test
     void 프로젝트_생성을_성공한다() {
@@ -69,6 +75,44 @@ class ProjectServiceTest {
         assertThat(result.getThumbnail()).isEqualTo(FileProvider.extractImageUrl(thumbnail1));
         assertThat(result.getTaskStatuses().size()).isEqualTo(3);
 
+    }
+
+    @Test
+    void projectId에_해당하는_프로젝트를_조회한다() {
+        // given
+        String fileName = "thumbnail.png";
+        MultipartFile thumbnail1 = FileProvider.getTestMultipartFile(fileName);
+        User user = User.builder()
+                .name("kykapple")
+                .githubId("kykapple")
+                .avatar("github_content")
+                .build();
+        Project project = Project.builder()
+                .managerId(managerId)
+                .name(name)
+                .description(desc)
+                .thumbnail(FileProvider.extractImageUrl(thumbnail1))
+                .build();
+        ReflectionTestUtils.setField(project, "taskStatuses", List.of(
+                new TaskStatus("To Do"),
+                new TaskStatus("In Progress"),
+                new TaskStatus("Done")
+        ));
+        ReflectionTestUtils.setField(project, "members", List.of(new UserProject(user, project)));
+
+        given(projectRepository.findById(eq(id)))
+                .willReturn(Optional.of(project));
+
+        // when
+        ProjectResponse result = projectService.getProject(id);
+
+        // then
+        assertThat(result.getName()).isEqualTo(project.getName());
+        assertThat(result.getDescription()).isEqualTo(project.getDescription());
+        assertThat(result.getMembers().size()).isOne();
+        assertThat(result.getMembers().get(0).getGithubId()).isEqualTo(user.getGithubId());
+        assertThat(result.getTasks().size()).isEqualTo(3);
+        assertThat(result.getTasks().get("Done")).isEmpty();
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -62,6 +62,7 @@ public class AcceptanceTest {
     private Auth auth;
     private User user;
     private String accessToken;
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -129,13 +129,13 @@ class UserControllerTest {
         given(projectService.createProject(eq(loginUser.getId()), any(CreateProjectRequest.class)))
                 .willReturn(project);
 
+        // when
         ResultActions perform = mockMvc.perform(multipart("/users/projects")
                 .file(thumbnail)
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("name", name)
                 .param("description", desc));
-        // when
 
         // then
         perform.andDo(print())

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -6,6 +6,13 @@ interface userProfile {
     avatar: string;
 }
 
+interface project {
+    id: number;
+    name: string;
+    description: string;
+    thumbnail: string;
+}
+
 export const getUserProfile = async () => {
     const response = await client.get<userProfile>(`/users/profile`);
 
@@ -19,7 +26,7 @@ export const updateDisplayName = async (displayName: string) => {
 };
 
 export const createProject = async (data: FormData) => {
-    const response = await client.post(`/users/projects`, data, {
+    const response = await client.post<project>(`/users/projects`, data, {
         headers: { 'Content-Type': 'multipart/form-data' },
     });
 
@@ -30,4 +37,4 @@ export const getUserProjects = async () => {
     const response = await client.get(`/users/projects`);
 
     return response;
-}
+};

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 
 import useModal from '../../hooks/useModal';
-import { projectInfoState } from '../../stores/projectState';
+import { projectState } from '../../stores/projectState';
 import UserIcon from '../Icon/User';
 import InviteModal from '../Modal/Invite';
 import {
@@ -18,17 +18,17 @@ import {
 
 const Header = () => {
     const { Modal, setModal } = useModal();
-    const projectInfo = useRecoilValue(projectInfoState);
+    const project = useRecoilValue(projectState);
 
     return (
         <Container>
             <LeftNav>
                 <ProjectInfo>
-                    <ProjectTitle>{projectInfo.name}</ProjectTitle>
-                    <ProjectDesc>{projectInfo.desc}</ProjectDesc>
+                    <ProjectTitle>{project.name}</ProjectTitle>
+                    <ProjectDesc>{project.description}</ProjectDesc>
                 </ProjectInfo>
                 <ProjectManagement>
-                    {projectInfo.name ? <ProjectManageButton onClick={setModal}>관리</ProjectManageButton> : null}
+                    {project.name ? <ProjectManageButton onClick={setModal}>관리</ProjectManageButton> : null}
                     <Modal>
                         <InviteModal />
                     </Modal>

--- a/frontend/src/components/Modal/Project/index.tsx
+++ b/frontend/src/components/Modal/Project/index.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { createProject } from '../../../apis/user';
 import { projectState } from '../../../stores/projectState';
 import { createFormData } from '../../../utils/common';
@@ -14,7 +14,7 @@ const ProjectModal = () => {
     const [description, setDescription] = useState('');
     const [thumbnail, setThumbnail] = useState<File | null>(null);
 
-    const [projectStates, setProjectState] = useRecoilState(projectState);
+    const setProjectState = useSetRecoilState(projectState);
 
     const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => setName(event.target.value);
 
@@ -38,8 +38,6 @@ const ProjectModal = () => {
                 description: projectDescription,
                 thumbnail: projectThumbnail,
             });
-
-            console.log(projectStates);
 
             history.push('/kanban', response.data);
         } catch (e: any) {

--- a/frontend/src/components/Modal/Project/index.tsx
+++ b/frontend/src/components/Modal/Project/index.tsx
@@ -1,9 +1,9 @@
 import React, { ChangeEvent, useState } from 'react';
 
 import { useHistory } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { createProject } from '../../../apis/user';
-import { projectDescState, projectNameState, projectThumbnailState } from '../../../stores/projectState';
+import { projectState } from '../../../stores/projectState';
 import { createFormData } from '../../../utils/common';
 import ProjectIcon from '../../Icon/Project';
 import { Container, SubmitButton, ProjectNameInput, ProjectDescInput } from './style';
@@ -14,9 +14,7 @@ const ProjectModal = () => {
     const [description, setDescription] = useState('');
     const [thumbnail, setThumbnail] = useState<File | null>(null);
 
-    const setProjectName = useSetRecoilState(projectNameState);
-    const setProjectDesc = useSetRecoilState(projectDescState);
-    const setProjectThumbnail = useSetRecoilState(projectThumbnailState);
+    const [projectStates, setProjectState] = useRecoilState(projectState);
 
     const handleNameChange = (event: ChangeEvent<HTMLInputElement>) => setName(event.target.value);
 
@@ -24,12 +22,24 @@ const ProjectModal = () => {
 
     const handleSubmit = async () => {
         try {
-            const formData = createFormData({ name, description, thumbnail });
+            const formData = thumbnail
+                ? createFormData({ name, description, thumbnail })
+                : createFormData({ name, description });
             const response = await createProject(formData);
-            const { name: projectName, description: projectDesc, thumbnail: projectThumbnail } = response.data;
-            setProjectName(projectName);
-            setProjectDesc(projectDesc);
-            setProjectThumbnail(projectThumbnail);
+            const {
+                id: projectId,
+                name: projectName,
+                description: projectDescription,
+                thumbnail: projectThumbnail,
+            } = response.data;
+            setProjectState({
+                id: projectId,
+                name: projectName,
+                description: projectDescription,
+                thumbnail: projectThumbnail,
+            });
+
+            console.log(projectStates);
 
             history.push('/kanban', response.data);
         } catch (e: any) {

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
+import { useHistory } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 import EmptySrc from '../../../public/assets/images/empty.png';
+import { projectState } from '../../stores/projectState';
 import {
     ProjectIcon,
     VerticalBar,
@@ -15,6 +18,7 @@ import {
 interface Project {
     id: number;
     name: string;
+    description: string;
     thumbnail: string;
 }
 
@@ -23,30 +27,47 @@ interface Props {
     project?: boolean;
 }
 
-export const SideBar = ({ props, project }: Props) => (
-    <>
-        <VerticalBar />
-        {project ? (
-            <ProjectContainer>
-                <ProjectWrapper>
-                    {props.map((el, idx) => (
-                        <Project key={idx}>
-                            <ProjectIcon src={(el as Project).thumbnail ? (el as Project).thumbnail : EmptySrc} />
-                            <span>{(el as Project).name}</span>
-                        </Project>
-                    ))}
-                </ProjectWrapper>
-            </ProjectContainer>
-        ) : (
-            <MenuContainer>
-                <MenuWrapper>
-                    {props.map((el) => (
-                        <>
-                            <Menu>{el}</Menu>
-                        </>
-                    ))}
-                </MenuWrapper>
-            </MenuContainer>
-        )}
-    </>
-);
+export const SideBar = ({ props, project }: Props) => {
+    const history = useHistory();
+    const setProjectState = useSetRecoilState(projectState);
+
+    // eslint-disable-next-line no-shadow
+    const enterProject = (project: Project) => {
+        const { id, name, description, thumbnail } = project;
+        setProjectState({
+            id,
+            name,
+            description,
+            thumbnail,
+        });
+        history.push('/kanban');
+    };
+
+    return (
+        <>
+            <VerticalBar />
+            {project ? (
+                <ProjectContainer>
+                    <ProjectWrapper>
+                        {props.map((el, idx) => (
+                            <Project key={idx} onClick={() => enterProject(el as Project)}>
+                                <ProjectIcon src={(el as Project).thumbnail ? (el as Project).thumbnail : EmptySrc} />
+                                <span>{(el as Project).name}</span>
+                            </Project>
+                        ))}
+                    </ProjectWrapper>
+                </ProjectContainer>
+            ) : (
+                <MenuContainer>
+                    <MenuWrapper>
+                        {props.map((el, idx) => (
+                            <div key={idx}>
+                                <Menu>{el}</Menu>
+                            </div>
+                        ))}
+                    </MenuWrapper>
+                </MenuContainer>
+            )}
+        </>
+    );
+};

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
@@ -18,10 +18,6 @@ const Kanban = () => {
     if (!project.id) {
         history.push('/home');
     }
-
-    useEffect(() => {
-        console.log(project.id);
-    }, []);
 
     return (
         <>

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
 import { SideBar } from '../../components/SideBar';
-import { projectNameState } from '../../stores/projectState';
+import { projectState } from '../../stores/projectState';
 import { Wrapper, KanbanAddButton, KanbanAdditional, Container } from './style';
 
 const statuses = ['To Do', 'Progress', 'Done'];
@@ -13,11 +13,15 @@ const statuses = ['To Do', 'Progress', 'Done'];
 const Kanban = () => {
     const history = useHistory();
     const menu = ['로드맵', '백로그', '대시보드', '지도'];
-    const projectName = useRecoilValue(projectNameState);
+    const project = useRecoilValue(projectState);
 
-    if (!projectName) {
-        history.push('/');
+    if (!project.id) {
+        history.push('/home');
     }
+
+    useEffect(() => {
+        console.log(project.id);
+    }, []);
 
     return (
         <>

--- a/frontend/src/stores/projectState.ts
+++ b/frontend/src/stores/projectState.ts
@@ -1,25 +1,18 @@
-import { atom, selector } from 'recoil';
+import { atom } from 'recoil';
 
-export const projectNameState = atom({
-    key: 'projectName',
-    default: null,
-});
+interface project {
+    id: number;
+    name: string;
+    description: string;
+    thumbnail: string;
+}
 
-export const projectDescState = atom({
-    key: 'projectDesc',
-    default: null,
-});
-
-export const projectThumbnailState = atom({
-    key: 'projectThumbnail',
-    default: null,
-});
-
-export const projectInfoState = selector({
+export const projectState = atom<project>({
     key: 'project',
-    get: ({ get }) => ({
-        name: get(projectNameState),
-        desc: get(projectDescState),
-        thumbnail: get(projectThumbnailState),
-    }),
+    default: {
+        id: -1,
+        name: '',
+        description: '',
+        thumbnail: '',
+    },
 });


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 프로젝트 조회 API 구현
- 테스트 코드 작성

### 📑 구현한 내용 목록
- [x] 프로젝트 조회 API 구현
- [x] 테스트 코드 작성
- [ ] API 연동

### 🚧 논의 사항
- 프로젝트 조회 API를 구현하였고, 응답 객체는 아래와 같습니다!
```
{
   id,
   managerId,
   name,
   description,
   thumbnail,
   members: [ ... ],
   tasks: {
      ToDo: [ ... ],
      InProgress: [ ... ],
      Done: [ ... ],
   }
}
```
- 테스크 테이블과 테스크 상태 테이블 사이에 연관 관계를 두기로 하였었는데, 아직 엔티티에는 반영되어 있지 않아 반영해두었습니다! 그리고 테스크 상태값을 조회할 때는 항상 테스크가 함께 조회되서 즉시 로딩으로 설정해주었습니다!
```
public class Task {
   ...

   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "task_status_id")
   private TaskStatus taskStatus;

}

public class TaskStatus {
   ...

   @OneToMany(mappedBy = "taskStatus", fetch = FetchType.EAGER)
   private List<Task> tasks = new ArrayList<>();
   
}
```

- close #51 
