### PR TITLE
[#74] feat: 태스크 조회 API 구현 및 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/AuthController.java
@@ -22,8 +22,8 @@ public class AuthController {
 
     @GetMapping("/login")
     public ResponseEntity githubLogin(@RequestParam String code) {
-        String accessToken = this.authService.githubLogin(code);
-        ResponseCookie cookie = this.cookieManager.createCookie("accessToken", accessToken);
+        String accessToken = authService.githubLogin(code);
+        ResponseCookie cookie = cookieManager.createCookie("accessToken", accessToken);
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
@@ -32,8 +32,8 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity logout(@Authenticated LoginUser loginUser, HttpServletResponse response) {
-        this.cookieManager.expireCookie(response, "accessToken");
-        this.authService.removeRefreshToken(loginUser.getId());
+        cookieManager.expireCookie(response, "accessToken");
+        authService.removeRefreshToken(loginUser.getId());
 
         return ResponseEntity.noContent()
                 .build();

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/argument_resolver/AuthArgumentResolver.java
@@ -29,6 +29,6 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String accessToken = (String) request.getAttribute("accessToken");
 
-        return this.authService.findUserFromToken(accessToken);
+        return authService.findUserFromToken(accessToken);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/kr/kro/colla/auth/presentation/interceptor/AuthInterceptor.java
@@ -25,17 +25,17 @@ public class AuthInterceptor implements HandlerInterceptor {
         }
 
         Cookie[] cookies = request.getCookies();
-        Cookie accessToken = this.cookieManager.parseCookies(cookies, "accessToken");
+        Cookie accessToken = cookieManager.parseCookies(cookies, "accessToken");
 
         if(accessToken == null) {
             throw new TokenNotFoundException();
         }
 
-        boolean isValid = this.authService.validateAccessToken(accessToken.getValue());
+        boolean isValid = authService.validateAccessToken(accessToken.getValue());
 
         if(!isValid) {
-            String newAccessToken = this.authService.validateRefreshToken(accessToken.getValue());
-            ResponseCookie cookie = this.cookieManager.createCookie("accessToken", newAccessToken);
+            String newAccessToken = authService.validateRefreshToken(accessToken.getValue());
+            ResponseCookie cookie = cookieManager.createCookie("accessToken", newAccessToken);
 
             response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
             accessToken.setValue(newAccessToken);

--- a/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
+++ b/backend/src/main/java/kr/kro/colla/auth/service/AuthService.java
@@ -24,39 +24,39 @@ public class AuthService {
     private final RedisManager redisManager;
 
     public String githubLogin(String code) {
-        String oAuthAccessToken = this.githubOAuthManager.getOAuthAccessToken(code);
-        GithubUserProfileResponse userProfile = this.githubOAuthManager.getUserProfile(oAuthAccessToken);
+        String oAuthAccessToken = githubOAuthManager.getOAuthAccessToken(code);
+        GithubUserProfileResponse userProfile = githubOAuthManager.getUserProfile(oAuthAccessToken);
 
-        User user = this.userService.createOrUpdateUser(userProfile);
-        CreateTokenResponse createTokenResponse = this.jwtProvider.createTokens(user.getId());
-        this.redisManager.saveRefreshToken(user.getId(), createTokenResponse.getRefreshToken());
+        User user = userService.createOrUpdateUser(userProfile);
+        CreateTokenResponse createTokenResponse = jwtProvider.createTokens(user.getId());
+        redisManager.saveRefreshToken(user.getId(), createTokenResponse.getRefreshToken());
 
         return createTokenResponse.getAccessToken();
     }
 
     public boolean validateAccessToken(String accessToken) {
-        return this.jwtProvider.validateToken(accessToken);
+        return jwtProvider.validateToken(accessToken);
     }
 
     public String validateRefreshToken(String accessToken) {
-        Long id = this.jwtProvider.findIdFromToken(accessToken);
-        String refreshToken = this.redisManager.findValue(id.toString());
-        boolean isValid = this.jwtProvider.validateToken(refreshToken);
+        Long id = jwtProvider.findIdFromToken(accessToken);
+        String refreshToken = redisManager.findValue(id.toString());
+        boolean isValid = jwtProvider.validateToken(refreshToken);
 
         if(!isValid) {
             throw new InvalidTokenException();
         }
 
-        return this.jwtProvider.createAccessToken(id);
+        return jwtProvider.createAccessToken(id);
     }
 
     public LoginUser findUserFromToken(String token) {
-        Long id = this.jwtProvider.findIdFromToken(token);
+        Long id = jwtProvider.findIdFromToken(token);
         return new LoginUser(id);
     }
 
     public void removeRefreshToken(Long id) {
-        this.redisManager.removeRefreshToken(id);
+        redisManager.removeRefreshToken(id);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/exception/exception/task/TaskNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/task/TaskNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.kro.colla.exception.exception.task;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class TaskNotFoundException extends NotFoundException {
+
+    public TaskNotFoundException() {
+        super("해당하는 태스크를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/profile/ProjectProfileStorage.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/profile/ProjectProfileStorage.java
@@ -4,5 +4,5 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface ProjectProfileStorage {
 
-    public String upload(MultipartFile file);
+    String upload(MultipartFile file);
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -23,7 +23,7 @@ public class ProjectController {
     private final ProjectService projectService;
 
     @GetMapping("/{projectId}")
-    public ResponseEntity<ProjectResponse> getProject(@PathVariable long projectId) {
+    public ResponseEntity<ProjectResponse> getProject(@PathVariable Long projectId) {
         ProjectResponse projectResponse = projectService.getProject(projectId);
 
         return ResponseEntity.ok(projectResponse);
@@ -31,7 +31,7 @@ public class ProjectController {
 
     @PostMapping("/{projectId}/members")
     public ResponseEntity inviteUser(@Authenticated LoginUser loginUser,
-                                       @PathVariable long projectId, @Valid @RequestBody ProjectMemberRequest projectMemberRequest){
+                                       @PathVariable Long projectId, @Valid @RequestBody ProjectMemberRequest projectMemberRequest){
         projectService.inviteUserToProject(projectId, loginUser.getId(), projectMemberRequest.getGithubId());
 
         return ResponseEntity.ok().build();
@@ -39,7 +39,7 @@ public class ProjectController {
 
     @PostMapping("/{projectId}/members/decision")
     public ResponseEntity decideInvitation(@Authenticated LoginUser loginUser,
-                                           @PathVariable long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
+                                           @PathVariable Long projectId, @Valid @RequestBody ProjectMemberDecision projectMemberDecision){
         ProjectMemberResponse projectMemberResponse = projectService.decideInvitation(projectId, loginUser.getId(), projectMemberDecision);
 
         return ResponseEntity.ok(projectMemberResponse);

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -134,9 +134,8 @@ public class ProjectService {
 
     public ProjectMemberResponse decideInvitation(Long projectId, Long loginUserId, ProjectMemberDecision projectMemberDecision) {
         Project project = findProjectById(projectId);
-        ProjectMemberResponse projectMemberResponse = noticeService.decideInvitation(loginUserId, project, projectMemberDecision);
 
-        return projectMemberResponse;
+        return noticeService.decideInvitation(loginUserId, project, projectMemberDecision);
     }
 
     public Project findProjectById(Long projectId) {

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepository.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/repository/TaskStatusRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface TaskStatusRepository extends JpaRepository<TaskStatus, Long> {
 
-    public Optional<TaskStatus> findByName(String name);
+    Optional<TaskStatus> findByName(String name);
 
 }

--- a/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
+++ b/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
@@ -7,6 +7,6 @@ import java.util.Optional;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
-    public Optional<Story> findByTitle(String title);
+    Optional<Story> findByTitle(String title);
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -6,6 +6,7 @@ import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.history.domain.History;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EntityListeners(EntityListeners.class)
 @Entity

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -1,10 +1,13 @@
 package kr.kro.colla.task.task.presentation;
 
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
 import kr.kro.colla.task.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -25,6 +28,13 @@ public class TaskController {
 
         return ResponseEntity.created(redirectUrl)
                 .build();
+    }
+
+    @GetMapping("/{taskId}")
+    public ResponseEntity<ProjectTaskResponse> getTask(@PathVariable Long taskId) {
+        ProjectTaskResponse projectTaskResponse = taskService.getTask(taskId);
+
+        return ResponseEntity.ok(projectTaskResponse);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskResponse.java
@@ -1,0 +1,30 @@
+package kr.kro.colla.task.task.presentation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ProjectTaskResponse {
+
+    private Long id;
+
+    private String manager;
+
+    private String title;
+
+    private String description;
+
+    private String story;
+
+    private String preTasks;
+
+    private Integer priority;
+
+    private String status;
+
+    private List<String> tags;
+
+}

--- a/backend/src/main/java/kr/kro/colla/user/user/domain/repository/UserRepository.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/domain/repository/UserRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    public Optional<User> findByGithubId(String githubId);
+    Optional<User> findByGithubId(String githubId);
 }

--- a/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/presentation/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
 
     @GetMapping("/profile")
     public ResponseEntity<UserProfileResponse> getUserProfile(@Authenticated LoginUser loginUser) {
-        User user = this.userService.findUserById(loginUser.getId());
+        User user = userService.findUserById(loginUser.getId());
 
         return ResponseEntity.ok(new UserProfileResponse(user));
     }
@@ -34,7 +34,7 @@ public class UserController {
             @Authenticated LoginUser loginUser,
             @RequestBody UpdateUserNameRequest updateUserNameRequest
     ) {
-        String updatedName = this.userService.updateDisplayName(loginUser.getId(), updateUserNameRequest.getName());
+        String updatedName = userService.updateDisplayName(loginUser.getId(), updateUserNameRequest.getName());
 
         return ResponseEntity.ok(new UpdateUserNameResponse(updatedName));
     }

--- a/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
+++ b/backend/src/main/java/kr/kro/colla/user/user/service/UserService.java
@@ -21,7 +21,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     public String updateDisplayName(Long id, String displayName) {
-        User user = this.userRepository.findById(id)
+        User user = userRepository.findById(id)
                 .orElseThrow(UserNotFoundException::new);
         user.changeDisplayName(displayName);
 
@@ -29,9 +29,9 @@ public class UserService {
     }
 
     public User createOrUpdateUser(GithubUserProfileResponse userProfile) {
-        return this.userRepository.findByGithubId(userProfile.getGithubId())
+        return userRepository.findByGithubId(userProfile.getGithubId())
                 .map(user -> user.changeProfile(userProfile))
-                .orElseGet(() -> this.userRepository.save(
+                .orElseGet(() -> userRepository.save(
                                 User.builder()
                                         .name(userProfile.getName())
                                         .githubId(userProfile.getGithubId())

--- a/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
@@ -1,0 +1,25 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectProvider {
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    public Project 를_생성한다(Long managerId) {
+        Project project = Project.builder()
+                .managerId(managerId)
+                .name("project name")
+                .description("project description")
+                .thumbnail("s3_content")
+                .build();
+
+        return projectRepository.save(project);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
@@ -1,0 +1,25 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.story.domain.repository.StoryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoryProvider {
+
+    @Autowired
+    private StoryRepository storyRepository;
+
+    public Story 를_생성한다(Project project) {
+        Story story = Story.builder()
+                .title("story title")
+                .preStories("[]")
+                .project(project)
+                .build();
+
+        return storyRepository.save(story);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -1,0 +1,32 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskProvider {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    public Task 를_생성한다(Long managerId, Project project, Story story) {
+        Task task = Task.builder()
+                .title("task title")
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(project.getTaskStatuses().get(0))
+                .story(story)
+                .preTasks("[]")
+                .build();
+
+        return taskRepository.save(task);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
@@ -1,0 +1,24 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserProvider {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public User 가_회원가입을_한다() {
+        User user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("s3_content")
+                .build();
+
+        return userRepository.save(user);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -3,14 +3,11 @@ package kr.kro.colla.task.task;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
-import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.common.fixture.*;
 import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.domain.repository.ProjectRepository;
-import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
-import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import kr.kro.colla.story.domain.Story;
+import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.user.user.domain.User;
-import kr.kro.colla.user.user.domain.repository.UserRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +21,7 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -36,57 +34,37 @@ public class AcceptanceTest {
     private JwtProvider jwtProvider;
 
     @Autowired
-    private UserRepository userRepository;
+    private UserProvider user;
 
     @Autowired
-    private ProjectRepository projectRepository;
+    private ProjectProvider project;
 
     @Autowired
-    private TaskRepository taskRepository;
+    private StoryProvider story;
+
+    @Autowired
+    private TaskProvider task;
 
     private Auth auth;
-    private User user;
-    private Project project;
-    private String accessToken;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
         auth = new Auth(jwtProvider);
-
-        user = User.builder()
-                .name("yeongkee")
-                .githubId("kykapple")
-                .avatar("s3_content")
-                .build();
-        userRepository.save(user);
-
-        project = Project.builder()
-                .managerId(user.getId())
-                .name("project name")
-                .description("project description")
-                .thumbnail("s3_content")
-                .build();
-        projectRepository.save(project);
-
-        accessToken = auth.로그인(user.getId());
-    }
-
-    @AfterEach
-    void rollback() {
-        taskRepository.deleteAll();
-        projectRepository.deleteAll();
-        userRepository.deleteAll();
     }
 
     @Test
     void 사용자가_프로젝트에_새로운_태스크를_추가한다() {
         // given
+        User registeredUser = user.가_회원가입을_한다();
+        String accessToken = auth.로그인(registeredUser.getId());
+        Project createdProject = project.를_생성한다(registeredUser.getId());
+
         Map<String, String> formData = new HashMap<>();
         formData.put("title", "task title");
         formData.put("priority", "3");
         formData.put("status", "To Do");
-        formData.put("projectId", project.getId().toString());
+        formData.put("projectId", createdProject.getId().toString());
 
         given()
                 .contentType(ContentType.URLENC)
@@ -105,6 +83,9 @@ public class AcceptanceTest {
     @Test
     void 태스크_생성_시_필요한_데이터가_없을_경우_예외가_발생한다() {
         // given
+        User registeredUser = user.가_회원가입을_한다();
+        String accessToken = auth.로그인(registeredUser.getId());
+
         Map<String, String> formData = new HashMap<>();
         formData.put("title", "task title");
         formData.put("priority", "3");
@@ -123,6 +104,58 @@ public class AcceptanceTest {
         .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("message", equalTo("projectId : 널이어서는 안됩니다"));
+    }
+
+    @Test
+    void 사용자가_프로젝트에_속한_태스크를_조회한다() {
+        // given
+        User registeredUser = user.가_회원가입을_한다();
+        String accessToken = auth.로그인(registeredUser.getId());
+        Project createdProject = project.를_생성한다(registeredUser.getId());
+        Story createdStory = story.를_생성한다(createdProject);
+        Task createdTask = task.를_생성한다(registeredUser.getId(), createdProject, createdStory);
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/tasks/" + createdTask.getId())
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("title", equalTo(createdTask.getTitle()))
+                .body("description", equalTo(createdTask.getDescription()))
+                .body("manager", equalTo(registeredUser.getName()))
+                .body("story", equalTo(createdStory.getTitle()))
+                .body("status", equalTo(createdTask.getTaskStatus().getName()))
+                .body("priority", equalTo(createdTask.getPriority()));
+    }
+
+    @Test
+    void 사용자가_담당자와_스토리가_없는_태스크를_조회한다() {
+        // given
+        User registeredUser = user.가_회원가입을_한다();
+        String accessToken = auth.로그인(registeredUser.getId());
+        Project createdProject = project.를_생성한다(registeredUser.getId());
+        Task createdTask = task.를_생성한다(null, createdProject, null);
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/tasks/" + createdTask.getId())
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("title", equalTo(createdTask.getTitle()))
+                .body("manager", nullValue())
+                .body("story", nullValue());
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.task.task.domain.repository;
 
 import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
+import kr.kro.colla.exception.exception.task.TaskNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
@@ -12,6 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @DataJpaTest
@@ -52,6 +54,41 @@ class TaskRepositoryTest {
         assertThat(result.getTitle()).isEqualTo(task.getTitle());
         assertThat(result.getTaskStatus().getName()).isEqualTo("To Do");
         assertThat(result.getProject().getName()).isEqualTo(project.getName());
+    }
+
+    @Test
+    void 프로젝트의_태스크를_조회한다() {
+        // given
+        Project project = Project.builder()
+                .name("collaboration")
+                .description("collaboration tool")
+                .managerId(1L)
+                .build();
+        projectRepository.save(project);
+
+        Task task = Task.builder()
+                .title("task title")
+                .description("task description")
+                .project(project)
+                .build();
+        taskRepository.save(task);
+
+        // when
+        Task result = taskRepository.findById(task.getId())
+                .orElseThrow(TaskNotFoundException::new);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo(task.getTitle());
+        assertThat(result.getDescription()).isEqualTo(task.getDescription());
+    }
+
+    @Test
+    void 존재하지_않는_태스크를_조회할_경우_예외가_발생한다() {
+        // when, then
+        assertThatThrownBy(
+                () -> taskRepository.findById(100L)
+                        .orElseThrow(TaskNotFoundException::new)
+        ).isInstanceOf(TaskNotFoundException.class);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.task.task.presentation;
 
 import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpHeaders;
@@ -11,10 +12,15 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(TaskController.class)
@@ -29,7 +35,7 @@ class TaskControllerTest extends ControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(post("/projects/tasks")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .param("title", "task title")
                 .param("priority", "3")
@@ -41,6 +47,40 @@ class TaskControllerTest extends ControllerTest {
 
         perform.andExpect(status().isCreated());
         assertThat(result.getResponse().getHeader(HttpHeaders.LOCATION)).isEqualTo("/api/projects/tasks/" + taskId);
+    }
+
+    @Test
+    void 프로젝트에_속한_태스크를_조회한다() throws Exception {
+        // given
+        Long taskId = 1L;
+        ProjectTaskResponse projectTaskResponse = ProjectTaskResponse.builder()
+                .id(taskId)
+                .title("task title")
+                .description("task description")
+                .story("user can login with github")
+                .preTasks("[]")
+                .manager("kykapple")
+                .status("In Progress")
+                .priority(4)
+                .tags(List.of("backend", "frontend"))
+                .build();
+
+        given(taskService.getTask(eq(taskId)))
+                .willReturn(projectTaskResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/tasks/" + taskId)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value(projectTaskResponse.getTitle()))
+                .andExpect(jsonPath("$.description").value(projectTaskResponse.getDescription()))
+                .andExpect(jsonPath("$.status").value(projectTaskResponse.getStatus()))
+                .andExpect(jsonPath("$.priority").exists())
+                .andExpect(jsonPath("$.tags").isArray());
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -9,7 +9,10 @@ import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.service.UserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -17,15 +20,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TaskServiceTest {
+
+    @Mock
+    private UserService userService;
 
     @Mock
     private StoryService storyService;
@@ -91,6 +98,84 @@ class TaskServiceTest {
         verify(taskStatusService, times(1)).findTaskStatusByName(taskStatusName);
         verify(taskTagService, times(1)).setTaskTag(any(Task.class), anyString());
         verify(taskRepository, times(1)).save(any(Task.class));
+    }
+
+    @Test
+    void 프로젝트의_태스크를_조회한다() {
+        // given
+        Long taskId = 1L, managerId = 5L;
+        User user = User.builder()
+                .name("yeongkee")
+                .githubId("kykapple")
+                .avatar("s3_content")
+                .build();
+        Project project = Project.builder()
+                .name("collaboration")
+                .description("collaboration tool")
+                .build();
+        Story story = Story.builder()
+                .title("user can login with github")
+                .preStories("[]")
+                .project(project)
+                .build();
+        Task task = Task.builder()
+                .title("task title")
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(new TaskStatus("In Progress"))
+                .story(story)
+                .preTasks("[]")
+                .build();
+        ReflectionTestUtils.setField(task, "id", taskId);
+
+        given(taskRepository.findById(eq(taskId)))
+                .willReturn(Optional.of(task));
+        given(userService.findUserById(eq(managerId)))
+                .willReturn(user);
+
+        // when
+        ProjectTaskResponse projectTaskResponse = taskService.getTask(taskId);
+
+        // then
+        assertThat(projectTaskResponse.getId()).isEqualTo(taskId);
+        assertThat(projectTaskResponse.getTitle()).isEqualTo(task.getTitle());
+        assertThat(projectTaskResponse.getStory()).isEqualTo(story.getTitle());
+        assertThat(projectTaskResponse.getManager()).isEqualTo(user.getName());
+        verify(taskRepository, times(1)).findById(anyLong());
+        verify(userService, times(1)).findUserById(anyLong());
+    }
+
+    @Test
+    void 담당자와_스토리가_없는_태스크를_조회한다() {
+        // given
+        Long taskId = 1L;
+        Project project = Project.builder()
+                .name("collaboration")
+                .description("collaboration tool")
+                .build();
+        Task task = Task.builder()
+                .title("task title")
+                .managerId(null)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(new TaskStatus("In Progress"))
+                .story(null)
+                .preTasks("[]")
+                .build();
+        ReflectionTestUtils.setField(task, "id", taskId);
+
+        given(taskRepository.findById(eq(taskId)))
+                .willReturn(Optional.of(task));
+
+        // when
+        ProjectTaskResponse projectTaskResponse = taskService.getTask(taskId);
+
+        // then
+        assertThat(projectTaskResponse.getManager()).isNull();
+        assertThat(projectTaskResponse.getStory()).isNull();
     }
 
 }

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -1,9 +1,16 @@
+import { TaskResponseType } from '../types/task';
 import { client } from './common';
 
 export const createTask = async (data: FormData) => {
     const response = await client.post(`/projects/tasks`, data, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     });
+
+    return response;
+};
+
+export const getTask = async (taskId: number) => {
+    const response = await client.get<TaskResponseType>(`/projects/tasks/${taskId}`);
 
     return response;
 };

--- a/frontend/src/components/KanbanCol/index.tsx
+++ b/frontend/src/components/KanbanCol/index.tsx
@@ -1,7 +1,8 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { useDrop } from 'react-dnd';
 
 import PlusIconSrc from '../../../public/assets/images/plus-circle.svg';
+import useInputTask from '../../hooks/useInputTask';
 import useModal from '../../hooks/useModal';
 import { ItemType, TaskType } from '../../types/kanban';
 import { TaskModal } from '../Modal/Task';
@@ -17,6 +18,8 @@ interface PropType {
 }
 
 const KanbanCol: FC<PropType> = ({ status, taskList, tasks, changeColumn, moveTaskHandler }) => {
+    const { clearInputTask } = useInputTask();
+    const [taskId, setTaskId] = useState<number | null>(null);
     const { Modal, setModal } = useModal();
     const [, drop] = useDrop({
         accept: 'task_type',
@@ -32,22 +35,39 @@ const KanbanCol: FC<PropType> = ({ status, taskList, tasks, changeColumn, moveTa
         },
     });
 
+    const showCreateTaskModal = (event: React.MouseEvent) => {
+        clearInputTask();
+        setTaskId(null);
+        setModal(event);
+    };
+
+    const showTask = (event: React.MouseEvent, selectedId: number) => {
+        setTaskId(selectedId);
+        setModal(event);
+    };
+
     return (
         <>
             <Wrapper>
                 <KanbanStatus>{status}</KanbanStatus>
                 <KanbanIssue ref={drop}>
                     {tasks.map((task) => (
-                        <Task key={task.id} task={task} changeColumn={changeColumn} moveHandler={moveTaskHandler} />
+                        <Task
+                            key={task.id}
+                            task={task}
+                            changeColumn={changeColumn}
+                            moveHandler={moveTaskHandler}
+                            showTask={showTask}
+                        />
                     ))}
-                    <AddTaskButton onClick={setModal}>
+                    <AddTaskButton onClick={(event) => showCreateTaskModal(event)}>
                         <PlusIcon src={PlusIconSrc} />
                         새로 만들기
                     </AddTaskButton>
                 </KanbanIssue>
             </Wrapper>
             <Modal>
-                <TaskModal status={status} taskList={taskList} hideModal={setModal} />
+                <TaskModal taskId={taskId} status={status} taskList={taskList} hideModal={setModal} />
             </Modal>
         </>
     );

--- a/frontend/src/components/Modal/Task/Detail/index.tsx
+++ b/frontend/src/components/Modal/Task/Detail/index.tsx
@@ -16,7 +16,7 @@ interface PropType {
 export const DetailInfoContainer: FC<PropType> = ({ status, detailInfoInput }) => {
     const { taskInput, handleChangeManagerId, handleChangeStatus, handleChangePriority, handleSelectTag } =
         detailInfoInput;
-    const { priority, selectedTags } = taskInput;
+    const { managerId, priority, selectedTags } = taskInput;
     const [manager, setManager] = useState('');
     const [memberVisible, setMemberVisible] = useState(false);
 
@@ -27,6 +27,12 @@ export const DetailInfoContainer: FC<PropType> = ({ status, detailInfoInput }) =
     useEffect(() => {
         handleChangeStatus(status);
     }, []);
+
+    useEffect(() => {
+        if (!parseInt(managerId, 10)) {
+            setManager(managerId);
+        }
+    }, [managerId]);
 
     return (
         <>

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -1,5 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
+import { getTask } from '../../../apis/task';
 import useInputTask from '../../../hooks/useInputTask';
 import { TaskType } from '../../../types/kanban';
 import { BasicInfoContainer } from './Basic';
@@ -7,13 +8,25 @@ import { DetailInfoContainer } from './Detail';
 import { Container, ModalContainer, CancelButton, CompleteButton, ButtonContainer } from './style';
 
 interface PropType {
+    taskId: number | null;
     status: string;
     taskList: TaskType[];
     hideModal: Function;
 }
 
-export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
-    const { basicInfoInput, detailInfoInput, handleCompleteButton } = useInputTask();
+export const TaskModal: FC<PropType> = ({ taskId, status, taskList, hideModal }) => {
+    const { basicInfoInput, detailInfoInput, handleCompleteButton, setSelectedTask } = useInputTask();
+
+    useEffect(() => {
+        if (!taskId) {
+            return;
+        }
+
+        (async () => {
+            const res = await getTask(taskId);
+            setSelectedTask(res.data);
+        })();
+    }, []);
 
     return (
         <ModalContainer>
@@ -23,7 +36,7 @@ export const TaskModal: FC<PropType> = ({ status, taskList, hideModal }) => {
             </Container>
             <ButtonContainer>
                 <CancelButton onClick={() => hideModal()}>취소</CancelButton>
-                <CompleteButton onClick={handleCompleteButton}>완료</CompleteButton>
+                <CompleteButton onClick={handleCompleteButton}>{taskId ? '수정' : '완료'}</CompleteButton>
             </ButtonContainer>
         </ModalContainer>
     );

--- a/frontend/src/components/Task/index.tsx
+++ b/frontend/src/components/Task/index.tsx
@@ -9,10 +9,13 @@ interface PropType {
     task: TaskType;
     changeColumn: Function;
     moveHandler: Function;
+    showTask: Function;
 }
 
-const Task: FC<PropType> = ({ task, changeColumn, moveHandler }) => {
+const Task: FC<PropType> = ({ task, changeColumn, moveHandler, showTask }) => {
     const { id, title, managerName, avatar, priority, index } = task;
+    const ref = useRef<HTMLDivElement>(null);
+
     const [{ isDragging }, drag] = useDrag({
         type: 'task_type',
         item: { id, index, name: 'task', type: 'task_type' },
@@ -26,8 +29,6 @@ const Task: FC<PropType> = ({ task, changeColumn, moveHandler }) => {
             }
         },
     });
-
-    const ref = useRef<HTMLDivElement>(null);
 
     const [, drop] = useDrop({
         accept: 'task_type',
@@ -65,7 +66,7 @@ const Task: FC<PropType> = ({ task, changeColumn, moveHandler }) => {
     const opacity = isDragging ? 0.4 : 1;
 
     return (
-        <Wrapper ref={ref} style={{ opacity }}>
+        <Wrapper ref={ref} style={{ opacity }} onClick={(event) => showTask(event, id)}>
             <Title>
                 <TaskTitle>{title}</TaskTitle>
                 <Priority>

--- a/frontend/src/components/Task/style.ts
+++ b/frontend/src/components/Task/style.ts
@@ -11,6 +11,7 @@ export const Wrapper = styled.div`
     border-radius: 10px;
     margin: 10px 10px;
     padding: 15px;
+    cursor: pointer;
 `;
 
 export const Title = styled.div`

--- a/frontend/src/hooks/useInputTask.ts
+++ b/frontend/src/hooks/useInputTask.ts
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { createTask } from '../apis/task';
 import { projectState } from '../stores/projectState';
-import { TaskInputType } from '../types/task';
+import { TaskInputType, TaskResponseType } from '../types/task';
 
 const useInputTask = () => {
     const project = useRecoilValue(projectState);
@@ -71,6 +71,33 @@ const useInputTask = () => {
         setTaskInput({ ...taskInput, selectedTags: newSelectedTags });
     };
 
+    const setSelectedTask = (task: TaskResponseType) => {
+        const { title, description, story, preTasks, manager, status, priority, tags } = task;
+        setTaskInput({
+            title,
+            description,
+            story,
+            preTasks: JSON.parse(preTasks),
+            managerId: manager,
+            status,
+            priority,
+            selectedTags: tags,
+        });
+    };
+
+    const clearInputTask = () => {
+        setTaskInput({
+            title: '',
+            description: '',
+            managerId: '',
+            priority: 5,
+            status: '',
+            selectedTags: [],
+            story: '',
+            preTasks: [],
+        });
+    };
+
     return {
         basicInfoInput: {
             taskInput,
@@ -88,6 +115,8 @@ const useInputTask = () => {
             handleSelectTag,
         },
         handleCompleteButton,
+        setSelectedTask,
+        clearInputTask,
     };
 };
 

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -25,3 +25,14 @@ export interface DetailInputType {
     handleChangePriority: Function;
     handleSelectTag: Function;
 }
+
+export interface TaskResponseType {
+    title: string;
+    description: string;
+    manager: string;
+    priority: number;
+    status: string;
+    tags: Array<string>;
+    story: string;
+    preTasks: string;
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 태스크 조회 API 구현
- 태스크 조회 API 테스크 코드 작성
- API 연동

### 📑 구현한 내용 목록
- [x] 태스크 조회 API 구현
- [x] 태스크 조회 API 테스크 코드 작성
- [x] API 연동

### 🚧 논의 사항
- 칸반 보드에서 태스크 클릭 시 동일한 모달창에 데이터가 채워지도록 구현하였습니다.
- AcceptanceTest를 진행하다 보니 given절에서 사용하는 fixture가 너무 많이 중복되어 아래와 같이 provider로 빼보았는데, 괜찮은지 의견 부탁드립니다! 괜찮다면 리팩토링 진행하도록 하겠습니다!

**common/fixture/ProjectProvider.java**
```
@Component
public class ProjectProvider {

    @Autowired
    private ProjectRepository projectRepository;

    public Project 를_생성한다(Long managerId) {
        Project project = Project.builder()
                .managerId(managerId)
                .name("project name")
                .description("project description")
                .thumbnail("s3_content")
                .build();

        return projectRepository.save(project);
    }

}
```
**실제 사용 인수 테스트**
```
@Test
    void 사용자가_프로젝트에_새로운_태스크를_추가한다() {
        // given
        User registeredUser = user.가_회원가입을_한다();
        String accessToken = auth.로그인(registeredUser.getId());
        Project createdProject = project.를_생성한다(registeredUser.getId());

        Map<String, String> formData = new HashMap<>();
        formData.put("title", "task title");
        formData.put("priority", "3");
        formData.put("status", "To Do");
        formData.put("projectId", createdProject.getId().toString());

        given()
                .contentType(ContentType.URLENC)
                .cookie("accessToken", accessToken)
                .formParams(formData)

        // when
        .when()
                .post("/api/projects/tasks")

        // then
        .then()
                .statusCode(HttpStatus.CREATED.value());
    }
```
- @beforeEach를 걷어낸 이유는 테스트 fixture에 대해 제대로 이해하고 있지 못한 것 같아서 [테스트 픽스처 올바르게 사용하기](https://jojoldu.tistory.com/611) 를 보고 수정해보았습니다..!

- #74
