### PR TITLE
[#57] feat: 테스크 생성 모달 담당자, 우선순위 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -64,7 +64,7 @@ public class ProjectController {
 
         if (projectMemberDecision.isAccept()){
             UserProject userProject = userProjectService.joinProject(user, project);
-            return ResponseEntity.ok(new ProjectMemberResponse(userProject));
+            return ResponseEntity.ok(new ProjectMemberResponse(userProject.getUser()));
         }
         return ResponseEntity.noContent().build();
 
@@ -82,6 +82,13 @@ public class ProjectController {
         List<ProjectStoryResponse> projectStories = projectService.getProjectStories(projectId);
 
         return ResponseEntity.ok(projectStories);
+    }
+
+    @GetMapping("/{projectId}/members")
+    public ResponseEntity<List<ProjectMemberResponse>> getProjectMembers(@PathVariable Long projectId) {
+        List<ProjectMemberResponse> projectMembers = projectService.getProjectMembers(projectId);
+
+        return ResponseEntity.ok(projectMembers);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberResponse.java
@@ -1,9 +1,10 @@
 package kr.kro.colla.project.project.presentation.dto;
 
 import kr.kro.colla.user.user.domain.User;
-import kr.kro.colla.user_project.domain.UserProject;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 @Getter
 public class ProjectMemberResponse {
 
@@ -15,8 +16,7 @@ public class ProjectMemberResponse {
 
     private String githubId;
 
-    public ProjectMemberResponse(UserProject userProject){
-        User user = userProject.getUser();
+    public ProjectMemberResponse(User user){
         this.id = user.getId();
         this.name = user.getName();
         this.avatar = user.getAvatar();

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import kr.kro.colla.exception.exception.project.ProjectNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
@@ -18,7 +19,6 @@ import javax.transaction.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -84,6 +84,13 @@ public class ProjectService {
         return findProjectById(projectId).getStories()
                 .stream()
                 .map(ProjectStoryResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public List<ProjectMemberResponse> getProjectMembers(Long projectId) {
+        return findProjectById(projectId).getMembers()
+                .stream()
+                .map(userProject -> new ProjectMemberResponse(userProject.getUser()))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -7,11 +7,7 @@ import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.fixture.Auth;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
-import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
-import kr.kro.colla.project.project.presentation.dto.ProjectMemberDecision;
-import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
-import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
-import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.domain.repository.StoryRepository;
 import kr.kro.colla.user.user.domain.User;
@@ -256,10 +252,36 @@ public class AcceptanceTest {
                 .body(projectMemberDecision)
         // when
         .when()
-                .post("/api/projects/"+project.getId()+"/members/decision")
+                .post("/api/projects/" + project.getId() + "/members/decision")
 
         // then
         .then()
                 .statusCode(HttpStatus.NO_CONTENT.value());
     }
+
+    @Test
+    void 사용자가_프로젝트_멤버를_조회한다() {
+        // given
+        List<ProjectMemberResponse> response = given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", this.accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + project.getId() + "/members")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<ProjectMemberResponse>>() {});
+
+        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.get(0).getId()).isEqualTo(user.getId());
+        assertThat(response.get(0).getName()).isEqualTo(user.getName());
+        assertThat(response.get(0).getAvatar()).isEqualTo(user.getAvatar());
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/domain/repository/ProjectRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/domain/repository/ProjectRepositoryTest.java
@@ -1,15 +1,18 @@
 package kr.kro.colla.project.project.domain.repository;
 
+import kr.kro.colla.exception.exception.project.ProjectNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import kr.kro.colla.user_project.domain.UserProject;
+import kr.kro.colla.user_project.domain.repository.UserProjectRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.validation.ConstraintViolationException;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -18,7 +21,16 @@ import static org.assertj.core.api.Assertions.*;
 class ProjectRepositoryTest {
 
     @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private ProjectRepository projectRepository;
+
+    @Autowired
+    private UserProjectRepository userProjectRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
 
     private Long managerId = 1L;
     private String name = "생성된 프로젝트", desc = "설명";
@@ -52,4 +64,44 @@ class ProjectRepositoryTest {
         assertThatThrownBy(()-> projectRepository.save(project))
                 .isInstanceOf(ConstraintViolationException.class);
     }
+
+    @Test
+    void 프로젝트_멤버를_조회한다() {
+        // given
+        User user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("github_content")
+                .build();
+        Project project = Project.builder()
+                .managerId(managerId)
+                .name(name)
+                .description(desc)
+                .build();
+        userRepository.save(user);
+        projectRepository.save(project);
+
+        UserProject userProject = UserProject.builder()
+                .project(project)
+                .user(user)
+                .build();
+        userProjectRepository.save(userProject);
+
+        flushAndClear();
+
+        // when
+        Project result = projectRepository.findById(project.getId())
+                .orElseThrow(ProjectNotFoundException::new);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getMembers().size()).isEqualTo(1);
+
+    }
+
+    private void flushAndClear() {
+        testEntityManager.flush();
+        testEntityManager.clear();
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -326,7 +326,7 @@ class ProjectControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/members")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -119,7 +119,7 @@ class ProjectControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId)
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -148,7 +148,7 @@ class ProjectControllerTest {
                 .willReturn(user);
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(projectMemberRequest)));
         // then
@@ -165,7 +165,7 @@ class ProjectControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(projectMemberRequest)));
         // then
@@ -184,7 +184,7 @@ class ProjectControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(projectMemberDecision)));
         // then
@@ -221,7 +221,7 @@ class ProjectControllerTest {
                 .willReturn(userProject);
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(projectMemberDecision)));
         // then
@@ -295,7 +295,7 @@ class ProjectControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/stories")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -308,6 +308,38 @@ class ProjectControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value(story.getTitle()));
         assertThat(projectStoryResponseList.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 프로젝트_멤버를_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        User user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("github_content")
+                .build();
+        List<ProjectMemberResponse> projectMemberResponses = List.of(new ProjectMemberResponse(user));
+
+        given(projectService.getProjectMembers(projectId))
+                .willReturn(projectMemberResponses);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/members")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        MvcResult result = perform.andReturn();
+        CollectionType collectionType = objectMapper.getTypeFactory()
+                .constructCollectionType(List.class, ProjectMemberResponse.class);
+        List<ProjectMemberResponse> projectMemberResponseList = objectMapper.readValue(result.getResponse().getContentAsString(), collectionType);
+
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].name").value(user.getName()))
+                .andExpect(jsonPath("$[0].avatar").value(user.getAvatar()));
+        assertThat(projectMemberResponseList).hasSize(1);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
@@ -4,6 +4,7 @@ import kr.kro.colla.common.fixture.FileProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
@@ -147,6 +148,41 @@ class ProjectServiceTest {
         assertThat(result.size()).isEqualTo(1);
         assertThat(response.getTitle()).isEqualTo(story.getTitle());
         verify(projectRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void 프로젝트의_멤버를_조회한다() {
+        // given
+        Project project = Project.builder()
+                .managerId(managerId)
+                .name(name)
+                .description(desc)
+                .build();
+        User user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("github_content")
+                .build();
+        UserProject userProject = UserProject.builder()
+                .project(project)
+                .user(user)
+                .build();
+        ReflectionTestUtils.setField(project, "members", List.of(userProject));
+        ReflectionTestUtils.setField(userProject, "user", user);
+
+        given(projectRepository.findById(id))
+                .willReturn(Optional.of(project));
+
+        // when
+        List<ProjectMemberResponse> result = projectService.getProjectMembers(id);
+
+        // then
+        ProjectMemberResponse response = result.get(0);
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(response.getName()).isEqualTo(user.getName());
+        assertThat(response.getAvatar()).isEqualTo(user.getAvatar());
+        verify(projectRepository, times(1)).findById(1L);
+
     }
 
 }

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -43,3 +43,9 @@ export const getProjectStories = async (projectId: number) => {
 
     return response;
 };
+
+export const getProjectMembers = async (projectId: number) => {
+    const response = await client.get(`/projects/${projectId}/members`);
+
+    return response;
+};

--- a/frontend/src/components/DropDown/Member/index.tsx
+++ b/frontend/src/components/DropDown/Member/index.tsx
@@ -1,0 +1,50 @@
+import React, { FC, useEffect, useState } from 'react';
+
+import { useRecoilValue } from 'recoil';
+import { getProjectMembers } from '../../../apis/project';
+import { projectState } from '../../../stores/projectState';
+import { Avatar, Name } from '../../Task/style';
+import { Member, MemberList } from './style';
+
+interface PropType {
+    setManager: Function;
+    setMemberVisible: Function;
+}
+
+interface MemberType {
+    id: number;
+    name: string;
+    avatar: string;
+}
+
+export const MemberDropDown: FC<PropType> = ({ setManager, setMemberVisible }) => {
+    const project = useRecoilValue(projectState);
+    const [memberList, setMemberList] = useState<MemberType[]>([]);
+
+    const selectManager = (name: string) => {
+        setManager(name);
+        setMemberVisible();
+    };
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const res = await getProjectMembers(project.id);
+                setMemberList(res.data);
+            } catch (err) {
+                setMemberList([]);
+            }
+        })();
+    }, []);
+
+    return (
+        <MemberList>
+            {memberList.map((member, idx) => (
+                <Member key={idx} onClick={() => selectManager(member.name)}>
+                    <Avatar src={member.avatar}></Avatar>
+                    <Name>{member.name}</Name>
+                </Member>
+            ))}
+        </MemberList>
+    );
+};

