### PR TITLE
[#49] feat: 프로젝트 사용자 초대 API 분리 및 테스트 추가

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -2,11 +2,16 @@ package kr.kro.colla.project.project.presentation;
 
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
+import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberDecision;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.user.notice.domain.NoticeType;
+import kr.kro.colla.user.notice.service.NoticeService;
+import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.domain.UserProject;
@@ -15,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/projects")
@@ -22,6 +29,7 @@ public class ProjectController {
 
     private final ProjectService projectService;
     private final UserService userService;
+    private final NoticeService noticeService;
     private final UserProjectService userProjectService;
 
     @GetMapping("/{projectId}")
@@ -32,13 +40,33 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/members")
-    public ResponseEntity joinMember(@Authenticated LoginUser loginUser,
-                                     @PathVariable long projectId, @RequestBody ProjectMemberRequest projectMemberRequest){
+    public ResponseEntity inviteMember(@Authenticated LoginUser loginUser,
+                                       @PathVariable long projectId, @Valid @RequestBody ProjectMemberRequest projectMemberRequest){
         Project project = projectService.findProjectById(projectId);
         User manager = userService.findUserById(loginUser.getId());
+        // manager 아닐 경우 예외처리
 
         User user = userService.findByGithubId(projectMemberRequest.getGithubId());
-        UserProject userProject = userProjectService.joinProject(user, project);
-        return ResponseEntity.ok(new ProjectMemberResponse(userProject));
+        CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
+                .noticeType(NoticeType.INVITE_USER)
+                .receiver(user)
+                .build();
+        noticeService.createNotice(createNoticeRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{projectId}/members/decision")
+    public ResponseEntity DecideInvitation(@Authenticated LoginUser loginUser,
+                                           @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
+        User user = userService.findUserById(loginUser.getId());
+        // user 알림 체크 및 읽음 처리
+        Project project = projectService.findProjectById(projectId);
+
+        if (projectMemberDecision.isAccept()){
+            UserProject userProject = userProjectService.joinProject(user, project);
+            return ResponseEntity.ok(new ProjectMemberResponse(userProject));
+        }
+        return ResponseEntity.noContent().build();
+
     }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -40,7 +40,7 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/members")
-    public ResponseEntity inviteMember(@Authenticated LoginUser loginUser,
+    public ResponseEntity inviteUser(@Authenticated LoginUser loginUser,
                                        @PathVariable long projectId, @Valid @RequestBody ProjectMemberRequest projectMemberRequest){
         Project project = projectService.findProjectById(projectId);
         User manager = userService.findUserById(loginUser.getId());
@@ -56,7 +56,7 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/members/decision")
-    public ResponseEntity DecideInvitation(@Authenticated LoginUser loginUser,
+    public ResponseEntity decideInvitation(@Authenticated LoginUser loginUser,
                                            @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
         User user = userService.findUserById(loginUser.getId());
         // user 알림 체크 및 읽음 처리

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -49,7 +49,7 @@ public class ProjectController {
         User user = userService.findByGithubId(projectMemberRequest.getGithubId());
         CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
                 .noticeType(NoticeType.INVITE_USER)
-                .receiver(user)
+                .receiverId(user.getId())
                 .build();
         noticeService.createNotice(createNoticeRequest);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -52,7 +52,7 @@ public class ProjectController {
                 .receiver(user)
                 .build();
         noticeService.createNotice(createNoticeRequest);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{projectId}/members/decision")

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
@@ -1,0 +1,13 @@
+package kr.kro.colla.project.project.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class ProjectMemberDecision {
+    @NotNull
+    private boolean accept;
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.project.project.presentation.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +8,7 @@ import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ProjectMemberDecision {
     @NotNull
     private boolean accept;

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberResponse.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public class ProjectMemberResponse {
 
+    private Long id;
+
     private String name;
 
     private String avatar;
@@ -15,6 +17,7 @@ public class ProjectMemberResponse {
 
     public ProjectMemberResponse(UserProject userProject){
         User user = userProject.getUser();
+        this.id = user.getId();
         this.name = user.getName();
         this.avatar = user.getAvatar();
         this.githubId = user.getGithubId();

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -68,6 +68,7 @@ public class ProjectService {
     }
 
     public Project findProjectById(Long projectId){
+        System.out.println(projectId);
         return projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
     }

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
@@ -16,10 +16,9 @@ import javax.validation.Valid;
 @Service
 public class NoticeService {
     private final NoticeRepository noticeRepository;
-    private final UserService userService;
 
     public Notice createNotice(@Valid CreateNoticeRequest createNoticeRequest) {
-        User user = userService.findUserById(createNoticeRequest.getTargetUserId());
+        User user = createNoticeRequest.getReceiver();
 
         Notice notice = Notice.builder()
                 .noticeType(createNoticeRequest.getNoticeType())

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
@@ -9,16 +9,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
+import javax.transaction.Transactional;
 import javax.validation.Valid;
 
-@Validated
 @RequiredArgsConstructor
 @Service
 public class NoticeService {
     private final NoticeRepository noticeRepository;
+    private final UserService userService;
 
-    public Notice createNotice(@Valid CreateNoticeRequest createNoticeRequest) {
-        User user = createNoticeRequest.getReceiver();
+    @Transactional
+    public Notice createNotice(CreateNoticeRequest createNoticeRequest) {
+        User user = userService.findUserById(createNoticeRequest.getReceiverId());
 
         Notice notice = Notice.builder()
                 .noticeType(createNoticeRequest.getNoticeType())

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
@@ -17,5 +17,5 @@ public class CreateNoticeRequest {
     private String mentionedURL;
 
     @NotNull
-    private User receiver;
+    private Long receiverId;
 }

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
@@ -1,7 +1,7 @@
 package kr.kro.colla.user.notice.service.dto;
 
 import kr.kro.colla.user.notice.domain.NoticeType;
-import lombok.AccessLevel;
+import kr.kro.colla.user.user.domain.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,5 +17,5 @@ public class CreateNoticeRequest {
     private String mentionedURL;
 
     @NotNull
-    private Long targetUserId;
+    private User receiver;
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -6,6 +6,7 @@ import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.fixture.Auth;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
@@ -101,4 +102,45 @@ public class AcceptanceTest {
         assertThat(response.getTasks().containsKey("Done")).isTrue();
     }
 
+    @Test
+    void 사용자_프로젝트_초대에_성공한다() {
+        // given
+        Long projectId = 132432L;
+        String githubId = "binimini";
+        ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest(githubId);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(projectMemberRequest)
+        // when
+        .when()
+                .post("/api/projects/"+projectId+"/members")
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 사용자_초대를_githubId_부족으로_실패한다() {
+        // given
+        Long projectId = 132432L;
+        ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest();
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(projectMemberRequest)
+        // when
+        .when()
+                .post("/api/projects/"+projectId+"/members")
+        // then
+        .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
+                .body("message", containsString("githubId"))
+                .body("message", containsString("비어 있을 수 없습니다"));
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -1,10 +1,15 @@
 package kr.kro.colla.project.project.presentation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
+import kr.kro.colla.user.notice.service.NoticeService;
+import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
 import kr.kro.colla.user.user.service.UserService;
@@ -29,6 +34,8 @@ import java.util.Map;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -40,20 +47,20 @@ class ProjectControllerTest {
     private MockMvc mockMvc;
 
     @MockBean
-    private AuthService authService;
-
-    @MockBean
     private CookieManager cookieManager;
 
     @MockBean
+    private AuthService authService;
+    @MockBean
     private ProjectService projectService;
-
     @MockBean
     private UserService userService;
-
     @MockBean
     private UserProjectService userProjectService;
+    @MockBean
+    private NoticeService noticeService;
 
+    private ObjectMapper objectMapper = new ObjectMapper();
     private String accessToken = "token";
     private LoginUser loginUser;
 
@@ -109,6 +116,63 @@ class ProjectControllerTest {
                 .andExpect(jsonPath("$.members").isArray())
                 .andExpect(jsonPath("$.tasks").isMap())
                 .andExpect(jsonPath("$.tasks.Done").isEmpty());
+    }
+
+    @Test
+    void 사용자_프로젝트_초대에_성공한다() throws Exception {
+        // given
+        Long projectId = 123142L;
+        String githubId = "binimini";
+        ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest(githubId);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/projects/"+projectId+"/members")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(projectMemberRequest)));
+        // then
+        perform
+                .andExpect(status().isNoContent());
+        verify(noticeService, times(1)).createNotice(any(CreateNoticeRequest.class));
+    }
+
+    @Test
+    void 사용자_초대를_githubId_부족으로_실패한다() throws Exception {
+        // given
+        Long projectId = 123142L;
+        ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest();
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/projects/"+projectId+"/members")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(projectMemberRequest)));
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value("400"))
+                .andExpect(jsonPath("$.message", "githubId").exists());
+        verify(noticeService, times(0)).createNotice(any(CreateNoticeRequest.class));
+    }
+
+    @Test
+    void 사용자_초대를_권한_부족으로_실패한다(){
+
+    }
+
+    @Test
+    void 사용자가_프로젝트_초대를_거절한다(){
+
+    }
+
+    @Test
+    void 사용자가_프로젝트_초대를_수락한다(){
+
+    }
+
+    @Test
+    void 초대_알람이_없을시_초대_결정에_실패한다(){
+
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberDecision;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.service.ProjectService;
@@ -13,6 +15,7 @@ import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
 import kr.kro.colla.user.user.service.UserService;
+import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
 import kr.kro.colla.utils.CookieManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -124,7 +128,14 @@ class ProjectControllerTest {
         Long projectId = 123142L;
         String githubId = "binimini";
         ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest(githubId);
+        User user = User.builder()
+                .name("subin")
+                .githubId(githubId)
+                .avatar("github")
+                .build();
 
+        given(userService.findByGithubId(githubId))
+                .willReturn(user);
         // when
         ResultActions perform = mockMvc.perform(post("/projects/"+projectId+"/members")
                 .cookie(new Cookie("accessToken", this.accessToken))
@@ -132,7 +143,7 @@ class ProjectControllerTest {
                 .content(objectMapper.writeValueAsString(projectMemberRequest)));
         // then
         perform
-                .andExpect(status().isNoContent());
+                .andExpect(status().isOk());
         verify(noticeService, times(1)).createNotice(any(CreateNoticeRequest.class));
     }
 
@@ -156,23 +167,61 @@ class ProjectControllerTest {
     }
 
     @Test
-    void 사용자_초대를_권한_부족으로_실패한다(){
+    void 사용자가_프로젝트_초대를_거절한다() throws Exception {
+        // given
+        Long projectId = 123142L;
+        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(false);
 
+        // when
+        ResultActions perform = mockMvc.perform(post("/projects/"+projectId+"/members/decision")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(projectMemberDecision)));
+        // then
+        perform
+                .andExpect(status().isNoContent());
+        verify(userProjectService, times(0)).joinProject(any(User.class), any(Project.class));
     }
 
     @Test
-    void 사용자가_프로젝트_초대를_거절한다(){
+    void 사용자가_프로젝트_초대를_수락한다() throws Exception {
+// given
+        Long projectId = 123142L, userId = loginUser.getId();
+        String userName = "subin", userAvatar = "github_contents", userGithubId = "binimini";
+        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(true);
+        User user = User.builder()
+                .name(userName)
+                .avatar(userAvatar)
+                .githubId(userGithubId)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        Project project = Project.builder()
+                .name("project_name")
+                .build();
+        UserProject userProject = UserProject.builder()
+                .user(user)
+                .project(project)
+                .build();
 
-    }
-
-    @Test
-    void 사용자가_프로젝트_초대를_수락한다(){
-
-    }
-
-    @Test
-    void 초대_알람이_없을시_초대_결정에_실패한다(){
-
+        given(userService.findUserById(any()))
+                .willReturn(user);
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
+        given(userProjectService.joinProject(any(User.class), any(Project.class)))
+                .willReturn(userProject);
+        // when
+        ResultActions perform = mockMvc.perform(post("/projects/"+projectId+"/members/decision")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(projectMemberDecision)));
+        // then
+        perform
+                .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.id").value(userId))
+                        .andExpect(jsonPath("$.name").value(userName))
+                        .andExpect(jsonPath("$.avatar").value(userAvatar))
+                        .andExpect(jsonPath("$.githubId").value(userGithubId));
+        verify(userProjectService, times(1)).joinProject(any(User.class), any(Project.class));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.verify;
 public class NoticeServiceTest {
     @Mock
     private NoticeRepository noticeRepository;
+    @Mock
+    private UserService userService;
 
     @InjectMocks
     private NoticeService noticeService;
@@ -57,12 +59,15 @@ public class NoticeServiceTest {
                 .avatar("github_content")
                 .build();
         ReflectionTestUtils.setField(notice, "id", id);
+        ReflectionTestUtils.setField(user, "id", userId);
         CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
                 .noticeType(NoticeType.INVITE_USER)
                 .mentionedURL(mentionURL)
-                .receiver(user)
+                .receiverId(userId)
                 .build();
 
+        given(userService.findUserById(userId))
+                .willReturn(user);
         given(noticeRepository.save(any(Notice.class)))
                 .willReturn(notice);
 
@@ -76,37 +81,6 @@ public class NoticeServiceTest {
         assertThat(result.getMentionedURL()).isEqualTo(mentionURL);
         assertThat(user.getNotices().size()).isEqualTo(1);
         verify(noticeRepository, times(1)).save(any(Notice.class));
-    }
-
-    @Test
-    void 알림_생성시_필드_검증에_실패한다(){
-        // given
-        String mentionURL = "mention";
-        User user = User.builder()
-                .name("binimini")
-                .githubId("binimini")
-                .avatar("github_content")
-                .build();
-        CreateNoticeRequest createNoticeRequest1 = CreateNoticeRequest.builder()
-                .mentionedURL(mentionURL)
-                .receiver(user)
-                .build();
-
-        CreateNoticeRequest createNoticeRequest2 = CreateNoticeRequest.builder()
-                .noticeType(NoticeType.INVITE_USER)
-                .mentionedURL(mentionURL)
-                .build();
-
-        // when
-        Set<ConstraintViolation<CreateNoticeRequest>> violations1 = validator.validate(createNoticeRequest1);
-        Set<ConstraintViolation<CreateNoticeRequest>> violations2 = validator.validate(createNoticeRequest2);
-
-        // then
-        assertThat(violations1.size()).isEqualTo(1);
-        assertThat(violations1.toArray()).extracting("propertyPath").toString().contains("noticeType");
-
-        assertThat(violations2.size()).isEqualTo(1);
-        assertThat(violations1.toArray()).extracting("propertyPath").toString().contains("receiver");
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -149,7 +149,7 @@ public class AcceptanceTest {
         // then
         .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("status", equalTo(400))
+                .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
                 .body("message", equalTo("name : 공백일 수 없습니다"));
     }
 


### PR DESCRIPTION
### 🔨 작업 내용 설명
API 두 개로 나누기로 논의했던 대로 나누고 (프로젝트 초대/프로젝트 초대 수락,거절)
기본적인 테스트까지 추가했습니다! (Acceptance Test는 아직 조금 미완성이에요!)

- 프로젝트의 매니저 아닌 사용자가 초대 요청할시
- 알림을 가지고 있지않은 사용자가 초대 수락/거절할시
- 프로젝트 초대 수락/거절 인수테스트

부분은 아직 구현하지 않아서 주석으로 표시해놨습니다
곧 구현하는대로 주석 삭제하겠습니다~
### 📑 구현한 내용 목록

- [x] 프로젝트 멤버 초대 API 분리
- [x] Notice Service에서의 검증 로직 삭제
- [x] Controller단 테스트 추가
- [x] Acceptance Test 추가 (일부)

### 🚧 논의 사항

- Notice가 User에 Lazy fetch로 되어있어서 알림을 추가할 User를 Notice Service 외부에서 가져오게되면
  해당 객체의 세션이 남아있지 않아 후에 Notice Service에서 알림을 추가할 때 문제가 발생했습니다.
  따라서 Controller 단에서 githubId로 User 검증을 한 뒤 User 객체는 Notice Service 내에서 가져와 
  `@Transactional`로 처리할 수 있도록 했습니다!
