### PR TITLE
[#67] feat: 프로젝트 초대 결정 API 수정 및 알림 읽음 처리

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.exception;
 
+import kr.kro.colla.exception.exception.ForbiddenException;
 import kr.kro.colla.exception.exception.NotFoundException;
 import kr.kro.colla.exception.exception.auth.UnauthorizedException;
 import kr.kro.colla.exception.exception.user.FileUploadException;
@@ -7,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.client.HttpClientErrorException;
@@ -39,6 +39,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ExceptionHandleResponse> handleNotFoundException (NotFoundException e) {
+        ExceptionHandleResponse response = new ExceptionHandleResponse(e.getStatusCode().value(), e.getMessage());
+        return ResponseEntity.status(e.getStatusCode())
+                .body(response);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionHandleResponse> handleForbiddenException (ForbiddenException e) {
         ExceptionHandleResponse response = new ExceptionHandleResponse(e.getStatusCode().value(), e.getMessage());
         return ResponseEntity.status(e.getStatusCode())
                 .body(response);

--- a/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/kr/kro/colla/exception/GlobalExceptionHandler.java
@@ -1,8 +1,9 @@
 package kr.kro.colla.exception;
 
+import kr.kro.colla.exception.exception.CustomException;
 import kr.kro.colla.exception.exception.ForbiddenException;
 import kr.kro.colla.exception.exception.NotFoundException;
-import kr.kro.colla.exception.exception.auth.UnauthorizedException;
+import kr.kro.colla.exception.exception.UnauthorizedException;
 import kr.kro.colla.exception.exception.user.FileUploadException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,27 +31,6 @@ public class GlobalExceptionHandler {
                 .body(response);
     }
 
-    @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ExceptionHandleResponse> handleUnauthorizedException (UnauthorizedException e) {
-        ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.UNAUTHORIZED.value(), e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(response);
-    }
-
-    @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ExceptionHandleResponse> handleNotFoundException (NotFoundException e) {
-        ExceptionHandleResponse response = new ExceptionHandleResponse(e.getStatusCode().value(), e.getMessage());
-        return ResponseEntity.status(e.getStatusCode())
-                .body(response);
-    }
-
-    @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<ExceptionHandleResponse> handleForbiddenException (ForbiddenException e) {
-        ExceptionHandleResponse response = new ExceptionHandleResponse(e.getStatusCode().value(), e.getMessage());
-        return ResponseEntity.status(e.getStatusCode())
-                .body(response);
-    }
-
     @ExceptionHandler(FileUploadException.class)
     public ResponseEntity<ExceptionHandleResponse> handleFileUploadException (FileUploadException e) {
         ExceptionHandleResponse response = new ExceptionHandleResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), e.getMessage());
@@ -58,4 +38,10 @@ public class GlobalExceptionHandler {
                 .body(response);
     }
 
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionHandleResponse> handleCustomException (CustomException e) {
+        ExceptionHandleResponse response = new ExceptionHandleResponse(e.getHttpStatus().value(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(response);
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/BadRequestException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package kr.kro.colla.exception.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BadRequestException extends CustomException {
+    public BadRequestException(String message) { super(HttpStatus.BAD_REQUEST, message); }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/CustomException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/CustomException.java
@@ -1,0 +1,14 @@
+package kr.kro.colla.exception.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private HttpStatus httpStatus;
+
+    public CustomException (HttpStatus httpStatus, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/ForbiddenException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/ForbiddenException.java
@@ -4,11 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class ForbiddenException extends RuntimeException {
-    private HttpStatus statusCode;
+public class ForbiddenException extends CustomException {
 
-    public ForbiddenException(String message){
-        super(message);
-        this.statusCode = HttpStatus.FORBIDDEN;
-    }
+    public ForbiddenException(String message) { super(HttpStatus.FORBIDDEN, message); }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/ForbiddenException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/ForbiddenException.java
@@ -1,0 +1,14 @@
+package kr.kro.colla.exception.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ForbiddenException extends RuntimeException {
+    private HttpStatus statusCode;
+
+    public ForbiddenException(String message){
+        super(message);
+        this.statusCode = HttpStatus.FORBIDDEN;
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/NotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/NotFoundException.java
@@ -4,11 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class NotFoundException extends RuntimeException {
-    private HttpStatus statusCode;
+public class NotFoundException extends CustomException {
 
-    public NotFoundException(String message){
-        super(message);
-        this.statusCode = HttpStatus.NOT_FOUND;
-    }
+    public NotFoundException(String message) { super(HttpStatus.NOT_FOUND, message); }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/UnauthorizedException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package kr.kro.colla.exception.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedException extends CustomException {
+
+    public UnauthorizedException(String message) {
+        super(HttpStatus.UNAUTHORIZED, message);
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/InvalidTokenException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/InvalidTokenException.java
@@ -1,5 +1,7 @@
 package kr.kro.colla.exception.exception.auth;
 
+import kr.kro.colla.exception.exception.UnauthorizedException;
+
 public class InvalidTokenException extends UnauthorizedException {
 
     public InvalidTokenException() {

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/TokenNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/TokenNotFoundException.java
@@ -1,5 +1,7 @@
 package kr.kro.colla.exception.exception.auth;
 
+import kr.kro.colla.exception.exception.UnauthorizedException;
+
 public class TokenNotFoundException extends UnauthorizedException {
 
     public TokenNotFoundException() {

--- a/backend/src/main/java/kr/kro/colla/exception/exception/auth/UnauthorizedException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/auth/UnauthorizedException.java
@@ -1,8 +1,0 @@
-package kr.kro.colla.exception.exception.auth;
-
-public class UnauthorizedException extends RuntimeException {
-
-    public UnauthorizedException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeBadRequestException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeBadRequestException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.notice;
+
+import kr.kro.colla.exception.exception.BadRequestException;
+
+public class NoticeBadRequestException extends BadRequestException {
+
+    public NoticeBadRequestException() { super("알림을 생성할 수 없는 요청입니다. 요청 형식을 확인해주세요"); }
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/notice/NoticeNotFoundException.java
@@ -3,5 +3,6 @@ package kr.kro.colla.exception.exception.notice;
 import kr.kro.colla.exception.exception.NotFoundException;
 
 public class NoticeNotFoundException extends NotFoundException {
+
     public NoticeNotFoundException() { super("해당하는 알림를 찾을 수 없습니다."); }
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotManagerException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotManagerException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.user;
+
+import kr.kro.colla.exception.exception.ForbiddenException;
+
+public class UserNotManagerException extends ForbiddenException {
+
+    public UserNotManagerException() { super("해당 사용자의 권한으로 접근할 수 없습니다.");}
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -45,7 +45,7 @@ public class ProjectController {
     @PostMapping("/{projectId}/members/decision")
     public ResponseEntity decideInvitation(@Authenticated LoginUser loginUser,
                                            @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
-        Optional<ProjectMemberResponse> result = projectService.handleInvitationDecision(projectId, loginUser.getId(), projectMemberDecision.isAccept());
+        Optional<ProjectMemberResponse> result = projectService.handleInvitationDecision(projectId, loginUser.getId(), projectMemberDecision);
 
         return result.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(result.get());
 

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -50,15 +51,9 @@ public class ProjectController {
     @PostMapping("/{projectId}/members/decision")
     public ResponseEntity decideInvitation(@Authenticated LoginUser loginUser,
                                            @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
-        User user = userService.findUserById(loginUser.getId());
-        // user 알림 체크 및 읽음 처리
-        Project project = projectService.findProjectById(projectId);
+        Optional<ProjectMemberResponse> result = projectService.decideInvitation(projectId, loginUser.getId(), projectMemberDecision.isAccept());
 
-        if (projectMemberDecision.isAccept()){
-            UserProject userProject = userProjectService.joinProject(user, project);
-            return ResponseEntity.ok(new ProjectMemberResponse(userProject.getUser()));
-        }
-        return ResponseEntity.noContent().build();
+        return result.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(result.get());
 
     }
 

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -29,7 +29,6 @@ public class ProjectController {
 
     private final UserService userService;
     private final StoryService storyService;
-    private final NoticeService noticeService;
     private final ProjectService projectService;
     private final UserProjectService userProjectService;
 
@@ -43,16 +42,8 @@ public class ProjectController {
     @PostMapping("/{projectId}/members")
     public ResponseEntity inviteUser(@Authenticated LoginUser loginUser,
                                        @PathVariable long projectId, @Valid @RequestBody ProjectMemberRequest projectMemberRequest){
-        Project project = projectService.findProjectById(projectId);
-        User manager = userService.findUserById(loginUser.getId());
-        // manager 아닐 경우 예외처리
+        projectService.inviteUserToProject(projectId, loginUser.getId(), projectMemberRequest.getGithubId());
 
-        User user = userService.findByGithubId(projectMemberRequest.getGithubId());
-        CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
-                .noticeType(NoticeType.INVITE_USER)
-                .receiverId(user.getId())
-                .build();
-        noticeService.createNotice(createNoticeRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -2,18 +2,12 @@ package kr.kro.colla.project.project.presentation;
 
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
-import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.tag.domain.Tag;
-import kr.kro.colla.user.notice.domain.NoticeType;
-import kr.kro.colla.user.notice.service.NoticeService;
-import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
-import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
-import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -51,7 +45,7 @@ public class ProjectController {
     @PostMapping("/{projectId}/members/decision")
     public ResponseEntity decideInvitation(@Authenticated LoginUser loginUser,
                                            @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
-        Optional<ProjectMemberResponse> result = projectService.decideInvitation(projectId, loginUser.getId(), projectMemberDecision.isAccept());
+        Optional<ProjectMemberResponse> result = projectService.handleInvitationDecision(projectId, loginUser.getId(), projectMemberDecision.isAccept());
 
         return result.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(result.get());
 

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectMemberDecision.java
@@ -12,4 +12,7 @@ import javax.validation.constraints.NotNull;
 public class ProjectMemberDecision {
     @NotNull
     private boolean accept;
+
+    @NotNull
+    private Long noticeId;
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -10,6 +10,7 @@ import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
+import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.notice.service.NoticeService;
 import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
@@ -145,11 +146,14 @@ public class ProjectService {
         noticeService.createNotice(createNoticeRequest);
     }
 
-    public Optional<ProjectMemberResponse> handleInvitationDecision(long projectId, long loginUserId, boolean accept) {
+    public Optional<ProjectMemberResponse> handleInvitationDecision(long projectId, long loginUserId, ProjectMemberDecision projectMemberDecision) {
         User user = userService.findUserById(loginUserId);
         Project project = findProjectById(projectId);
 
-        if (accept) {
+        Notice notice = noticeService.findById(projectMemberDecision.getNoticeId());
+        notice.check();
+
+        if (projectMemberDecision.isAccept()) {
             UserProject userProject = userProjectService.joinProject(user, project);
             return Optional.of(new ProjectMemberResponse(userProject.getUser()));
         }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -132,8 +132,11 @@ public class ProjectService {
         }
 
         User user = userService.findByGithubId(memberGithubId);
+
         CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
                 .noticeType(NoticeType.INVITE_USER)
+                .projectId(projectId)
+                .projectName(project.getName())
                 .receiverId(user.getId())
                 .build();
         noticeService.createNotice(createNoticeRequest);

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -20,7 +20,6 @@ import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -146,7 +145,7 @@ public class ProjectService {
         noticeService.createNotice(createNoticeRequest);
     }
 
-    public Optional<ProjectMemberResponse> decideInvitation(long projectId, long loginUserId, boolean accept) {
+    public Optional<ProjectMemberResponse> handleInvitationDecision(long projectId, long loginUserId, boolean accept) {
         User user = userService.findUserById(loginUserId);
         Project project = findProjectById(projectId);
 

--- a/backend/src/main/java/kr/kro/colla/user/notice/domain/Notice.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/domain/Notice.java
@@ -21,18 +21,26 @@ public class Notice {
     @Enumerated(EnumType.ORDINAL)
     private NoticeType noticeType;
 
-    @Column
-    private String mentionedURL;
-
     @NotNull
     @Column
     private Boolean isChecked;
 
+    @Column
+    private String mentionedURL;
+
+    @Column
+    private Long projectId;
+
+    @Column
+    private String projectName;
+
     @Builder
-    public Notice(NoticeType noticeType, String mentionedURL){
+    public Notice(NoticeType noticeType, String mentionedURL, Long projectId, String projectName){
         this.isChecked = false;
         this.noticeType = noticeType;
         this.mentionedURL = mentionedURL;
+        this.projectId = projectId;
+        this.projectName = projectName;
     }
 
     public void check() { this.isChecked = true; }

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
@@ -22,30 +22,16 @@ import javax.transaction.Transactional;
 public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final UserService userService;
-    private final ProjectService projectService;
 
     public Notice createNotice(CreateNoticeRequest createNoticeRequest) {
         User user = userService.findUserById(createNoticeRequest.getReceiverId());
 
-        Notice notice;
-        switch (createNoticeRequest.getNoticeType()){
-            case INVITE_USER:
-                Project project = projectService.findProjectById(createNoticeRequest.getProjectId());
-                notice = Notice.builder()
-                        .noticeType(NoticeType.INVITE_USER)
-                        .projectId(project.getId())
-                        .projectName(project.getName())
-                        .build();
-                break;
-            case MENTION_USER:
-                notice = Notice.builder()
-                        .noticeType(NoticeType.MENTION_USER)
-                        .mentionedURL(createNoticeRequest.getMentionedURL())
-                        .build();
-                break;
-            default:
-                throw new NoticeBadRequestException();
-        }
+        Notice notice = Notice.builder()
+                .noticeType(createNoticeRequest.getNoticeType())
+                .mentionedURL(createNoticeRequest.getMentionedURL())
+                .projectId(createNoticeRequest.getProjectId())
+                .projectName(createNoticeRequest.getProjectName())
+                .build();
 
         Notice result = noticeRepository.save(notice);
         user.addNotice(result);

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/NoticeService.java
@@ -1,7 +1,11 @@
 package kr.kro.colla.user.notice.service;
 
+import kr.kro.colla.exception.exception.notice.NoticeBadRequestException;
 import kr.kro.colla.exception.exception.notice.NoticeNotFoundException;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.notice.domain.repository.NoticeRepository;
 import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
@@ -18,14 +22,30 @@ import javax.transaction.Transactional;
 public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final UserService userService;
+    private final ProjectService projectService;
 
     public Notice createNotice(CreateNoticeRequest createNoticeRequest) {
         User user = userService.findUserById(createNoticeRequest.getReceiverId());
 
-        Notice notice = Notice.builder()
-                .noticeType(createNoticeRequest.getNoticeType())
-                .mentionedURL(createNoticeRequest.getMentionedURL())
-                .build();
+        Notice notice;
+        switch (createNoticeRequest.getNoticeType()){
+            case INVITE_USER:
+                Project project = projectService.findProjectById(createNoticeRequest.getProjectId());
+                notice = Notice.builder()
+                        .noticeType(NoticeType.INVITE_USER)
+                        .projectId(project.getId())
+                        .projectName(project.getName())
+                        .build();
+                break;
+            case MENTION_USER:
+                notice = Notice.builder()
+                        .noticeType(NoticeType.MENTION_USER)
+                        .mentionedURL(createNoticeRequest.getMentionedURL())
+                        .build();
+                break;
+            default:
+                throw new NoticeBadRequestException();
+        }
 
         Notice result = noticeRepository.save(notice);
         user.addNotice(result);

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
@@ -18,6 +18,8 @@ public class CreateNoticeRequest {
 
     private Long projectId;
 
+    private String projectName;
+
     @NotNull
     private Long receiverId;
 }

--- a/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
+++ b/backend/src/main/java/kr/kro/colla/user/notice/service/dto/CreateNoticeRequest.java
@@ -16,6 +16,8 @@ public class CreateNoticeRequest {
 
     private String mentionedURL;
 
+    private Long projectId;
+
     @NotNull
     private Long receiverId;
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserNoticeResponse.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/dto/UserNoticeResponse.java
@@ -16,10 +16,16 @@ public class UserNoticeResponse {
 
     private Boolean isChecked;
 
+    private Long projectId;
+
+    private String projectName;
+
     public UserNoticeResponse(Notice notice){
         this.id = notice.getId();
         this.noticeType = notice.getNoticeType();
         this.mentionedURL = notice.getMentionedURL();
         this.isChecked = notice.getIsChecked();
+        this.projectId = notice.getProjectId();
+        this.projectName = notice.getProjectName();
     }
 }

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -187,10 +187,10 @@ class ProjectControllerTest {
     @Test
     void 사용자가_프로젝트_초대를_거절한다() throws Exception {
         // given
-        Long projectId = 123142L;
-        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(false);
+        Long projectId = 123142L, noticeId = 64232L;
+        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(false, noticeId);
 
-        given(projectService.handleInvitationDecision(projectId, loginUser.getId(), false))
+        given(projectService.handleInvitationDecision(eq(projectId), eq(loginUser.getId()), any(ProjectMemberDecision.class)))
                 .willReturn(Optional.empty());
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
@@ -200,14 +200,14 @@ class ProjectControllerTest {
         // then
         perform
                 .andExpect(status().isNoContent());
-        verify(projectService, times(1)).handleInvitationDecision(projectId, loginUser.getId(), false);
+        verify(projectService, times(1)).handleInvitationDecision(eq(projectId), eq(loginUser.getId()), any(ProjectMemberDecision.class));
     }
 
     @Test
     void 사용자가_프로젝트_초대를_수락한다() throws Exception {
         // given
-        Long projectId = 123142L, userId = loginUser.getId();
-        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(true);
+        Long projectId = 123142L, userId = loginUser.getId(), noticeId = 63452L;
+        ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(true, noticeId);
         User user = User.builder()
                 .name("random user name")
                 .avatar("random user avatar")
@@ -215,7 +215,7 @@ class ProjectControllerTest {
                 .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
-        given(projectService.handleInvitationDecision(projectId, loginUser.getId(), true))
+        given(projectService.handleInvitationDecision(eq(projectId), eq(loginUser.getId()), any(ProjectMemberDecision.class)))
                 .willReturn(Optional.of(new ProjectMemberResponse(user)));
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
@@ -229,7 +229,7 @@ class ProjectControllerTest {
                 .andExpect(jsonPath("$.name").value(user.getName()))
                 .andExpect(jsonPath("$.avatar").value(user.getAvatar()))
                 .andExpect(jsonPath("$.githubId").value(user.getGithubId()));
-        verify(projectService, times(1)).handleInvitationDecision(projectId, loginUser.getId(), true);
+        verify(projectService, times(1)).handleInvitationDecision(eq(projectId), eq(loginUser.getId()), any(ProjectMemberDecision.class));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -1,24 +1,19 @@
 package kr.kro.colla.project.project.presentation;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.service.AuthService;
 import kr.kro.colla.exception.exception.user.UserNotManagerException;
-import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.tag.domain.Tag;
-import kr.kro.colla.user.notice.service.NoticeService;
-import kr.kro.colla.user.notice.service.dto.CreateNoticeRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProfileResponse;
 import kr.kro.colla.user.user.service.UserService;
-import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
 import kr.kro.colla.utils.CookieManager;
 import org.junit.jupiter.api.BeforeEach;
@@ -195,7 +190,7 @@ class ProjectControllerTest {
         Long projectId = 123142L;
         ProjectMemberDecision projectMemberDecision = new ProjectMemberDecision(false);
 
-        given(projectService.decideInvitation(projectId, loginUser.getId(), false))
+        given(projectService.handleInvitationDecision(projectId, loginUser.getId(), false))
                 .willReturn(Optional.empty());
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
@@ -205,7 +200,7 @@ class ProjectControllerTest {
         // then
         perform
                 .andExpect(status().isNoContent());
-        verify(projectService, times(1)).decideInvitation(projectId, loginUser.getId(), false);
+        verify(projectService, times(1)).handleInvitationDecision(projectId, loginUser.getId(), false);
     }
 
     @Test
@@ -220,7 +215,7 @@ class ProjectControllerTest {
                 .build();
         ReflectionTestUtils.setField(user, "id", userId);
 
-        given(projectService.decideInvitation(projectId, loginUser.getId(), true))
+        given(projectService.handleInvitationDecision(projectId, loginUser.getId(), true))
                 .willReturn(Optional.of(new ProjectMemberResponse(user)));
         // when
         ResultActions perform = mockMvc.perform(post("/projects/" + projectId + "/members/decision")
@@ -234,7 +229,7 @@ class ProjectControllerTest {
                 .andExpect(jsonPath("$.name").value(user.getName()))
                 .andExpect(jsonPath("$.avatar").value(user.getAvatar()))
                 .andExpect(jsonPath("$.githubId").value(user.getGithubId()));
-        verify(projectService, times(1)).decideInvitation(projectId, loginUser.getId(), true);
+        verify(projectService, times(1)).handleInvitationDecision(projectId, loginUser.getId(), true);
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
@@ -42,8 +42,6 @@ public class NoticeServiceTest {
     @InjectMocks
     private NoticeService noticeService;
 
-    private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-
     @Test
     void 알림_생성에_성공한다() {
         // given

--- a/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/notice/service/NoticeServiceTest.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.user.notice.service;
 
 
+import kr.kro.colla.exception.exception.notice.NoticeNotFoundException;
 import kr.kro.colla.exception.exception.user.UserNotFoundException;
 import kr.kro.colla.user.notice.domain.Notice;
 import kr.kro.colla.user.notice.domain.NoticeType;
@@ -23,6 +24,7 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -45,10 +47,12 @@ public class NoticeServiceTest {
     @Test
     void 알림_생성에_성공한다() {
         // given
-        String mentionURL = "mention";
-        Long id = 123L, userId = 324L;
+        String mentionURL = "mention_url", projectName = "project_to_invite";
+        Long id = 123L, userId = 324L, projectId = 3456L;
         Notice notice = Notice.builder()
                 .noticeType(NoticeType.INVITE_USER)
+                .projectName(projectName)
+                .projectId(projectId)
                 .mentionedURL(mentionURL)
                 .build();
         User user = User.builder()
@@ -60,8 +64,10 @@ public class NoticeServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
         CreateNoticeRequest createNoticeRequest = CreateNoticeRequest.builder()
                 .noticeType(NoticeType.INVITE_USER)
-                .mentionedURL(mentionURL)
                 .receiverId(userId)
+                .projectName(projectName)
+                .projectId(projectId)
+                .mentionedURL(mentionURL)
                 .build();
 
         given(userService.findUserById(userId))
@@ -77,8 +83,47 @@ public class NoticeServiceTest {
         assertThat(result.getIsChecked()).isEqualTo(false);
         assertThat(result.getNoticeType()).isEqualTo(NoticeType.INVITE_USER);
         assertThat(result.getMentionedURL()).isEqualTo(mentionURL);
+        assertThat(result.getProjectId()).isEqualTo(projectId);
+        assertThat(result.getProjectName()).isEqualTo(projectName);
         assertThat(user.getNotices().size()).isEqualTo(1);
         verify(noticeRepository, times(1)).save(any(Notice.class));
     }
 
+    @Test
+    void 알림_조회에_성공한다() {
+        // given
+        Long noticeId = 76253L;
+        String mention = "path/asdfasf/mention/zxcvvv";
+        Notice notice = Notice.builder()
+                        .noticeType(NoticeType.MENTION_USER)
+                        .mentionedURL(mention)
+                        .build();
+        ReflectionTestUtils.setField(notice, "id", noticeId);
+
+        given(noticeRepository.findById(noticeId))
+                .willReturn(Optional.of(notice));
+        // when
+        Notice result = noticeService.findById(noticeId);
+
+        // then
+        assertThat(result.getId()).isEqualTo(notice.getId());
+        assertThat(result.getNoticeType()).isEqualTo(notice.getNoticeType());
+        assertThat(result.getMentionedURL()).isEqualTo(notice.getMentionedURL());
+        assertThat(result.getProjectId()).isEqualTo(notice.getProjectId());
+        verify(noticeRepository, times(1)).findById(noticeId);
+    }
+
+    @Test
+    void 존재하지_않는_알림_조회시_예외가_발생한다() {
+        // given
+        Long notFoundNoticeId = 122345L;
+
+        given(noticeRepository.findById(notFoundNoticeId))
+                .willThrow(NoticeNotFoundException.class);
+        // when
+        assertThatThrownBy(() -> {
+            noticeService.findById(notFoundNoticeId);
+        }).isInstanceOf(NoticeNotFoundException.class);
+
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -245,6 +245,8 @@ public class AcceptanceTest {
                 .build();
         CreateNoticeRequest createNoticeRequest2 = CreateNoticeRequest.builder()
                 .noticeType(NoticeType.INVITE_USER)
+                .projectName("test project name")
+                .projectId(2342421L)
                 .receiverId(user.getId())
                 .build();
 
@@ -276,6 +278,8 @@ public class AcceptanceTest {
                     assertThat(response.get(i).getNoticeType()).isEqualTo(notices.get(i).getNoticeType());
                     assertThat(response.get(i).getIsChecked()).isEqualTo(notices.get(i).getIsChecked());
                     assertThat(response.get(i).getMentionedURL()).isEqualTo(notices.get(i).getMentionedURL());
+                    assertThat(response.get(i).getProjectId()).isEqualTo(notices.get(i).getProjectId());
+                    assertThat(response.get(i).getProjectName()).isEqualTo(notices.get(i).getProjectName());
                 });
 
     }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -273,7 +273,7 @@ class UserControllerTest {
                 .andExpect(jsonPath("$[*].mentionedURL").value(containsInAnyOrder(notice1.getMentionedURL(), notice2.getMentionedURL(), notice3.getMentionedURL())))
                 .andExpect(jsonPath("$[*].isChecked").value(containsInAnyOrder(false, false, false)))
                 .andExpect(jsonPath("$[*].projectName").value(containsInAnyOrder(notice1.getProjectName(), notice2.getProjectName(), notice3.getProjectName())))
-                .andExpect(jsonPath("$[*].projectId").value(containsInAnyOrder(notice1.getProjectId().intValue(), notice2.getProjectId().intValue(), notice3.getProjectId().intValue())))
+                .andExpect(jsonPath("$[*].projectId").value(containsInAnyOrder(notice1.getProjectId().intValue(), notice2.getProjectId(), notice3.getProjectId().intValue())))
                 .andExpect(jsonPath("$.length()").value(3));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/presentation/UserControllerTest.java
@@ -236,10 +236,12 @@ class UserControllerTest {
     @Test
     void 사용자의_알림을_조회한다() throws Exception {
         // given
-        String mention = "mentioned_url";
-        Long noticeId1 = 62453L, noticeId2 = 7532L, noticeId3 = 54543L;
+        String mention = "mentioned_url", projectName1 = "random_1_project", projectName2 = "random_2_project";
+        Long noticeId1 = 62453L, noticeId2 = 7532L, noticeId3 = 54543L, projectId1 = 23465L, projectId2 = 134144L;
         Notice notice1 = Notice.builder()
                 .noticeType(NoticeType.INVITE_USER)
+                .projectName(projectName1)
+                .projectId(projectId1)
                 .build();
         ReflectionTestUtils.setField(notice1,"id", noticeId1);
         Notice notice2 = Notice.builder()
@@ -249,6 +251,8 @@ class UserControllerTest {
         ReflectionTestUtils.setField(notice2,"id", noticeId2);
         Notice notice3 = Notice.builder()
                 .noticeType(NoticeType.INVITE_USER)
+                .projectName(projectName2)
+                .projectId(projectId2)
                 .build();
         ReflectionTestUtils.setField(notice3,"id", noticeId3);
 
@@ -262,13 +266,14 @@ class UserControllerTest {
 
         // then
         MvcResult result = perform.andReturn();
-        System.out.println(result.getResponse().getContentAsString());
         perform
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[*].id").value(containsInAnyOrder(noticeId1.intValue(), noticeId2.intValue(), noticeId3.intValue())))
                 .andExpect(jsonPath("$[*].noticeType").value(containsInAnyOrder(notice1.getNoticeType().name(), notice2.getNoticeType().name(), notice3.getNoticeType().name())))
                 .andExpect(jsonPath("$[*].mentionedURL").value(containsInAnyOrder(notice1.getMentionedURL(), notice2.getMentionedURL(), notice3.getMentionedURL())))
                 .andExpect(jsonPath("$[*].isChecked").value(containsInAnyOrder(false, false, false)))
+                .andExpect(jsonPath("$[*].projectName").value(containsInAnyOrder(notice1.getProjectName(), notice2.getProjectName(), notice3.getProjectName())))
+                .andExpect(jsonPath("$[*].projectId").value(containsInAnyOrder(notice1.getProjectId().intValue(), notice2.getProjectId().intValue(), notice3.getProjectId().intValue())))
                 .andExpect(jsonPath("$.length()").value(3));
     }
 }

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -44,12 +44,11 @@ export const getProjectMembers = async (projectId: number) => {
     return response;
 };
 
-
 export const createTag = async (projectId: number, name: string) => {
     const response = await client.post(`/projects/${projectId}/tags`, { name });
-  
+
     return response;
-}
+};
 
 export const inviteUser = async (projectId: number, githubId: string) => {
     const response = await client.post(`/projects/${projectId}/members`, { githubId });
@@ -57,15 +56,14 @@ export const inviteUser = async (projectId: number, githubId: string) => {
     return response;
 };
 
-
 export const getProjectTags = async (projectId: number) => {
     const response = await client.get<Array<projectTags>>(`/projects/${projectId}/tags`);
 
     return response;
-}
+};
 
-export const decideInvitation = async (projectId: number, accept: boolean) => {
-    const response = await client.post(`/projects/${projectId}/members/decision`, { accept });
+export const decideInvitation = async (projectId: number, noticeId: number, accept: boolean) => {
+    const response = await client.post(`/projects/${projectId}/members/decision`, { accept, noticeId });
 
     return response;
 };

--- a/frontend/src/components/Modal/Invite/style.tsx
+++ b/frontend/src/components/Modal/Invite/style.tsx
@@ -1,16 +1,15 @@
 import styled from '@emotion/styled';
 import { GRAY, GREEN } from '../../../styles/color';
-import { Center, Column, Modal } from '../../../styles/common';
+import { Center, Column, Modal, WidthAround } from '../../../styles/common';
 
 export const Wrapper = styled.div`
     position: absolute;
     justify-content: space-around;
     width: 500px;
-    height: 300px;
     font-size: 20px;
     border-radius: 40px;
     background: ${GRAY};
-    padding: 40px 20px;
+    padding: 20px;
 
     top: 10px;
 
@@ -38,8 +37,10 @@ export const InviteButton = styled.button`
 `;
 
 export const Member = styled.div`
-    display: flex;
-    justify-content: space-around;
+    margin-top: 10px;
+    margin-bottom: 10px;
+
+    ${WidthAround}
 `;
 
 export const MemberInfo = styled.div`
@@ -66,6 +67,8 @@ export const ImageContainer = styled.div`
 
 export const MemberList = styled.div`
     overflow-y: scroll;
+    margin-top: 10px;
+    margin-bottom: 30px;
     &::-webkit-scrollbar {
         display: none;
     }

--- a/frontend/src/components/Modal/Notice/index.tsx
+++ b/frontend/src/components/Modal/Notice/index.tsx
@@ -7,24 +7,12 @@ import { getUserNotices } from '../../../apis/user';
 import { NoticeType } from '../../../types/user';
 import { Icon, Invitation, InvitationDecision, Notice, NoticeMessage, Wrapper } from './style';
 
-const dummyNotices = [
-    {
-        id: 12313,
-        noticeType: 'INVITE_USER',
-        isChecked: true,
-    },
-    {
-        id: 15313,
-        noticeType: 'MENTION_USER',
-        isChecked: false,
-        mentionedURL: '/home',
-    },
-];
 const NoticeModal = () => {
-    const [notices, setNotices] = useState<Array<NoticeType>>(dummyNotices);
+    const [notices, setNotices] = useState<Array<NoticeType>>([]);
 
     const handleNotices = async () => {
         const res = await getUserNotices();
+        console.log(res.data);
         setNotices(res.data);
     };
 
@@ -32,7 +20,7 @@ const NoticeModal = () => {
         let message;
         switch (notice.noticeType) {
             case 'INVITE_USER':
-                message = `${notice.projectId} 프로젝트로부터 초대 받았습니다.`;
+                message = `${notice.projectName} 프로젝트로부터 초대 받았습니다.`;
                 break;
             case 'MENTION_USER':
                 message = `${notice.mentionedURL}에서 언급되었습니다.`;

--- a/frontend/src/components/Modal/Notice/index.tsx
+++ b/frontend/src/components/Modal/Notice/index.tsx
@@ -10,10 +10,14 @@ import { Icon, Invitation, InvitationDecision, Notice, NoticeMessage, Wrapper } 
 const NoticeModal = () => {
     const [notices, setNotices] = useState<Array<NoticeType>>([]);
 
-    const handleNotices = async () => {
+    const updateNotices = async () => {
         const res = await getUserNotices();
-        console.log(res.data);
         setNotices(res.data);
+    };
+
+    const handleClick = async (notice: NoticeType, accept: boolean) => {
+        await decideInvitation(notice.projectId!, notice.id, accept);
+        await updateNotices();
     };
 
     const translateNotice = (notice: NoticeType) => {
@@ -37,12 +41,8 @@ const NoticeModal = () => {
                         <>
                             <div>{message}</div>
                             <Invitation>
-                                <InvitationDecision onClick={() => decideInvitation(notice.projectId!, true)}>
-                                    수락
-                                </InvitationDecision>
-                                <InvitationDecision onClick={() => decideInvitation(notice.projectId!, false)}>
-                                    거절
-                                </InvitationDecision>
+                                <InvitationDecision onClick={() => handleClick(notice, true)}>수락</InvitationDecision>
+                                <InvitationDecision onClick={() => handleClick(notice, false)}>거절</InvitationDecision>
                             </Invitation>
                         </>
                     ) : (
@@ -56,7 +56,7 @@ const NoticeModal = () => {
     };
 
     useEffect(() => {
-        handleNotices();
+        updateNotices();
     }, []);
 
     return <Wrapper>{notices.map((notice) => translateNotice(notice))}</Wrapper>;

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -10,4 +10,5 @@ export interface NoticeType {
     isChecked: boolean;
     mentionedURL?: string;
     projectId?: number;
+    projectName?: string;
 }


### PR DESCRIPTION
### 🔨 작업 내용 설명
백엔드의 알림에 프로젝트 정보를 추가해 (프로젝트 아이디, 프로젝트 이름)
프론트에서 알림 정보만으로 수락/거절 API 요청을 만들어낼 수 있도록 보완했습니다.

API 요청을 실행한 알림은 확인 처리되도록 추가 구현했습니다!

몇몇 검증도 추가했지만 아직 추가해야할 검증이 남아있습니다! 
(프로젝트 초대 수락시 기존 멤버인지, 해당 알림이 확인되지 않은 알림인지, 해당 프로젝트의 초대 알림인지 검증)

### 📑 구현한 내용 목록
- [x]  프로젝트 초대, 초대 수락/거절 로직 서비스 함수로 수정
- [x]  추가된 서비스 함수 테스트
- [x] 프로젝트 초대 API 매니저 검증 추가
- [x] 알림 객체에 프로젝트 관련 정보 추가
- [x] 프로젝트 초대 결정 API 알림 읽기 처리
- [ ] 프로젝트 초대 결정 API 알림 검증 추가
- [x] 추가된 검증 및 처리 테스트
- [x] UI와 프로젝트 초대 알림 연동

### 🚧 논의 사항

- 컨트롤러 단에 나와있던 로직들 프로젝트 서비스로 옮겨놓고, 테스트 추가했습니다!
 어떤 서비스의 역할인지는 아직 애매한 감이 있네요 🙄

- 프로젝트 멤버 정보를 `/kanban`에서 프로젝트 정보를 받아올 때 갱신하니
  알림으로 프로젝트 초대를 수락했을 때 바로 반영되지 않고 새로고침해야 반영됩니다.
  프로젝트 멤버를 멤버 조회로 모달 렌더링에 따라 갱신해야할까요? 아니면 다른 가능한 갱신 방법 있다면 이야기해주세요! 🙃

- close #67 
