### PR TITLE
[#75] feat: 프로젝트 테스크 상태값 추가 삭제 API 구현 및 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -88,4 +88,11 @@ public class ProjectController {
 
         return ResponseEntity.ok(new ProjectTaskStatusResponse(taskStatus));
     }
+
+    @DeleteMapping("/{projectId}/statuses")
+    public ResponseEntity deleteTaskStatus(@PathVariable Long projectId, @Valid @RequestBody DeleteTaskStatusRequest deleteRequest) {
+        projectService.deleteTaskStatus(projectId, deleteRequest.getStatusName());
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -4,6 +4,7 @@ import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.ProjectService;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.tag.domain.Tag;
@@ -81,4 +82,10 @@ public class ProjectController {
         return ResponseEntity.ok(projectTags);
     }
 
+    @PostMapping("/{projectId}/statuses")
+    public ResponseEntity<ProjectTaskStatusResponse> createTaskStatus(@PathVariable Long projectId, @Valid @RequestBody CreateTaskStatusRequest createRequest) {
+        TaskStatus taskStatus = projectService.createTaskStatus(projectId, createRequest.getName());
+
+        return ResponseEntity.ok(new ProjectTaskStatusResponse(taskStatus));
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -91,7 +91,7 @@ public class ProjectController {
 
     @DeleteMapping("/{projectId}/statuses")
     public ResponseEntity deleteTaskStatus(@PathVariable Long projectId, @Valid @RequestBody DeleteTaskStatusRequest deleteRequest) {
-        projectService.deleteTaskStatus(projectId, deleteRequest.getStatusName());
+        projectService.deleteTaskStatus(projectId, deleteRequest.getName());
 
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/CreateTaskStatusRequest.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/CreateTaskStatusRequest.java
@@ -1,0 +1,15 @@
+package kr.kro.colla.project.project.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateTaskStatusRequest {
+    @NotNull
+    private String name;
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/DeleteTaskStatusRequest.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/DeleteTaskStatusRequest.java
@@ -11,5 +11,5 @@ import javax.validation.constraints.NotNull;
 @Getter
 public class DeleteTaskStatusRequest {
     @NotNull
-    private String statusName;
+    private String name;
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/DeleteTaskStatusRequest.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/DeleteTaskStatusRequest.java
@@ -1,0 +1,15 @@
+package kr.kro.colla.project.project.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class DeleteTaskStatusRequest {
+    @NotNull
+    private String statusName;
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectTaskStatusResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectTaskStatusResponse.java
@@ -1,0 +1,18 @@
+package kr.kro.colla.project.project.presentation.dto;
+
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class ProjectTaskStatusResponse {
+    private Long id;
+
+    private String name;
+
+    public ProjectTaskStatusResponse(TaskStatus taskStatus) {
+        this.id = taskStatus.getId();
+        this.name = taskStatus.getName();
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -8,6 +8,7 @@ import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.project.task_status.service.TaskStatusService;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
@@ -38,6 +39,7 @@ public class ProjectService {
     private final UserProjectService userProjectService;
     private final ProjectRepository projectRepository;
     private final ProjectProfileStorage projectProfileStorage;
+    private final TaskStatusService taskStatusService;
 
     public Project createProject(Long managerId, CreateProjectRequest createProjectRequest) {
         User user = userService.findUserById(managerId);
@@ -149,5 +151,11 @@ public class ProjectService {
         TaskStatus taskStatus = new TaskStatus(name);
         project.addStatus(taskStatus);
         return taskStatus;
+    }
+
+    public void deleteTaskStatus(Long projectId, String statusName) {
+        Project project = findProjectById(projectId);
+        TaskStatus taskStatus = taskStatusService.findTaskStatusByName(statusName);
+        project.getTaskStatuses().remove(taskStatus);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -7,6 +7,7 @@ import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
@@ -141,5 +142,12 @@ public class ProjectService {
     public Project findProjectById(Long projectId) {
         return projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
+    }
+
+    public TaskStatus createTaskStatus(Long projectId, String name) {
+        Project project = findProjectById(projectId);
+        TaskStatus taskStatus = new TaskStatus(name);
+        project.addStatus(taskStatus);
+        return taskStatus;
     }
 }

--- a/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
@@ -24,37 +24,37 @@ import static org.mockito.BDDMockito.given;
 public abstract class ControllerTest {
 
     @Autowired
-    public MockMvc mockMvc;
+    protected MockMvc mockMvc;
 
     @Autowired
-    public ObjectMapper objectMapper;
+    protected ObjectMapper objectMapper;
 
     @MockBean
-    public CookieManager cookieManager;
+    protected CookieManager cookieManager;
 
     @MockBean
-    public AuthService authService;
+    protected AuthService authService;
 
     @MockBean
-    public UserService userService;
+    protected UserService userService;
 
     @MockBean
-    public ProjectService projectService;
+    protected ProjectService projectService;
 
     @MockBean
-    public UserProjectService userProjectService;
+    protected UserProjectService userProjectService;
 
     @MockBean
-    public TaskService taskService;
+    protected TaskService taskService;
 
     @MockBean
-    public StoryService storyService;
+    protected StoryService storyService;
 
     @MockBean
-    public NoticeService noticeService;
+    protected NoticeService noticeService;
 
-    public String accessToken = "token";
-    public LoginUser loginUser;
+    protected String accessToken = "token";
+    protected LoginUser loginUser;
 
     @BeforeEach
     void setUp() {

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -50,13 +50,13 @@ export const decideInvitation = async (projectId: number, noticeId: number, acce
 };
 
 export const createTaskStatus = async (projectId: number, name: String) => {
-    const response = await client.post(`/project/${projectId}/statuses`, { name });
+    const response = await client.post(`/projects/${projectId}/statuses`, { name });
 
     return response;
 };
 
 export const deleteTaskStatus = async (projectId: number, name: String) => {
-    const response = await client.delete(`/project/${projectId}/statuses`, { data: { name } });
+    const response = await client.delete(`/projects/${projectId}/statuses`, { data: { name } });
 
     return response;
 };

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -63,3 +63,15 @@ export const decideInvitation = async (projectId: number, noticeId: number, acce
 
     return response;
 };
+
+export const createStatus = async (projectId: number, name: String) => {
+    const response = await client.post(`/project/${projectId}/statuses`, { name });
+
+    return response;
+};
+
+export const deleteStatus = async (projectId: number, name: String) => {
+    const response = await client.delete(`/project/${projectId}/statuses`, { data: { name } });
+
+    return response;
+};

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -1,20 +1,5 @@
-import { ProjectTagType, ProjectType } from '../types/project';
+import { ProjectTagType, ProjectAllType } from '../types/project';
 import { client } from './common';
-
-interface task {
-    id: number;
-    title: string;
-    managerName: string;
-    avatar: string;
-    priority: number;
-}
-
-interface ProjectAllType extends ProjectType {
-    managerId: number;
-    tasks: {
-        [key: string]: Array<task>;
-    };
-}
 
 export const getProject = async (projectId: number) => {
     const response = await client.get<ProjectAllType>(`/projects/${projectId}`);
@@ -64,13 +49,13 @@ export const decideInvitation = async (projectId: number, noticeId: number, acce
     return response;
 };
 
-export const createStatus = async (projectId: number, name: String) => {
+export const createTaskStatus = async (projectId: number, name: String) => {
     const response = await client.post(`/project/${projectId}/statuses`, { name });
 
     return response;
 };
 
-export const deleteStatus = async (projectId: number, name: String) => {
+export const deleteTaskStatus = async (projectId: number, name: String) => {
     const response = await client.delete(`/project/${projectId}/statuses`, { data: { name } });
 
     return response;

--- a/frontend/src/components/Modal/Notice/index.tsx
+++ b/frontend/src/components/Modal/Notice/index.tsx
@@ -5,7 +5,7 @@ import noticeIconImg from '../../../../public/assets/images/notification_outline
 import { decideInvitation } from '../../../apis/project';
 import { getUserNotices } from '../../../apis/user';
 import { NoticeType } from '../../../types/user';
-import { Icon, Invitation, InvitationDecision, Notice, NoticeMessage, Wrapper } from './style';
+import { Icon, Invitation, InvitationDecision, NoNotice, Notice, NoticeMessage, Wrapper } from './style';
 
 const NoticeModal = () => {
     const [notices, setNotices] = useState<Array<NoticeType>>([]);
@@ -59,7 +59,15 @@ const NoticeModal = () => {
         updateNotices();
     }, []);
 
-    return <Wrapper>{notices.map((notice) => translateNotice(notice))}</Wrapper>;
+    return (
+        <Wrapper>
+            {notices.length === 0 ? (
+                <NoNotice>알림이 없습니다</NoNotice>
+            ) : (
+                notices.map((notice) => translateNotice(notice))
+            )}
+        </Wrapper>
+    );
 };
 
 export default NoticeModal;

--- a/frontend/src/components/Modal/Notice/style.tsx
+++ b/frontend/src/components/Modal/Notice/style.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
-import { GREEN, LIGHT_GREEN } from '../../../styles/color';
-import { Column, Modal, WidthAround } from '../../../styles/common';
+import { GREEN, LIGHT_GREEN, WHITE } from '../../../styles/color';
+import { Column, Modal, WidthAround, WidthCenter } from '../../../styles/common';
 
 export const Wrapper = styled.div`
     position: absolute;
@@ -15,6 +15,11 @@ export const Wrapper = styled.div`
     ${Modal}
 `;
 
+export const NoNotice = styled.div`
+    font-size: 18px;
+
+    ${WidthCenter}
+`;
 export const Notice = styled.div`
     height: 80px;
     padding: 10px;
@@ -22,7 +27,7 @@ export const Notice = styled.div`
     margin-bottom: 12px;
     border-radius: 10px;
     font-size: 18px;
-    background: ${(props: { check: boolean }) => (props.check ? LIGHT_GREEN : 'white')};
+    background: ${(props: { check: boolean }) => (props.check ? LIGHT_GREEN : WHITE)};
     pointer-events: ${(props: { check: boolean }) => (props.check ? 'none' : 'auto')};
 
     ${WidthAround}

--- a/frontend/src/components/Modal/Story/style.ts
+++ b/frontend/src/components/Modal/Story/style.ts
@@ -23,9 +23,6 @@ export const StoryArea = styled.textarea`
     height: 80px;
     font-size: 15px;
     border-radius: 10px;
-    border: none;
-    resize: none;
-    outline: none;
     margin: 10px 0 0 20px;
     padding: 10px 0 0 10px;
 `;

--- a/frontend/src/components/Modal/Task/Basic/style.tsx
+++ b/frontend/src/components/Modal/Task/Basic/style.tsx
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+
+import { WHITE } from '../../../../styles/color';
 import { LiftUp } from '../../../../styles/common';
 
 export const TaskContainer = styled.div`
@@ -50,9 +52,6 @@ export const DeleteButton = styled.img`
 
 export const DescriptionArea = styled.textarea`
     font-size: 15px;
-    border: none;
-    resize: none;
-    outline: none;
     border-radius: 10px;
     padding: 10px 0 0 10px;
 `;
@@ -64,7 +63,7 @@ export const DropDown = styled.div`
     min-height: 30px;
     border-radius: 10px;
     padding: 5px 0 5px 10px;
-    background-color: #fff;
+    background-color: ${WHITE};
     cursor: pointer;
 `;
 

--- a/frontend/src/components/Modal/Task/style.ts
+++ b/frontend/src/components/Modal/Task/style.ts
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+
+import { RED, WHITE } from '../../../styles/color';
 import { LiftUp } from '../../../styles/common';
 
 export const ModalContainer = styled.div`
@@ -9,7 +11,7 @@ export const ModalContainer = styled.div`
     min-height: 430px;
     margin-top: 70px;
     border-radius: 20px;
-    background-color: #f1f1f1;
+    background-color: ${WHITE};
     box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1), 0 4px 20px rgba(0, 0, 0, 0.1);
 `;
 
@@ -43,7 +45,7 @@ const Button = css`
 
 export const CancelButton = styled.div`
     margin-left: 40px;
-    color: #ff0000;
+    color: ${RED};
 
     ${Button}
 `;

--- a/frontend/src/components/Modal/TaskStatus/index.tsx
+++ b/frontend/src/components/Modal/TaskStatus/index.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import { createTaskStatus } from '../../../apis/project';
+import { projectState } from '../../../stores/projectState';
+import { ButtonContainer, Cancel, Input, Submit, Wrapper } from './style';
+
+const TaskStatusModal = () => {
+    const [input, setInput] = useState('');
+    const project = useRecoilValue(projectState);
+
+    const handleInput = (e: any) => setInput(e.target.value);
+
+    const closeModal = () => {
+        window.dispatchEvent(new Event('click'));
+        setInput('');
+    };
+
+    const submitInput = async () => {
+        await createTaskStatus(project.id, input);
+        setInput('');
+        window.location.replace('/kanban');
+    };
+    return (
+        <Wrapper>
+            <div>테스크 상태 추가</div>
+            <Input placeholder="추가할 상태 이름을 입력하세요" value={input} onChange={handleInput} />
+            <ButtonContainer>
+                <Cancel onClick={closeModal}>취소</Cancel>
+                <Submit onClick={submitInput}>완료</Submit>
+            </ButtonContainer>
+        </Wrapper>
+    );
+};
+
+export default TaskStatusModal;

--- a/frontend/src/components/Modal/TaskStatus/style.tsx
+++ b/frontend/src/components/Modal/TaskStatus/style.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+import { LIGHT_GRAY, RED } from '../../../styles/color';
+import { Modal } from '../../../styles/common';
+
+export const Wrapper = styled.div`
+    width: 300px;
+    height: 140px;
+    background: ${LIGHT_GRAY};
+    border-radius: 20px;
+    padding: 30px;
+    font-size: 20px;
+
+    justify-content: space-around;
+    align-items: center;
+    ${Modal}
+`;
+
+export const Input = styled.input`
+    width: 270px;
+    height: 40px;
+    border-radius: 10px;
+`;
+
+export const ButtonContainer = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+`;
+
+export const Submit = styled.button``;
+
+export const Cancel = styled.button`
+    color: ${RED};
+`;

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -62,11 +62,15 @@ const Kanban = () => {
                 thumbnail,
                 members,
             });
-            setTaskList([
-                ...tasks['To Do'].map((task) => ({ ...task, column: 'To Do' })),
-                ...tasks['In Progress'].map((task) => ({ ...task, column: 'In Progress' })),
-                ...tasks['Done'].map((task) => ({ ...task, column: 'Done' })),
-            ]);
+
+            const addColumnToTasks = (taskStatus: string): TaskType[] => [
+                ...tasks[taskStatus].map((task) => ({ ...task, column: taskStatus })),
+            ];
+            let newTaskList: TaskType[] = [];
+            Object.keys(tasks).forEach((taskStatus: string) => {
+                newTaskList = [...newTaskList, ...addColumnToTasks(taskStatus)];
+            });
+            setTaskList(newTaskList);
         })();
     }, []);
 

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -19,9 +19,9 @@ const Kanban = () => {
     const history = useHistory();
     const { state } = useLocation<stateType>();
     const [taskList, setTaskList] = useState<Array<TaskType>>([]);
+    const [taskStatuses, setTaskStatuses] = useState<Array<string>>([]);
     const setProjectState = useSetRecoilState(projectState);
 
-    const statuses = ['To Do', 'In Progress', 'Done'];
     const menu = ['로드맵', '백로그', '대시보드', '지도'];
 
     if (!state.projectId) {
@@ -66,10 +66,12 @@ const Kanban = () => {
             const addColumnToTasks = (taskStatus: string): TaskType[] => [
                 ...tasks[taskStatus].map((task) => ({ ...task, column: taskStatus })),
             ];
+
             let newTaskList: TaskType[] = [];
             Object.keys(tasks).forEach((taskStatus: string) => {
                 newTaskList = [...newTaskList, ...addColumnToTasks(taskStatus)];
             });
+            setTaskStatuses(Object.keys(tasks));
             setTaskList(newTaskList);
         })();
     }, []);
@@ -80,7 +82,7 @@ const Kanban = () => {
             <SideBar props={menu} />
             <Container>
                 <Wrapper>
-                    {statuses.map((value) => (
+                    {taskStatuses.map((value) => (
                         <KanbanCol
                             key={value}
                             status={value}

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -1,19 +1,22 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-
 import { useSetRecoilState } from 'recoil';
+
 import PlusIcon from '../../../public/assets/images/plus-circle.svg';
 import { getProject } from '../../apis/project';
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
+import TaskStatusModal from '../../components/Modal/TaskStatus';
 import { SideBar } from '../../components/SideBar';
+import useModal from '../../hooks/useModal';
 import { projectState } from '../../stores/projectState';
 import { TaskType } from '../../types/kanban';
-import { Wrapper, KanbanAddButton, KanbanAdditional, Container } from './style';
+import { Wrapper, Container, KanbanStatusAddButton, KanbanAddImage } from './style';
 
 interface stateType {
     projectId: number;
 }
+const menu = ['로드맵', '백로그', '대시보드', '지도'];
 
 const Kanban = () => {
     const history = useHistory();
@@ -21,8 +24,7 @@ const Kanban = () => {
     const [taskList, setTaskList] = useState<Array<TaskType>>([]);
     const [taskStatuses, setTaskStatuses] = useState<Array<string>>([]);
     const setProjectState = useSetRecoilState(projectState);
-
-    const menu = ['로드맵', '백로그', '대시보드', '지도'];
+    const { Modal, setModal } = useModal();
 
     if (!state.projectId) {
         history.push('/home');
@@ -94,9 +96,12 @@ const Kanban = () => {
                             moveTaskHandler={moveTaskHandler}
                         />
                     ))}
-                    <KanbanAdditional>
-                        <KanbanAddButton src={PlusIcon} />
-                    </KanbanAdditional>
+                    <KanbanStatusAddButton onClick={setModal}>
+                        <KanbanAddImage src={PlusIcon} />
+                    </KanbanStatusAddButton>
+                    <Modal>
+                        <TaskStatusModal />
+                    </Modal>
                 </Wrapper>
             </Container>
         </>

--- a/frontend/src/pages/Kanban/style.tsx
+++ b/frontend/src/pages/Kanban/style.tsx
@@ -18,7 +18,7 @@ export const Wrapper = styled.div`
     padding-bottom: 10px;
 `;
 
-export const KanbanAdditional = styled.div`
+export const KanbanStatusAddButton = styled.button`
     width: 300px;
     height: 50px;
     border-radius: 10px;
@@ -33,7 +33,7 @@ export const KanbanAdditional = styled.div`
     ${Center}
 `;
 
-export const KanbanAddButton = styled.img`
+export const KanbanAddImage = styled.img`
     width: 40px;
     height: 40px;
 `;

--- a/frontend/src/stores/projectState.ts
+++ b/frontend/src/stores/projectState.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from 'recoil';
+import { atom } from 'recoil';
 import { ProjectType } from '../types/project';
 
 export const projectState = atom<ProjectType>({
@@ -9,13 +9,5 @@ export const projectState = atom<ProjectType>({
         description: '',
         thumbnail: '',
         members: [],
-    },
-});
-
-export const projectMemberState = selector({
-    key: 'projectMember',
-    get: ({ get }) => {
-        const project = get(projectState);
-        return project.members;
     },
 });

--- a/frontend/src/styles/color.ts
+++ b/frontend/src/styles/color.ts
@@ -1,6 +1,8 @@
-export const LIGHT_GRAY = 'rgba(196, 196, 196, 0.2)';
+export const LIGHT_GRAY = 'rgb(241, 241, 241)';
 export const GRAY = 'rgba(196, 196, 196)';
 
 export const LIGHT_GREEN = 'rgba(234, 255, 235)';
 export const GREEN = 'rgba(206, 232, 207)';
 export const DARK_GREEN = 'rgba(203, 218, 204)';
+
+export const RED = `#ff0000`;

--- a/frontend/src/styles/color.ts
+++ b/frontend/src/styles/color.ts
@@ -6,3 +6,5 @@ export const GREEN = 'rgba(206, 232, 207)';
 export const DARK_GREEN = 'rgba(203, 218, 204)';
 
 export const RED = `#ff0000`;
+
+export const WHITE = '#f1f1f1';

--- a/frontend/src/styles/global.tsx
+++ b/frontend/src/styles/global.tsx
@@ -21,6 +21,13 @@ const GlobalStyle = () => (
                 font-size: inherit;
             }
 
+            textarea {
+                border: none;
+                resize: none;
+                outline: none;
+                font-size: inherit;
+            }
+
             a {
                 text-decoration: none;
                 color: inherit;

--- a/frontend/src/styles/global.tsx
+++ b/frontend/src/styles/global.tsx
@@ -10,6 +10,7 @@ const GlobalStyle = () => (
                     opacity: 50%;
                     cursor: pointer;
                 }
+                font-size: inherit;
             }
 
             input {
@@ -17,6 +18,7 @@ const GlobalStyle = () => (
                 &:focus {
                     outline: none;
                 }
+                font-size: inherit;
             }
 
             a {

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -1,3 +1,4 @@
+import { TaskType } from './kanban';
 import { UserProfile } from './user';
 
 export interface ProjectType {
@@ -6,6 +7,13 @@ export interface ProjectType {
     description: string;
     thumbnail: string;
     members: Array<UserProfile>;
+}
+
+export interface ProjectAllType extends ProjectType {
+    managerId: number;
+    tasks: {
+        [key: string]: Array<TaskType>;
+    };
 }
 
 export interface ProjectTagType {


### PR DESCRIPTION
### 🔨 작업 내용 설명

사용자가 마음대로 칸반 상태값을 변경할 수 있도록
테스크 상태값을 추가/삭제하는 API를 구현하고, 기본적인 테스트를 구현했습니다.

기존 프로젝트 상태값이 더미 데이터로 존재해, 테스크 상태와 정보를 반영하는 로직이 하드 코딩되어있어서 😱😱
API 응답 데이터를 기반으로 상태값 저장한 뒤 처리하도록 수정했습니다!

테스크 상태값 추가 모달 추가하고, 해당 모달로 상태값을 추가가 가능하도록 연동했습니다!
(새로운 상태값이 추가되면 해당 페이지로 리다이렉트 되도록 처리했습니다~)

테스크 상태값 삭제를 위한 UI를 작업이 안되어있어서, 테스크 상태값 삭제는 요청 함수만 작업해놓았습니다~

### 📑 구현한 내용 목록
- [x] 테스크 상태값 추가 API 구현
- [x] 테스크 상태값 삭제 API 구현
- [x] 테스크 상태값 추가 삭제 테스트
- [x] 테스크 상태값 추가 모달 UI
- [x] 기존 테스크 상태값 더미 데이터 삭제
- [x] 테스크 상태값 추가 API 연동

### 🚧 논의 사항
- CSS 작업 중 공통으로 사용할 수 있는 사항(컬러, HTML 태그 CSS 리셋 등)은 
  해당 역할에 맞는 파일로 분리한 뒤 호출해서 사용해주세요~ 🙇🏻‍♀️🙇🏻‍♂️

- 큰 문제는 없겠지만 상속해서 사용할 ControllerTest는 목적 이외의 사용 방지하기 위해 protected 범위로 변경했습니다~

- close #75 
