### PR TITLE
[#60] feat: 사용자 알림 조회 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeNotFoundException.java
@@ -1,0 +1,7 @@
+package kr.kro.colla.exception.exception.notice;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class NoticeNotFoundException extends NotFoundException {
+    public NoticeNotFoundException() { super("해당하는 알림를 찾을 수 없습니다."); }
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -52,8 +52,6 @@ public class ProjectService {
                 .map(UserProject::getUser)
                 .forEach(user -> members.put(user.getId(), user));
 
-        System.out.println(members.get(1L));
-
         project.getTaskStatuses()
                 .stream()
                 .forEach(taskStatus -> {
@@ -82,7 +80,6 @@ public class ProjectService {
     }
 
     public Project findProjectById(Long projectId){
-        System.out.println(projectId);
         return projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
     }

--- a/backend/src/main/java/kr/kro/colla/user/notice/domain/Notice.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/domain/Notice.java
@@ -34,4 +34,6 @@ public class Notice {
         this.noticeType = noticeType;
         this.mentionedURL = mentionedURL;
     }
+
+    public void check() { this.isChecked = true; }
 }

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
@@ -1,24 +1,24 @@
 package kr.kro.colla.user.notice.service;
 
+import kr.kro.colla.exception.exception.notice.NoticeNotFoundException;
 import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.notice.domain.repository.NoticeRepository;
 import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.stereotype.Service;
-import org.springframework.validation.annotation.Validated;
 
 import javax.transaction.Transactional;
-import javax.validation.Valid;
 
 @RequiredArgsConstructor
+@Transactional
 @Service
 public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final UserService userService;
 
-    @Transactional
     public Notice createNotice(CreateNoticeRequest createNoticeRequest) {
         User user = userService.findUserById(createNoticeRequest.getReceiverId());
 
@@ -31,5 +31,16 @@ public class NoticeService {
         user.addNotice(result);
 
         return result;
+    }
+
+    public Notice checkNotice(Long id) {
+        Notice notice = findById(id);
+        notice.check();
+        return notice;
+    }
+
+    public Notice findById(Long id) {
+        return noticeRepository.findById(id)
+                .orElseThrow(NoticeNotFoundException::new);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/domain/User.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/domain/User.java
@@ -53,5 +53,5 @@ public class User {
 
     public void changeDisplayName(String name) { this.name = name; }
 
-    public void addNotice(Notice notice){ this.notices.add(notice); }
+    public void addNotice(Notice notice) { this.notices.add(notice); }
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
@@ -4,6 +4,7 @@ import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.*;
 import kr.kro.colla.user.user.service.UserService;
@@ -55,9 +56,13 @@ public class UserController {
 
     @GetMapping("/projects")
     public ResponseEntity<List<UserProjectResponse>> getUserProject(@Authenticated LoginUser loginUser) {
-        List<UserProjectResponse> userProjectResponseDtoList = userService.getUserProject(loginUser.getId());
+        List<UserProjectResponse> userProjectResponseDtoList = userService.getUserProjects(loginUser.getId());
 
         return ResponseEntity.ok(userProjectResponseDtoList);
     }
 
+    @GetMapping("/notices")
+    public ResponseEntity<List<Notice>> getUserNotices(@Authenticated LoginUser loginUser) {
+        return ResponseEntity.ok(userService.getUserNotices(loginUser.getId()));
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
@@ -4,8 +4,8 @@ import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
-import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
 import kr.kro.colla.user.user.presentation.dto.*;
 import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.service.UserProjectService;
@@ -62,7 +62,8 @@ public class UserController {
     }
 
     @GetMapping("/notices")
-    public ResponseEntity<List<Notice>> getUserNotices(@Authenticated LoginUser loginUser) {
-        return ResponseEntity.ok(userService.getUserNotices(loginUser.getId()));
+    public ResponseEntity<List<UserNoticeResponse>> getUserNotices(@Authenticated LoginUser loginUser) {
+        List<UserNoticeResponse> userNoticeResponses = userService.getUserNotices(loginUser.getId());
+        return ResponseEntity.ok(userNoticeResponses);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserNoticeResponse.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserNoticeResponse.java
@@ -1,0 +1,25 @@
+package kr.kro.colla.user.user.presentation.dto;
+
+import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.user.notice.domain.NoticeType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserNoticeResponse {
+    private Long id;
+
+    private NoticeType noticeType;
+
+    private String mentionedURL;
+
+    private Boolean isChecked;
+
+    public UserNoticeResponse(Notice notice){
+        this.id = notice.getId();
+        this.noticeType = notice.getNoticeType();
+        this.mentionedURL = notice.getMentionedURL();
+        this.isChecked = notice.getIsChecked();
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -5,6 +5,7 @@ import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
+import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,8 +42,8 @@ public class UserService {
                 );
     }
 
-    public List<Notice> getUserNotices(Long id){
-        return findUserById(id).getNotices();
+    public List<UserNoticeResponse> getUserNotices(Long id){
+        return findUserById(id).getNotices().stream().map(notice-> new UserNoticeResponse(notice)).collect(Collectors.toList());
 
     }
     public List<UserProjectResponse> getUserProjects(Long id) {

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -44,8 +44,8 @@ public class UserService {
 
     public List<UserNoticeResponse> getUserNotices(Long id){
         return findUserById(id).getNotices().stream().map(notice-> new UserNoticeResponse(notice)).collect(Collectors.toList());
-
     }
+
     public List<UserProjectResponse> getUserProjects(Long id) {
         return findUserById(id).getProjects()
                 .stream()

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -2,6 +2,7 @@ package kr.kro.colla.user.user.service;
 
 import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
 import kr.kro.colla.exception.exception.user.UserNotFoundException;
+import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
@@ -40,7 +41,11 @@ public class UserService {
                 );
     }
 
-    public List<UserProjectResponse> getUserProject(Long id) {
+    public List<Notice> getUserNotices(Long id){
+        return findUserById(id).getNotices();
+
+    }
+    public List<UserProjectResponse> getUserProjects(Long id) {
         return findUserById(id).getProjects()
                 .stream()
                 .map(userProject -> new UserProjectResponse(userProject.getProject()))

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -1,6 +1,5 @@
 package kr.kro.colla.project.project.presentation;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.service.AuthService;
@@ -185,7 +184,7 @@ class ProjectControllerTest {
 
     @Test
     void 사용자가_프로젝트_초대를_수락한다() throws Exception {
-// given
+        // given
         Long projectId = 123142L, userId = loginUser.getId();
         String userName = "subin", userAvatar = "github_contents", userGithubId = "binimini";
         ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(true);
@@ -217,10 +216,10 @@ class ProjectControllerTest {
         // then
         perform
                 .andExpect(status().isOk())
-                        .andExpect(jsonPath("$.id").value(userId))
-                        .andExpect(jsonPath("$.name").value(userName))
-                        .andExpect(jsonPath("$.avatar").value(userAvatar))
-                        .andExpect(jsonPath("$.githubId").value(userGithubId));
+                .andExpect(jsonPath("$.id").value(userId))
+                .andExpect(jsonPath("$.name").value(userName))
+                .andExpect(jsonPath("$.avatar").value(userAvatar))
+                .andExpect(jsonPath("$.githubId").value(userGithubId));
         verify(userProjectService, times(1)).joinProject(any(User.class), any(Project.class));
     }
 

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -36,8 +36,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
@@ -235,7 +233,7 @@ public class AcceptanceTest {
 
     @Transactional
     @Test
-    void 사용자는_사용자의_알림들을_조회할_수_있다(){
+    void 사용자는_사용자의_알림들을_조회할_수_있다() {
         // given
         List<Notice> data = new ArrayList<>();
         Notice notice1 = Notice.builder()

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -9,14 +9,17 @@ import kr.kro.colla.common.fixture.Auth;
 import kr.kro.colla.common.fixture.FileProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.user.notice.domain.NoticeType;
+import kr.kro.colla.user.notice.domain.repository.NoticeRepository;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
 
 import kr.kro.colla.user.user.presentation.dto.UpdateUserNameRequest;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
-import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.domain.repository.UserProjectRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,10 +30,15 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 
+import javax.transaction.Transactional;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,16 +56,13 @@ public class AcceptanceTest {
     private JwtProvider jwtProvider;
 
     @Autowired
-    private UserService userService;
-
-    @Autowired
     private UserRepository userRepository;
-
     @Autowired
     private ProjectRepository projectRepository;
-
     @Autowired
     private UserProjectRepository userProjectRepository;
+    @Autowired
+    private NoticeRepository noticeRepository;
 
     private Auth auth;
     private User user;
@@ -78,6 +83,13 @@ public class AcceptanceTest {
         accessToken = auth.로그인(user.getId());
     }
 
+    @AfterEach
+    void rollback() {
+        userProjectRepository.deleteAll();
+        projectRepository.deleteAll();
+        noticeRepository.deleteAll();
+        userRepository.deleteAll();
+    }
     @Test
     void 로그인한_사용자의_프로필을_조회한다() {
         // given
@@ -219,5 +231,53 @@ public class AcceptanceTest {
         assertThat(response.get(1).getDescription()).isEqualTo(project2.getDescription());
         assertThat(response.get(0).getManagerId()).isEqualTo(user.getId());
         assertThat(response.get(1).getManagerId()).isEqualTo(user.getId());
+    }
+
+    @Transactional
+    @Test
+    void 사용자는_사용자의_알림들을_조회할_수_있다(){
+        // given
+        List<Notice> data = new ArrayList<>();
+        Notice notice1 = Notice.builder()
+                .noticeType(NoticeType.INVITE_USER)
+                .build();
+        Notice notice2 = Notice.builder()
+                .noticeType(NoticeType.MENTION_USER)
+                .mentionedURL("test/url/for/mention")
+                .build();
+        data.add(notice1);
+        data.add(notice2);
+
+        noticeRepository.save(notice1);
+        noticeRepository.save(notice2);
+
+        User receiver = userRepository.findById(user.getId()).get();
+        receiver.addNotice(notice1);
+        receiver.addNotice(notice2);
+
+        List<Notice> response = given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+        // when
+        .when()
+                .get("/api/users/notices")
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<Notice>>() {});
+        assertThat(response.size()).isEqualTo(2);
+
+        IntStream
+                .range(0, response.size())
+                .forEach(i->{
+                            assertThat(response.get(i).getId()).isEqualTo(data.get(i).getId());
+                            assertThat(response.get(i).getNoticeType()).isEqualTo(data.get(i).getNoticeType());
+                            assertThat(response.get(i).getIsChecked()).isEqualTo(data.get(i).getIsChecked());
+                            assertThat(response.get(i).getMentionedURL()).isEqualTo(data.get(i).getMentionedURL());
+                    });
+
     }
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -7,9 +7,12 @@ import kr.kro.colla.auth.service.AuthService;
 import kr.kro.colla.common.fixture.FileProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import kr.kro.colla.user.user.presentation.dto.UpdateUserNameRequest;
+import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
 import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.service.UserProjectService;
@@ -30,6 +33,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import javax.servlet.http.Cookie;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -229,4 +233,42 @@ class UserControllerTest {
         assertThat(userProjectResponseList.size()).isEqualTo(2);
     }
 
+    @Test
+    void 사용자의_알림을_조회한다() throws Exception {
+        // given
+        String mention = "mentioned_url";
+        Long noticeId1 = 62453L, noticeId2 = 7532L, noticeId3 = 54543L;
+        Notice notice1 = Notice.builder()
+                .noticeType(NoticeType.INVITE_USER)
+                .build();
+        ReflectionTestUtils.setField(notice1,"id", noticeId1);
+        Notice notice2 = Notice.builder()
+                .noticeType(NoticeType.MENTION_USER)
+                .mentionedURL(mention)
+                .build();
+        ReflectionTestUtils.setField(notice2,"id", noticeId2);
+        Notice notice3 = Notice.builder()
+                .noticeType(NoticeType.INVITE_USER)
+                .build();
+        ReflectionTestUtils.setField(notice3,"id", noticeId3);
+
+        given(userService.getUserNotices(loginUser.getId()))
+                .willReturn(List.of(notice1, notice2, notice3).stream().map(notice-> new UserNoticeResponse(notice)).collect(Collectors.toList()));
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/users/notices")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        MvcResult result = perform.andReturn();
+        System.out.println(result.getResponse().getContentAsString());
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[*].id").value(containsInAnyOrder(noticeId1.intValue(), noticeId2.intValue(), noticeId3.intValue())))
+                .andExpect(jsonPath("$[*].noticeType").value(containsInAnyOrder(notice1.getNoticeType().name(), notice2.getNoticeType().name(), notice3.getNoticeType().name())))
+                .andExpect(jsonPath("$[*].mentionedURL").value(containsInAnyOrder(notice1.getMentionedURL(), notice2.getMentionedURL(), notice3.getMentionedURL())))
+                .andExpect(jsonPath("$[*].isChecked").value(containsInAnyOrder(false, false, false)))
+                .andExpect(jsonPath("$.length()").value(3));
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -208,7 +208,7 @@ class UserControllerTest {
                 new UserProjectResponse(project2)
         );
 
-        given(userService.getUserProject(loginUser.getId()))
+        given(userService.getUserProjects(loginUser.getId()))
                 .willReturn(userProjectResponseDtoList);
 
         // when


### PR DESCRIPTION
### 🔨 작업 내용 설명
사용자 한 명의 알림을 모두 GET하는 API와,
알림의 확인 상태 변경 함수를 작성했습니다.

아직 실제 알림을 통해서 요청이 들어왔을 때 (ex) `알림의 프로젝트 초대를 수락/거절`)
알림의 확인 상태가 변경되도록 연동은 아직 되어있지 않습니다! 
(Notice 프로퍼티 변경하고 검증 로직한 뒤 연동할 예정)
### 📑 구현한 내용 목록

- [x] 알림 조회 API 구현
- [x] 알림 읽은 상태 변경 함수 구현
- [x] 알림 관련 테스트 추가 

### 🚧 논의 사항

- 기존 테스트 케이스가 동작하지 않았던 이유가 뭘까요 🤣
- `UserService.getUserNotices()`의 반환형이 `List<Notice>`일 경우 `LazyIntializationException`이 발생하고, 
 `UserNoticeResponse`와 같은 DTO로 변환해 반환할 경우 정상 처리됩니다. 
 Notice 정보만 반환하는 경우에도 User와의 연관관계를 참고하게 되는 걸까요? 🤔🤔
- close #60 