--- a/frontend/src/components/DropDown/Member/style.ts
+++ b/frontend/src/components/DropDown/Member/style.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+import { List, Work } from '../../../styles/dropdown';
+
+export const MemberList = styled.div`
+    width: 200px;
+    top: 190px;
+    left: 630px;
+
+    ${List}
+`;
+
+export const Member = styled.div`
+    width: 162px;
+    ${Work}
+`;

--- a/frontend/src/components/DropDown/PreTask/style.ts
+++ b/frontend/src/components/DropDown/PreTask/style.ts
@@ -25,7 +25,7 @@ export const List = css`
 `;
 
 export const TaskList = styled.div`
-    top: 430px;
+    top: 450px;
     left: 120px;
 
     ${List}

--- a/frontend/src/components/DropDown/PreTask/style.ts
+++ b/frontend/src/components/DropDown/PreTask/style.ts
@@ -1,60 +1,17 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { GRAY } from '../../../styles/color';
-
-export const List = css`
-    position: absolute;
-    display: flex;
-    flex-direction: column;
-    width: 375px;
-    max-height: 300px;
-    border: 1px solid ${GRAY};
-    border-radius: 10px;
-    padding-left: 10px;
-    background-color: #fff;
-    overflow-y: scroll;
-
-    &::-webkit-scrollbar {
-        width: 8px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background: #bbbbbb;
-        border-radius: 10px;
-    }
-`;
+import { List, Title, Work } from '../../../styles/dropdown';
 
 export const TaskList = styled.div`
