### PR TITLE
[#70] feat: 태스크 생성 API 구현 및 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/exception/project/task_status/TaskStatusNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/project/task_status/TaskStatusNotFoundException.java
@@ -1,0 +1,11 @@
+package kr.kro.colla.exception.exception.project.task_status;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class TaskStatusNotFoundException extends NotFoundException {
+
+    public TaskStatusNotFoundException() {
+        super("해당하는 태스크 상태가 존재하지 않습니다.");
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/story/StoryNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/story/StoryNotFoundException.java
@@ -1,0 +1,9 @@
+package kr.kro.colla.exception.exception.story;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class StoryNotFoundException extends NotFoundException {
+
+    public StoryNotFoundException() { super("해당하는 스토리를 찾을 수 없습니다."); }
+
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/task/tag/InvalidTagFormatException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/task/tag/InvalidTagFormatException.java
@@ -1,0 +1,9 @@
+package kr.kro.colla.exception.exception.task.tag;
+
+public class InvalidTagFormatException extends RuntimeException {
+
+    public InvalidTagFormatException() {
+        super("잘못된 형식의 태그 리스트입니다.");
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -40,8 +40,7 @@ public class Project {
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     private List<UserProject> members = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     private List<Task> tasks = new ArrayList<>();
 
     @OneToMany(

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -8,6 +8,7 @@ import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.tag.domain.Tag;
+import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.notice.service.NoticeService;
 import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
@@ -104,6 +105,12 @@ public class ProjectController {
         List<ProjectTagResponse> projectTags = projectService.getProjectTags(projectId);
 
         return ResponseEntity.ok(projectTags);
+    }
+
+    @PostMapping("{projectId}/tasks")
+    public ResponseEntity createTask(CreateTaskRequest createTaskRequest) {
+        System.out.println(createTaskRequest);
+        return null;
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -21,8 +21,7 @@ public class TaskStatus {
     @Column
     private String name;
 
-    @OneToMany(fetch = FetchType.EAGER)
-    @JoinColumn(name = "task_status_id")
+    @OneToMany(mappedBy = "taskStatus", fetch = FetchType.EAGER)
     private List<Task> tasks = new ArrayList<>();
 
     public TaskStatus(String name){

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepository.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepository.java
@@ -1,0 +1,12 @@
+package kr.kro.colla.project.task_status.domain.repository;
+
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
+
+    public Optional<TaskStatus> findByName(String name);
+
+}

--- a/backend/src/main/java/kr/kro/colla/project/task_status/service/TaskStatusService.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/service/TaskStatusService.java
@@ -1,0 +1,23 @@
+package kr.kro.colla.project.task_status.service;
+
+import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TaskStatusService {
+
+    private final TaskStatusRepository taskStatusRepository;
+
+    public TaskStatus findTaskStatusByName(String name) {
+        return taskStatusRepository.findByName(name)
+                .orElseThrow(TaskStatusNotFoundException::new);
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
+++ b/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
@@ -3,5 +3,10 @@ package kr.kro.colla.story.domain.repository;
 import kr.kro.colla.story.domain.Story;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StoryRepository extends JpaRepository<Story, Long> {
+
+    public Optional<Story> findByTitle(String title);
+
 }

--- a/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
+++ b/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.story.service;
 
+import kr.kro.colla.exception.exception.story.StoryNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
 import kr.kro.colla.project.project.service.ProjectService;
@@ -27,6 +28,12 @@ public class StoryService {
                 .build();
 
         return storyRepository.save(story);
+    }
+
+    public Story findStoryByTitle(String title) {
+        System.out.println(title);
+        return storyRepository.findByTitle(title)
+                .orElseThrow(StoryNotFoundException::new);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
+++ b/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
@@ -31,7 +31,6 @@ public class StoryService {
     }
 
     public Story findStoryByTitle(String title) {
-        System.out.println(title);
         return storyRepository.findByTitle(title)
                 .orElseThrow(StoryNotFoundException::new);
     }

--- a/backend/src/main/java/kr/kro/colla/task/tag/domain/repository/TagRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/tag/domain/repository/TagRepository.java
@@ -3,10 +3,13 @@ package kr.kro.colla.task.tag.domain.repository;
 import kr.kro.colla.task.tag.domain.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
-    public Optional<Tag> findByName(String name);
+    Optional<Tag> findByName(String name);
+
+    List<Tag> findByNameIn(List<String> tagNames);
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/tag/service/TagService.java
+++ b/backend/src/main/java/kr/kro/colla/task/tag/service/TagService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional
@@ -19,6 +20,10 @@ public class TagService {
 
         return tagRepository.findByName(tag.getName())
                 .orElseGet(() -> tagRepository.save(tag));
+    }
+
+    public List<Tag> findTagsByName(List<String> tagNames) {
+        return tagRepository.findByNameIn(tagNames);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -1,9 +1,13 @@
 package kr.kro.colla.task.task.domain;
 
 import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.history.domain.History;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import lombok.Getter;
 
@@ -12,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 @EntityListeners(EntityListeners.class)
 @Entity
@@ -43,6 +48,14 @@ public class Task {
     private Integer priority;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "task_status_id")
+    private TaskStatus taskStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "story_id")
     private Story story;
 
@@ -56,5 +69,17 @@ public class Task {
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "task_id")
     private List<History> histories = new ArrayList<>();
+
+    @Builder
+    public Task(String title, Long managerId, String description, Integer priority, Project project, TaskStatus taskStatus, Story story, String preTasks) {
+        this.title = title;
+        this.managerId = managerId;
+        this.description = description;
+        this.priority = priority;
+        this.project = project;
+        this.taskStatus = taskStatus;
+        this.story = story;
+        this.preTasks = preTasks;
+    }
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package kr.kro.colla.task.task.domain.repository;
+
+import kr.kro.colla.task.task.domain.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -1,21 +1,31 @@
 package kr.kro.colla.task.task.presentation;
 
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import javax.validation.Valid;
+import java.net.URI;
+
 @RequiredArgsConstructor
-@RequestMapping("/tasks")
+@RequestMapping("/projects/tasks")
 @Controller
 public class TaskController {
 
-    @PostMapping("/")
-    public ResponseEntity createTask(@ModelAttribute CreateTaskRequest createTaskRequest) {
-        return null;
+    private final TaskService taskService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTask(@Valid CreateTaskRequest createTaskRequest) {
+        System.out.println(createTaskRequest);
+        Long taskId = taskService.createTask(createTaskRequest);
+        URI redirectUrl = URI.create("/api/projects/tasks/" + taskId);
+
+        return ResponseEntity.created(redirectUrl)
+                .build();
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -20,7 +20,6 @@ public class TaskController {
 
     @PostMapping
     public ResponseEntity<Void> createTask(@Valid CreateTaskRequest createTaskRequest) {
-        System.out.println(createTaskRequest);
         Long taskId = taskService.createTask(createTaskRequest);
         URI redirectUrl = URI.create("/api/projects/tasks/" + taskId);
 

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/CreateTaskRequest.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/CreateTaskRequest.java
@@ -4,23 +4,32 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
 @ToString
 @AllArgsConstructor
 @Getter
 public class CreateTaskRequest {
 
+    @NotBlank
     private String title;
 
     private Long managerId;
 
     private String description;
 
-    private String priority;
+    @Min(1) @Max(5)
+    private Integer priority;
 
+    @NotBlank
     private String status;
 
     private String tags;
 
+    @NotNull
     private Long projectId;
 
     private String story;

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/CreateTaskRequest.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/CreateTaskRequest.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
-@ToString
 @AllArgsConstructor
 @Getter
 public class CreateTaskRequest {

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -44,7 +44,10 @@ public class TaskService {
                 .preTasks(createTaskRequest.getPreTasks())
                 .build();
 
-        taskTagService.setTaskTag(task, createTaskRequest.getTags());
+        if (createTaskRequest.getTags() != null) {
+            taskTagService.setTaskTag(task, createTaskRequest.getTags());
+        }
+
         return taskRepository.save(task)
                 .getId();
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -1,0 +1,52 @@
+package kr.kro.colla.task.task.service;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.service.TaskStatusService;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.story.service.StoryService;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task_tag.service.TaskTagService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TaskService {
+
+    private final StoryService storyService;
+    private final ProjectService projectService;
+    private final TaskTagService taskTagService;
+    private final TaskStatusService taskStatusService;
+    private final TaskRepository taskRepository;
+
+    public Long createTask(CreateTaskRequest createTaskRequest) {
+        Project project = projectService.findProjectById(createTaskRequest.getProjectId());
+        Story story = createTaskRequest.getStory() != null
+                ? storyService.findStoryByTitle(createTaskRequest.getStory())
+                : null;
+        TaskStatus taskStatus = taskStatusService.findTaskStatusByName(createTaskRequest.getStatus());
+
+        Task task = Task.builder()
+                .title(createTaskRequest.getTitle())
+                .managerId(createTaskRequest.getManagerId())
+                .description(createTaskRequest.getDescription())
+                .priority(createTaskRequest.getPriority())
+                .project(project)
+                .taskStatus(taskStatus)
+                .story(story)
+                .preTasks(createTaskRequest.getPreTasks())
+                .build();
+
+        taskTagService.setTaskTag(task, createTaskRequest.getTags());
+        return taskRepository.save(task)
+                .getId();
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task_tag/domain/TaskTag.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_tag/domain/TaskTag.java
@@ -20,7 +20,7 @@ public class TaskTag {
     private Long id;
 
     @ManyToOne
-    @JoinColumn
+    @JoinColumn(name ="project_id")
     private Project project;
 
     @ManyToOne
@@ -31,13 +31,11 @@ public class TaskTag {
     @JoinColumn(name = "tag_id")
     private Tag tag;
 
-    @Builder
     public TaskTag(Project project, Tag tag) {
         this.project = project;
         this.tag = tag;
     }
 
-    @Builder
     public TaskTag(Task task, Tag tag) {
         this.task = task;
         this.tag = tag;

--- a/backend/src/main/java/kr/kro/colla/task/task_tag/service/TaskTagService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_tag/service/TaskTagService.java
@@ -33,8 +33,7 @@ public class TaskTagService {
     public void setTaskTag(Task task, String tags) {
         try {
             ObjectMapper objectMapper = new ObjectMapper();
-            List<String> tagNames = objectMapper.readValue(tags, new TypeReference<List<String>>() {
-            });
+            List<String> tagNames = objectMapper.readValue(tags, new TypeReference<List<String>>() {});
 
             tagService.findTagsByName(tagNames)
                     .stream()

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
@@ -3,12 +3,9 @@ package kr.kro.colla.user.user.presentation;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.user.domain.User;
-import kr.kro.colla.user.user.domain.repository.UserRepository;
 import kr.kro.colla.user.user.presentation.dto.*;
 import kr.kro.colla.user.user.service.UserService;
-import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,8 +19,6 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
-    private final ProjectService projectService;
-    private final UserProjectService userProjectService;
 
     @GetMapping("/profile")
     public ResponseEntity<UserProfileResponse> getUserProfile(@Authenticated LoginUser loginUser) {
@@ -47,9 +42,7 @@ public class UserController {
             @Authenticated LoginUser loginUser,
             @Valid CreateProjectRequest createProjectRequest
     ) {
-        User user = userService.findUserById(loginUser.getId());
-        Project project = projectService.createProject(user.getId(), createProjectRequest);
-        userProjectService.joinProject(user, project);
+        Project project = userService.createProject(loginUser.getId(), createProjectRequest);
 
         return ResponseEntity.ok(new UserProjectResponse(project));
     }

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -2,11 +2,14 @@ package kr.kro.colla.user.user.service;
 
 import kr.kro.colla.auth.infrastructure.dto.GithubUserProfileResponse;
 import kr.kro.colla.exception.exception.user.UserNotFoundException;
-import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.domain.repository.UserRepository;
+import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
+import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +22,8 @@ import java.util.stream.Collectors;
 @Service
 public class UserService {
 
+    private final ProjectService projectService;
+    private final UserProjectService userProjectService;
     private final UserRepository userRepository;
 
     public String updateDisplayName(Long id, String displayName) {
@@ -42,8 +47,19 @@ public class UserService {
                 );
     }
 
+    public Project createProject(Long id, CreateProjectRequest createProjectRequest) {
+        User user = findUserById(id);
+        Project project = projectService.createProject(user.getId(), createProjectRequest);
+        userProjectService.joinProject(user, project);
+
+        return project;
+    }
+
     public List<UserNoticeResponse> getUserNotices(Long id){
-        return findUserById(id).getNotices().stream().map(notice-> new UserNoticeResponse(notice)).collect(Collectors.toList());
+        return findUserById(id).getNotices()
+                .stream()
+                .map(UserNoticeResponse::new)
+                .collect(Collectors.toList());
     }
 
     public List<UserProjectResponse> getUserProjects(Long id) {

--- a/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/presentation/AuthControllerTest.java
@@ -1,13 +1,9 @@
 package kr.kro.colla.auth.presentation;
 
-import kr.kro.colla.auth.service.AuthService;
-import kr.kro.colla.utils.CookieManager;
+import kr.kro.colla.common.ControllerTest;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.ResponseCookie;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -16,16 +12,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(AuthController.class)
-class AuthControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @MockBean
-    private CookieManager cookieManager;
-
-    @MockBean
-    private AuthService authService;
+class AuthControllerTest extends ControllerTest {
 
     @Test
     void 로그인_성공_시_Jwt토큰이_반환된다() throws Exception {

--- a/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
@@ -1,0 +1,72 @@
+package kr.kro.colla.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.kro.colla.auth.domain.LoginUser;
+import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.story.service.StoryService;
+import kr.kro.colla.task.task.service.TaskService;
+import kr.kro.colla.user.notice.service.NoticeService;
+import kr.kro.colla.user.user.service.UserService;
+import kr.kro.colla.user_project.service.UserProjectService;
+import kr.kro.colla.utils.CookieManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.servlet.http.Cookie;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+public abstract class ControllerTest {
+
+    @Autowired
+    public MockMvc mockMvc;
+
+    @Autowired
+    public ObjectMapper objectMapper;
+
+    @MockBean
+    public CookieManager cookieManager;
+
+    @MockBean
+    public AuthService authService;
+
+    @MockBean
+    public UserService userService;
+
+    @MockBean
+    public ProjectService projectService;
+
+    @MockBean
+    public UserProjectService userProjectService;
+
+    @MockBean
+    public TaskService taskService;
+
+    @MockBean
+    public StoryService storyService;
+
+    @MockBean
+    public NoticeService noticeService;
+
+    public String accessToken = "token";
+    public LoginUser loginUser;
+
+    @BeforeEach
+    void setUp() {
+        String accessToken = "token";
+        loginUser = new LoginUser(20L);
+
+        given(cookieManager.parseCookies(any(Cookie[].class), eq("accessToken")))
+                .willReturn(new Cookie("accessToken", accessToken));
+        given(authService.validateAccessToken(eq(accessToken)))
+                .willReturn(true);
+        given(authService.findUserFromToken(accessToken))
+                .willReturn(loginUser);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -348,10 +348,7 @@ public class AcceptanceTest {
         Tag tag = new Tag("backend");
         tagRepository.save(tag);
 
-        TaskTag taskTag = TaskTag.builder()
-                .project(project)
-                .tag(tag)
-                .build();
+        TaskTag taskTag = new TaskTag(project, tag);
         taskTagRepository.save(taskTag);
 
         List<ProjectTagResponse> response = given()

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -1,10 +1,7 @@
 package kr.kro.colla.project.project.presentation;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import kr.kro.colla.auth.domain.LoginUser;
-import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.ProjectService;
@@ -16,18 +13,13 @@ import kr.kro.colla.user.notice.service.NoticeService;
 import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
-import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
-import kr.kro.colla.utils.CookieManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -48,50 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProjectController.class)
-class ProjectControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private CookieManager cookieManager;
-
-    @MockBean
-    private AuthService authService;
-
-    @MockBean
-    private ProjectService projectService;
-
-    @MockBean
-    private UserService userService;
-
-    @MockBean
-    private UserProjectService userProjectService;
-
-    @MockBean
-    private NoticeService noticeService;
-
-    @MockBean
-    private StoryService storyService;
-
-    private String accessToken = "token";
-    private LoginUser loginUser;
-
-    @BeforeEach
-    void setUp() {
-        String accessToken = "token";
-        loginUser = new LoginUser(345234L);
-
-        given(cookieManager.parseCookies(any(Cookie[].class), eq("accessToken")))
-                .willReturn(new Cookie("accessToken", accessToken));
-        given(authService.validateAccessToken(eq(accessToken)))
-                .willReturn(true);
-        given(authService.findUserFromToken(accessToken))
-                .willReturn(loginUser);
-    }
+class ProjectControllerTest extends ControllerTest {
 
     @Test
     void projectId에_해당하는_프로젝트를_조회한다() throws Exception {

--- a/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
@@ -228,10 +228,7 @@ class ProjectServiceTest {
                 .description(desc)
                 .build();
         Tag tag = new Tag("backend");
-        TaskTag taskTag = TaskTag.builder()
-                .project(project)
-                .tag(tag)
-                .build();
+        TaskTag taskTag = new TaskTag(project, tag);
         ReflectionTestUtils.setField(project, "taskTags", List.of(taskTag));
         ReflectionTestUtils.setField(taskTag, "tag", tag);
 

--- a/backend/src/test/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepositoryTest.java
@@ -1,0 +1,34 @@
+package kr.kro.colla.project.task_status.domain.repository;
+
+import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class TaskStatusRepositoryTest {
+
+    @Autowired
+    private TaskStatusRepository taskStatusRepository;
+
+    @Test
+    void 태스크_상태를_이름으로_조회한다() {
+        // given
+        String name = "In Progress";
+        TaskStatus taskStatus = new TaskStatus(name);
+        taskStatusRepository.save(taskStatus);
+
+        // when
+        TaskStatus result = taskStatusRepository.findByName(name)
+                .orElseThrow(TaskStatusNotFoundException::new);
+
+        // then
+        assertThat(result.getName()).isEqualTo(name);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/project/task_status/service/TaskStatusServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/task_status/service/TaskStatusServiceTest.java
@@ -1,0 +1,60 @@
+package kr.kro.colla.project.task_status.service;
+
+import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TaskStatusServiceTest {
+
+    @Mock
+    private TaskStatusRepository taskStatusRepository;
+
+    @InjectMocks
+    private TaskStatusService taskStatusService;
+
+    @Test
+    void 태스크_상태를_이름으로_조회한다() {
+        // given
+        String name = "In Progress";
+        TaskStatus taskStatus = new TaskStatus(name);
+
+        given(taskStatusRepository.findByName(name))
+                .willReturn(Optional.of(taskStatus));
+
+        // when
+        TaskStatus result = taskStatusService.findTaskStatusByName(name);
+
+        // then
+        assertThat(result.getName()).isEqualTo(name);
+        verify(taskStatusRepository, times(1)).findByName(any(String.class));
+    }
+
+    @Test
+    void 존재하지_않는_이름으로_조회_시_예외가_발생한다() {
+        // given
+        String name = "invalid name";
+
+        given(taskStatusRepository.findByName(name))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> taskStatusService.findTaskStatusByName(name))
+                .isInstanceOf(TaskStatusNotFoundException.class);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/story/domain/repository/StoryRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/domain/repository/StoryRepositoryTest.java
@@ -1,0 +1,36 @@
+package kr.kro.colla.story.domain.repository;
+
+import kr.kro.colla.exception.exception.story.StoryNotFoundException;
+import kr.kro.colla.story.domain.Story;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class StoryRepositoryTest {
+
+    @Autowired
+    private StoryRepository storyRepository;
+
+    @Test
+    void 스토리를_제목으로_조회한다() {
+        // given
+        String title = "user can login with github";
+        Story story = Story.builder()
+                .title(title)
+                .build();
+        storyRepository.save(story);
+
+        // when
+        Story result = storyRepository.findByTitle(title)
+                .orElseThrow(StoryNotFoundException::new);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(title);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.story.service;
 
+import kr.kro.colla.exception.exception.story.StoryNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
 import kr.kro.colla.project.project.service.ProjectService;
@@ -12,7 +13,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -60,6 +64,38 @@ class StoryServiceTest {
         assertThat(result.getTitle()).isEqualTo(story.getTitle());
         assertThat(result.getPreStories()).isEqualTo("[]");
         assertThat(result.getProject().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 스토리를_제목으로_조회한다() {
+        // given
+        String title = "user can login with github";
+        Story story = Story.builder()
+                .title(title)
+                .build();
+
+        given(storyRepository.findByTitle(title))
+                .willReturn(Optional.of(story));
+
+        // when
+        Story result = storyService.findStoryByTitle(title);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(title);
+        verify(storyRepository, times(1)).findByTitle(any(String.class));
+    }
+
+    @Test
+    void 존재하지_않는_스토리_제목으로_조회_시_예외가_발생한다() {
+        // given
+        String title = "invalid title";
+
+        given(storyRepository.findByTitle(title))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> storyService.findStoryByTitle(title))
+                .isInstanceOf(StoryNotFoundException.class);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/tag/domain/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/tag/domain/repository/TagRepositoryTest.java
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("test")
@@ -26,6 +28,25 @@ class TagRepositoryTest {
         // then
         assertThat(result.getId()).isNotNull();
         assertThat(result.getName()).isEqualTo(tag.getName());
+    }
+
+    @Test
+    void 태그_목록에_포함된_태그들을_조회한다() {
+        // given
+        List<String> tagNames = List.of("backend", "frontend");
+        tagRepository.saveAll(List.of(
+                new Tag("backend"),
+                new Tag("frontend"),
+                new Tag("refactoring")
+        ));
+
+        // when
+        List<Tag> tags = tagRepository.findByNameIn(tagNames);
+
+        // then
+        assertThat(tags.size()).isEqualTo(2);
+        assertThat(tags).extracting("name")
+                .contains("backend", "frontend");
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/tag/service/TagServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +61,27 @@ class TagServiceTest {
         verify(tagRepository, times(1)).findByName(any(String.class));
         verify(tagRepository, never()).save(any(Tag.class));
         assertThat(result.getName()).isEqualTo(tag.getName());
+    }
+
+    @Test
+    void 태그_목록에_포함된_태그들을_조회한다() {
+        // given
+        List<String> tagNames = List.of("backend", "refactoring");
+        List<Tag> tags = List.of(
+                new Tag("backend"),
+                new Tag("refactoring")
+        );
+
+        given(tagRepository.findByNameIn(tagNames))
+                .willReturn(tags);
+
+        // when
+        List<Tag> result = tagService.findTagsByName(tagNames);
+
+        // then
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).extracting("name")
+                .contains("backend", "refactoring");
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -1,0 +1,128 @@
+package kr.kro.colla.task.task;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    private Auth auth;
+    private User user;
+    private Project project;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        auth = new Auth(jwtProvider);
+
+        user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("s3_content")
+                .build();
+        userRepository.save(user);
+
+        project = Project.builder()
+                .managerId(user.getId())
+                .name("project name")
+                .description("project description")
+                .thumbnail("s3_content")
+                .build();
+        projectRepository.save(project);
+
+        accessToken = auth.로그인(user.getId());
+    }
+
+    @AfterEach
+    void rollback() {
+        taskRepository.deleteAll();
+        projectRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void 사용자가_프로젝트에_새로운_태스크를_추가한다() {
+        // given
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", "task title");
+        formData.put("priority", "3");
+        formData.put("status", "To Do");
+        formData.put("projectId", project.getId().toString());
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+
+        // when
+        .when()
+                .post("/api/projects/tasks")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    void 태스크_생성_시_필요한_데이터가_없을_경우_예외가_발생한다() {
+        // given
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", "task title");
+        formData.put("priority", "3");
+        formData.put("status", "To Do");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+
+        // when
+        .when()
+                .post("/api/projects/tasks")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", equalTo("projectId : 널이어서는 안됩니다"));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -1,0 +1,57 @@
+package kr.kro.colla.task.task.domain.repository;
+
+import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
+import kr.kro.colla.task.task.domain.Task;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+class TaskRepositoryTest {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskStatusRepository taskStatusRepository;
+
+    @Test
+    void 프로젝트에_새로운_태스크를_등록한다() {
+        // given
+        Project project = Project.builder()
+                .name("collaboration")
+                .description("collaboration tool")
+                .managerId(1L)
+                .build();
+        projectRepository.save(project);
+
+        TaskStatus taskStatus = taskStatusRepository.findByName("To Do")
+                .orElseThrow(TaskStatusNotFoundException::new);
+        Task task = Task.builder()
+                .title("task title")
+                .description("task description")
+                .project(project)
+                .taskStatus(taskStatus)
+                .build();
+
+        // when
+        Task result = taskRepository.save(task);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(task.getTitle());
+        assertThat(result.getTaskStatus().getName()).isEqualTo("To Do");
+        assertThat(result.getProject().getName()).isEqualTo(project.getName());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -1,0 +1,46 @@
+package kr.kro.colla.task.task.presentation;
+
+import kr.kro.colla.common.ControllerTest;
+import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.Cookie;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TaskController.class)
+class TaskControllerTest extends ControllerTest {
+
+    @Test
+    void 프로젝트에_새로운_태스크를_등록한다() throws Exception {
+        // given
+        Long taskId = 1L;
+        given(taskService.createTask(any(CreateTaskRequest.class)))
+                .willReturn(taskId);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/projects/tasks")
+                .cookie(new Cookie("accessToken", this.accessToken))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("title", "task title")
+                .param("priority", "3")
+                .param("status", "To Do")
+                .param("projectId", "1"));
+
+        // then
+        MvcResult result = perform.andReturn();
+
+        perform.andExpect(status().isCreated());
+        assertThat(result.getResponse().getHeader(HttpHeaders.LOCATION)).isEqualTo("/api/projects/tasks/" + taskId);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -1,0 +1,96 @@
+package kr.kro.colla.task.task.service;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.service.TaskStatusService;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.story.service.StoryService;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task_tag.service.TaskTagService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TaskServiceTest {
+
+    @Mock
+    private StoryService storyService;
+
+    @Mock
+    private ProjectService projectService;
+
+    @Mock
+    private TaskTagService taskTagService;
+
+    @Mock
+    private TaskStatusService taskStatusService;
+
+    @Mock
+    private TaskRepository taskRepository;
+
+    @InjectMocks
+    private TaskService taskService;
+
+    @Test
+    void 프로젝트에_새로운_태스크를_생성한다() {
+        // given
+        String storyTitle = "user can login with github", taskStatusName = "To Do";
+        CreateTaskRequest createTaskRequest = new CreateTaskRequest("task title", null, "task description", 4, taskStatusName, "[\"backend\"]", 1L, storyTitle, "[]");
+        Project project = Project.builder()
+                .name("collaboration")
+                .description("collaboration tool")
+                .build();
+        Story story = Story.builder()
+                .title(storyTitle)
+                .preStories("[]")
+                .project(project)
+                .build();
+        TaskStatus taskStatus = new TaskStatus(taskStatusName);
+        Task task = Task.builder()
+                .title(createTaskRequest.getTitle())
+                .managerId(createTaskRequest.getManagerId())
+                .description(createTaskRequest.getDescription())
+                .priority(createTaskRequest.getPriority())
+                .project(project)
+                .taskStatus(taskStatus)
+                .story(story)
+                .preTasks(createTaskRequest.getPreTasks())
+                .build();
+        ReflectionTestUtils.setField(task, "id", 1L);
+
+        given(projectService.findProjectById(1L))
+                .willReturn(project);
+        given(storyService.findStoryByTitle(storyTitle))
+                .willReturn(story);
+        given(taskStatusService.findTaskStatusByName(taskStatusName))
+                .willReturn(taskStatus);
+        given(taskRepository.save(any(Task.class)))
+                .willReturn(task);
+
+        // when
+        Long taskId = taskService.createTask(createTaskRequest);
+
+        // then
+        assertThat(taskId).isNotNull();
+        verify(projectService, times(1)).findProjectById(1L);
+        verify(storyService, times(1)).findStoryByTitle(storyTitle);
+        verify(taskStatusService, times(1)).findTaskStatusByName(taskStatusName);
+        verify(taskTagService, times(1)).setTaskTag(any(Task.class), anyString());
+        verify(taskRepository, times(1)).save(any(Task.class));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task_tag/domain/repository/TaskTagRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_tag/domain/repository/TaskTagRepositoryTest.java
@@ -25,10 +25,7 @@ class TaskTagRepositoryTest {
                 .description("project description")
                 .build();
         Tag tag = new Tag("backend");
-        TaskTag taskTag = TaskTag.builder()
-                .project(project)
-                .tag(tag)
-                .build();
+        TaskTag taskTag = new TaskTag(project, tag);
 
         // when
         TaskTag result = taskTagRepository.save(taskTag);

--- a/backend/src/test/java/kr/kro/colla/task/task_tag/domain/repository/TaskTagRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_tag/domain/repository/TaskTagRepositoryTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.task.task_tag.domain.repository;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.task.tag.domain.Tag;
+import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,26 @@ class TaskTagRepositoryTest {
 
         // then
         assertThat(result.getProject()).isNotNull();
+        assertThat(result.getTag()).isNotNull();
+    }
+
+    @Test
+    void 태스크에_태그를_지정한다() {
+        // given
+        Task task = Task.builder()
+                .title("task title")
+                .description("task description")
+                .priority(3)
+                .build();
+        Tag tag = new Tag("refactoring");
+        TaskTag taskTag = new TaskTag(task, tag);
+
+        // when
+        TaskTag result = taskTagRepository.save(taskTag);
+
+        // then
+        assertThat(result.getProject()).isNull();
+        assertThat(result.getTask()).isNotNull();
         assertThat(result.getTag()).isNotNull();
     }
 

--- a/backend/src/test/java/kr/kro/colla/task/task_tag/service/TaskTagServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_tag/service/TaskTagServiceTest.java
@@ -1,0 +1,59 @@
+package kr.kro.colla.task.task_tag.service;
+
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.task.tag.domain.Tag;
+import kr.kro.colla.task.tag.service.TagService;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_tag.domain.TaskTag;
+import kr.kro.colla.task.task_tag.domain.repository.TaskTagRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class TaskTagServiceTest {
+
+    @Mock
+    private TagService tagService;
+
+    @Mock
+    private TaskTagRepository taskTagRepository;
+
+    @InjectMocks
+    private TaskTagService taskTagService;
+
+    @Test
+    void 태스트에_선택한_태그들을_지정한다() {
+        // given
+        Task task = Task.builder()
+                .title("task title")
+                .description("task description")
+                .taskStatus(new TaskStatus("In Progress"))
+                .build();
+        String tags = "[\"backend\", \"refactoring\"]";
+        List<Tag> tagList = List.of(
+                new Tag("backend"),
+                new Tag("refactoring")
+        );
+
+        given(tagService.findTagsByName(any(List.class)))
+                .willReturn(tagList);
+
+        // when
+        taskTagService.setTaskTag(task, tags);
+
+        // then
+        verify(taskTagRepository, times(2)).save(any(TaskTag.class));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -32,9 +32,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 
-import javax.transaction.Transactional;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,12 +55,16 @@ public class AcceptanceTest {
 
     @Autowired
     private UserRepository userRepository;
+
     @Autowired
     private ProjectRepository projectRepository;
+
     @Autowired
     private UserProjectRepository userProjectRepository;
+
     @Autowired
     private NoticeRepository noticeRepository;
+
     @Autowired
     private NoticeService noticeService;
 

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -40,8 +40,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -61,12 +60,6 @@ class UserControllerTest {
 
     @MockBean
     private UserService userService;
-
-    @MockBean
-    private ProjectService projectService;
-
-    @MockBean
-    private UserProjectService userProjectService;
 
     @MockBean
     private CookieManager cookieManager;
@@ -128,9 +121,7 @@ class UserControllerTest {
                 .build();
         ReflectionTestUtils.setField(user, "id", loginUser.getId());
 
-        given(userService.findUserById(loginUser.getId()))
-                .willReturn(user);
-        given(projectService.createProject(eq(loginUser.getId()), any(CreateProjectRequest.class)))
+        given(userService.createProject(eq(loginUser.getId()), any(CreateProjectRequest.class)))
                 .willReturn(project);
 
         // when
@@ -147,7 +138,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.managerId").value(loginUser.getId()))
                 .andExpect(jsonPath("$.name").value(name))
                 .andExpect(jsonPath("$.description").value(desc));
-        verify(projectService, times(1)).createProject(eq(loginUser.getId()), any(CreateProjectRequest.class));
+        verify(userService, times(1)).createProject(eq(loginUser.getId()), any(CreateProjectRequest.class));
     }
 
     @Test
@@ -168,7 +159,7 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("name : must not be blank"));
-        verify(projectService, times(0)).createProject(any(), any());
+        verify(userService, never()).createProject(any(), any());
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -1,12 +1,9 @@
 package kr.kro.colla.user.user.presentation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import kr.kro.colla.auth.domain.LoginUser;
-import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.common.fixture.FileProvider;
 import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.user.domain.User;
@@ -14,19 +11,12 @@ import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import kr.kro.colla.user.user.presentation.dto.UpdateUserNameRequest;
 import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
-import kr.kro.colla.user.user.service.UserService;
-import kr.kro.colla.user_project.service.UserProjectService;
-import kr.kro.colla.utils.CookieManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -47,38 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
-class UserControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private AuthService authService;
-
-    @MockBean
-    private UserService userService;
-
-    @MockBean
-    private CookieManager cookieManager;
-
-    private String accessToken = "token";
-    private LoginUser loginUser;
-
-    @BeforeEach
-    void setUp() {
-        String accessToken = "token";
-        loginUser = new LoginUser(345234L);
-
-        given(cookieManager.parseCookies(any(Cookie[].class), eq("accessToken")))
-                .willReturn(new Cookie("accessToken", accessToken));
-        given(authService.validateAccessToken(eq(accessToken)))
-                .willReturn(true);
-        given(authService.findUserFromToken(accessToken))
-                .willReturn(loginUser);
-    }
+class UserControllerTest extends ControllerTest {
 
     @Test
     void 사용자의_프로필을_조회한다() throws Exception {
@@ -128,7 +87,7 @@ class UserControllerTest {
         ResultActions perform = mockMvc.perform(multipart("/users/projects")
                 .file(thumbnail)
                 .cookie(new Cookie("accessToken", accessToken))
-                .contentType(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA)
                 .param("name", name)
                 .param("description", desc));
 

--- a/backend/src/test/java/kr/kro/colla/user_project/service/UserProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user_project/service/UserProjectServiceTest.java
@@ -27,6 +27,7 @@ class UserProjectServiceTest {
 
     @Test
     void 프로젝트의_사용자_추가에_성공한다(){
+        // given
         User user = User.builder()
                 .githubId("binimini")
                 .name("subin")
@@ -39,8 +40,9 @@ class UserProjectServiceTest {
                 .user(user)
                 .project(project).build();
         ReflectionTestUtils.setField(userProject, "id", 234L);
-        // given
-        given(userProjectRepository.save(any(UserProject.class))).willReturn(userProject);
+
+        given(userProjectRepository.save(any(UserProject.class)))
+                .willReturn(userProject);
 
         // when
         UserProject result = userProjectService.joinProject(user, project);

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -1,4 +1,4 @@
-import { ProjectType } from '../types/project';
+import { ProjectTagType, ProjectType } from '../types/project';
 import { client } from './common';
 
 interface task {
@@ -14,10 +14,6 @@ interface ProjectAllType extends ProjectType {
     tasks: {
         [key: string]: Array<task>;
     };
-}
-
-interface projectTags {
-    name: string;
 }
 
 export const getProject = async (projectId: number) => {
@@ -44,12 +40,11 @@ export const getProjectMembers = async (projectId: number) => {
     return response;
 };
 
-
 export const createTag = async (projectId: number, name: string) => {
     const response = await client.post(`/projects/${projectId}/tags`, { name });
-  
+
     return response;
-}
+};
 
 export const inviteUser = async (projectId: number, githubId: string) => {
     const response = await client.post(`/projects/${projectId}/members`, { githubId });
@@ -57,12 +52,11 @@ export const inviteUser = async (projectId: number, githubId: string) => {
     return response;
 };
 
-
 export const getProjectTags = async (projectId: number) => {
-    const response = await client.get<Array<projectTags>>(`/projects/${projectId}/tags`);
+    const response = await client.get<Array<ProjectTagType>>(`/projects/${projectId}/tags`);
 
     return response;
-}
+};
 
 export const decideInvitation = async (projectId: number, accept: boolean) => {
     const response = await client.post(`/projects/${projectId}/members/decision`, { accept });

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -1,7 +1,7 @@
 import { client } from './common';
 
 export const createTask = async (data: FormData) => {
-    const response = await client.post(`/tasks/`, data, {
+    const response = await client.post(`/projects/tasks`, data, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     });
 

--- a/frontend/src/components/DropDown/Member/index.tsx
+++ b/frontend/src/components/DropDown/Member/index.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { getProjectMembers } from '../../../apis/project';
 import { projectState } from '../../../stores/projectState';
+import { ProjectMemberType } from '../../../types/project';
 import { Avatar, Name } from '../../Task/style';
 import { Member, MemberList } from './style';
 
@@ -12,15 +13,9 @@ interface PropType {
     handleChangeManagerId: Function;
 }
 
-interface MemberType {
-    id: number;
-    name: string;
-    avatar: string;
-}
-
 export const MemberDropDown: FC<PropType> = ({ setManager, setMemberVisible, handleChangeManagerId }) => {
     const project = useRecoilValue(projectState);
-    const [memberList, setMemberList] = useState<MemberType[]>([]);
+    const [memberList, setMemberList] = useState<ProjectMemberType[]>([]);
 
     const selectManager = (id: number, name: string) => {
         setManager(name);
@@ -30,26 +25,19 @@ export const MemberDropDown: FC<PropType> = ({ setManager, setMemberVisible, han
 
     useEffect(() => {
         (async () => {
-            try {
-                const res = await getProjectMembers(project.id);
-                setMemberList(res.data);
-            } catch (err) {
-                setMemberList([]);
-            }
+            const res = await getProjectMembers(project.id);
+            setMemberList(res.data);
         })();
     }, []);
 
     return (
         <MemberList>
-            {memberList.map((member, idx) => {
-                const { id, name, avatar } = member;
-                return (
-                    <Member key={idx} onClick={() => selectManager(id, name)}>
-                        <Avatar src={avatar}></Avatar>
-                        <Name>{name}</Name>
-                    </Member>
-                );
-            })}
+            {memberList.map(({ id, name, avatar }, idx) => (
+                <Member key={idx} onClick={() => selectManager(id, name)}>
+                    <Avatar src={avatar}></Avatar>
+                    <Name>{name}</Name>
+                </Member>
+            ))}
         </MemberList>
     );
 };

--- a/frontend/src/components/DropDown/Story/index.tsx
+++ b/frontend/src/components/DropDown/Story/index.tsx
@@ -22,12 +22,8 @@ export const StoryDropDown: FC<PropType> = ({ setStory, setStoryVisible }) => {
 
     useEffect(() => {
         (async () => {
-            try {
-                const res = await getProjectStories(project.id);
-                setStoryList(res.data);
-            } catch (err) {
-                setStoryList([]);
-            }
+            const res = await getProjectStories(project.id);
+            setStoryList(res.data);
         })();
     }, []);
 

--- a/frontend/src/components/List/TagList/index.tsx
+++ b/frontend/src/components/List/TagList/index.tsx
@@ -28,12 +28,8 @@ export const TagList: FC<PropType> = ({ selectedTags, handleSelectTag }) => {
 
     useEffect(() => {
         (async () => {
-            try {
-                const res = await getProjectTags(project.id);
-                setTags(() => res.data.map((tag) => tag.name));
-            } catch (err) {
-                setTags([]);
-            }
+            const res = await getProjectTags(project.id);
+            setTags(() => res.data.map((tag) => tag.name));
         })();
     }, []);
 

--- a/frontend/src/components/Modal/Tag/index.tsx
+++ b/frontend/src/components/Modal/Tag/index.tsx
@@ -20,13 +20,9 @@ export const TagModal: FC<PropType> = ({ showTagModal, setTags }) => {
     };
 
     const handleCompleteButton = async () => {
-        try {
-            const res = await createTag(project.id, tag);
-            setTags((prev: Array<string>) => [...prev, res.data.name]);
-            showTagModal();
-        } catch (err) {
-            showTagModal();
-        }
+        const res = await createTag(project.id, tag);
+        setTags((prev: Array<string>) => [...prev, res.data.name]);
+        showTagModal();
     };
 
     return (

--- a/frontend/src/hooks/useInputTask.ts
+++ b/frontend/src/hooks/useInputTask.ts
@@ -20,23 +20,19 @@ const useInputTask = () => {
     const { title, description, managerId, priority, status, selectedTags, story, preTasks } = taskInput;
 
     const handleCompleteButton = async () => {
-        try {
-            const formData = new FormData();
-            formData.append('title', title);
-            formData.append('description', description);
-            formData.append('managerId', managerId);
-            formData.append('priority', JSON.stringify(priority));
-            formData.append('status', status);
-            formData.append('tags', JSON.stringify(selectedTags));
-            formData.append('projectId', JSON.stringify(project.id));
-            formData.append('story', story);
-            formData.append('preTasks', JSON.stringify(preTasks));
+        const formData = new FormData();
+        formData.append('title', title);
+        formData.append('description', description);
+        formData.append('managerId', managerId);
+        formData.append('priority', JSON.stringify(priority));
+        formData.append('status', status);
+        formData.append('tags', JSON.stringify(selectedTags));
+        formData.append('projectId', JSON.stringify(project.id));
+        formData.append('story', story);
+        formData.append('preTasks', JSON.stringify(preTasks));
 
-            await createTask(formData);
-            window.location.replace('/kanban');
-        } catch (err) {
-            // TODO : toast 알림
-        }
+        await createTask(formData);
+        window.location.replace('/kanban');
     };
 
     const handleChangeTitle = (e: React.ChangeEvent) => {

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -7,3 +7,13 @@ export interface ProjectType {
     thumbnail: string;
     members: Array<UserProfile>;
 }
+
+export interface ProjectTagType {
+    name: string;
+}
+
+export interface ProjectMemberType {
+    id: number;
+    name: string;
+    avatar: string;
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 태스크 생성 API 구현
- 태스크 생성 API 테스크 코드 구현
- API 연동

### 📑 구현한 내용 목록
- [x] 태스크 생성 API 구현
- [x] 태스크 생성 API 테스크 코드 구현
- [x] API 연동

### 🚧 논의 사항
- 태스크 생성을 위해 Task 엔티티에 Project와 TaskStatus 엔티티 연관관계를 설정해주었습니다.
- Controller단 테스트에 중복되는 객체들이 많아 `ControllerTest` 추상 클래스로 분리하고 각 Controller 테스트에서 상속 받아 사용하도록 하였습니다!

- close #70 