+    width: 375px;
     top: 450px;
     left: 120px;
 
     ${List}
 `;
 
-export const Work = css`
-    display: flex;
-    width: 337px;
-    justify-content: space-between;
-    padding: 10px;
-    margin-right: 10px;
-    border-bottom: 1px solid #000;
-
-    :last-child {
-        border: none;
-    }
-
-    :hover {
-        background-color: #f1f1f1;
-        cursor: pointer;
-    }
-`;
-
 export const Task = styled.div`
+    width: 337px;
     ${Work}
-`;
-
-export const Title = css`
-    max-width: 260px;
 `;
 
 export const TaskTitle = styled.div`

--- a/frontend/src/components/DropDown/Story/style.ts
+++ b/frontend/src/components/DropDown/Story/style.ts
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
-import { List, Title, Work } from '../PreTask/style';
+import { List, Title, Work } from '../../../styles/dropdown';
 
 export const StoryList = styled.div`
+    width: 375px;
     top: 390px;
     left: 120px;
 
@@ -9,6 +10,7 @@ export const StoryList = styled.div`
 `;
 
 export const Story = styled.div`
+    width: 337px;
     ${Work}
 `;
 

--- a/frontend/src/components/Modal/Story/index.tsx
+++ b/frontend/src/components/Modal/Story/index.tsx
@@ -36,7 +36,7 @@ export const StoryModal: FC<PropType> = ({ showStoryModal, selectStory }) => {
                 <StoryArea value={story} onChange={handleModifyStory} />
             </Story>
             <ButtonContainer>
-                <CancelButton onClick={() => showStoryModal}>취소</CancelButton>
+                <CancelButton onClick={() => showStoryModal()}>취소</CancelButton>
                 <CompleteButton onClick={handleCompleteButton}>완료</CompleteButton>
             </ButtonContainer>
         </Container>

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -4,6 +4,7 @@ import DeleteIconSrc from '../../../../public/assets/images/delete.png';
 import DownIconSrc from '../../../../public/assets/images/down.png';
 import StarImgSrc from '../../../../public/assets/images/star.png';
 import { TaskType } from '../../../types/kanban';
+import { MemberDropDown } from '../../DropDown/Member';
 import { PreTaskDropDown } from '../../DropDown/PreTask';
 import { Task, TaskTitle } from '../../DropDown/PreTask/style';
 import { StoryDropDown } from '../../DropDown/Story';
@@ -45,6 +46,8 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
     const [storyVisible, setStoryVisible] = useState(false);
     const [preTaskVisible, setPreTaskVisible] = useState(false);
     const [preTaskList, setPreTaskList] = useState([]);
+    const [manager, setManager] = useState('');
+    const [memberVisible, setMemberVisible] = useState(false);
 
     const showStoryModal = () => {
         setStoryModalVisible((prev) => !prev);
@@ -60,6 +63,10 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
 
     const deletePreTask = (idx: number) => {
         setPreTaskList((prev) => prev.filter((el) => el !== idx));
+    };
+
+    const showMemberList = () => {
+        setMemberVisible((prev) => !prev);
     };
 
     return (
@@ -110,7 +117,8 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
                 <DetailContainer>
                     <DetailComponent>
                         담당자
-                        <MemberList>
+                        <MemberList onClick={showMemberList}>
+                            {manager}
                             <DownIcon src={DownIconSrc} />
                         </MemberList>
                     </DetailComponent>
@@ -145,6 +153,7 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
                 />
             ) : null}
             {storyVisible ? <StoryDropDown setStory={setStory} setStoryVisible={setStoryVisible} /> : null}
+            {memberVisible ? <MemberDropDown setManager={setManager} setMemberVisible={setMemberVisible} /> : null}
         </ModalContainer>
     );
 };

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -32,6 +32,7 @@ import {
     PreTaskList,
     DeleteButton,
     PreTask,
+    Weight,
 } from './style';
 
 interface PropType {
@@ -48,6 +49,7 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
     const [preTaskList, setPreTaskList] = useState([]);
     const [manager, setManager] = useState('');
     const [memberVisible, setMemberVisible] = useState(false);
+    const [priority, setPriority] = useState(-1);
 
     const showStoryModal = () => {
         setStoryModalVisible((prev) => !prev);
@@ -67,6 +69,10 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
 
     const showMemberList = () => {
         setMemberVisible((prev) => !prev);
+    };
+
+    const changePriority = (idx: number) => {
+        setPriority(idx);
     };
 
     return (
@@ -133,7 +139,13 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
                                 .fill(0)
                                 .map((el, i) => i + 1)
                                 .map((el, idx) => (
-                                    <span key={idx}>{el}</span>
+                                    <Weight
+                                        key={idx}
+                                        className={priority === idx ? 'selected' : ''}
+                                        onClick={() => changePriority(idx)}
+                                    >
+                                        {el}
+                                    </Weight>
                                 ))}
                         </Priority>
                     </DetailComponent>

--- a/frontend/src/components/Modal/Task/style.ts
+++ b/frontend/src/components/Modal/Task/style.ts
@@ -127,12 +127,13 @@ export const MemberList = styled.div`
     display: flex;
     align-items: center;
     width: 200px;
-    height: 30px;
+    min-height: 25px;
     border: 1px solid #000;
     border-radius: 10px;
     margin-top: 10px;
-    padding-left: 10px;
+    padding: 5px 0 5px 10px;
     background-color: transparent;
+    cursor: pointer;
 `;
 
 export const Status = styled.div`

--- a/frontend/src/components/Modal/Task/style.ts
+++ b/frontend/src/components/Modal/Task/style.ts
@@ -125,6 +125,7 @@ export const DetailComponent = styled.div`
 
 export const MemberList = styled.div`
     display: flex;
+    align-items: center;
     width: 200px;
     height: 30px;
     border: 1px solid #000;

--- a/frontend/src/components/Modal/Task/style.ts
+++ b/frontend/src/components/Modal/Task/style.ts
@@ -145,10 +145,20 @@ export const Priority = styled.div`
     justify-content: space-between;
     width: 200px;
     margin-top: 10px;
+`;
 
-    span {
-        cursor: pointer;
-        ${LiftUp}
+export const Weight = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 24px;
+    height: 24px;
+    cursor: pointer;
+    ${LiftUp}
+
+    &.selected {
+        border: 1px solid #000;
+        border-radius: 50px;
     }
 `;
 

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import { useSetRecoilState } from 'recoil';
 import PlusIcon from '../../../public/assets/images/plus-circle.svg';
 import { getProject } from '../../apis/project';
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
 import { SideBar } from '../../components/SideBar';
+import { projectState } from '../../stores/projectState';
 import { TaskType } from '../../types/kanban';
 import { Wrapper, KanbanAddButton, KanbanAdditional, Container } from './style';
 
@@ -17,6 +19,7 @@ const Kanban = () => {
     const history = useHistory();
     const { state } = useLocation<stateType>();
     const [taskList, setTaskList] = useState<Array<TaskType>>([]);
+    const setProjectState = useSetRecoilState(projectState);
 
     const statuses = ['To Do', 'In Progress', 'Done'];
     const menu = ['로드맵', '백로그', '대시보드', '지도'];
@@ -51,7 +54,13 @@ const Kanban = () => {
     useEffect(() => {
         (async () => {
             const res = await getProject(state.projectId);
-            const { tasks } = res.data;
+            const { id, name, description, thumbnail, tasks } = res.data;
+            setProjectState({
+                id,
+                name,
+                description,
+                thumbnail,
+            });
             setTaskList([
                 ...tasks['To Do'].map((task) => ({ ...task, column: 'To Do' })),
                 ...tasks['In Progress'].map((task) => ({ ...task, column: 'In Progress' })),

--- a/frontend/src/styles/dropdown.ts
+++ b/frontend/src/styles/dropdown.ts
@@ -1,0 +1,44 @@
+import { css } from '@emotion/react';
+import { GRAY } from './color';
+
+export const List = css`
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    max-height: 300px;
+    border: 1px solid ${GRAY};
+    border-radius: 10px;
+    padding-left: 10px;
+    background-color: #fff;
+    overflow-y: scroll;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #bbbbbb;
+        border-radius: 10px;
+    }
+`;
+
+export const Work = css`
+    display: flex;
+    justify-content: space-between;
+    padding: 10px;
+    margin-right: 10px;
+    border-bottom: 1px solid #000;
+
+    :last-child {
+        border: none;
+    }
+
+    :hover {
+        background-color: #f1f1f1;
+        cursor: pointer;
+    }
+`;
+
+export const Title = css`
+    max-width: 260px;
+`;


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 프로젝트 멤버 조회 API 구현 및 테스트 코드 작성
- 테스크 생성 모달 담당자 드롭다운 구현
- 테스크 생성 모달 우선순위 선택 구현

### 📑 구현한 내용 목록
- [x] 프로젝트 멤버 조회 API
- [x] 담당자 드롭다운 구현
- [x] 우선순위 선택 구현

### 🚧 논의 사항
- 드롭다운에 사용되는 공통 `css`들을 `styles` 디렉토리의 `dropdown.ts`로 분리하였습니다!
- 칸반 페이지 새로 고침 시마다 전역 프로젝트 상태값 날라가는 문제를 기존 `useEffect`의 프로젝트 데이터를 가져오는 부분에서 다시 전역 상태값을 설정해주도록 하여 해결하였습니다!

- close #57 
