### PR TITLE
[#79, #80] feat: 태스크 수정 API 테스트 코드 작성 및 댓글 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/comment/domain/Comment.java
+++ b/backend/src/main/java/kr/kro/colla/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.comment.domain;
 
+import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.user.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -11,6 +12,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +29,10 @@ public class Comment {
     @JoinColumn(name = "user_id")
     private User user;
 
+    @ManyToOne
+    @JoinColumn(name = "task_id")
+    private Task task;
+
     @Column
     private String contents;
 
@@ -35,9 +42,23 @@ public class Comment {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment superComment;
+
+    @OneToMany(
+            mappedBy = "superComment",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.PERSIST,
+            orphanRemoval = true
+    )
+    private List<Comment> subComment = new ArrayList<>();
+
     @Builder
-    public Comment(User user, String contents) {
+    public Comment(User user, Task task, Comment superComment, String contents) {
         this.user = user;
+        this.task = task;
+        this.superComment = superComment;
         this.contents = contents;
     }
 

--- a/backend/src/main/java/kr/kro/colla/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/kr/kro/colla/comment/domain/repository/CommentRepository.java
@@ -1,7 +1,16 @@
 package kr.kro.colla.comment.domain.repository;
 
 import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.task.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("select c from Comment c where c.task = :task")
+    List<Comment> findAll(@Param("task") Task task);
+
 }

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/CommentController.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/CommentController.java
@@ -14,21 +14,21 @@ import javax.validation.Valid;
 import java.util.Map;
 
 @RequiredArgsConstructor
-@RequestMapping("/task/comments")
 @RestController
 public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping
-    public ResponseEntity<CreateCommentResponse> saveComment(@Authenticated LoginUser loginUser, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
-        CreateCommentResponse createCommentResponse = commentService.saveComment(loginUser.getId(), createCommentRequest);
+    @PostMapping("/tasks/{taskId}/comments")
+    public ResponseEntity<CreateCommentResponse> saveComment(@Authenticated LoginUser loginUser, @PathVariable Long taskId,
+                                                             @Valid @RequestBody CreateCommentRequest createCommentRequest) {
+        CreateCommentResponse createCommentResponse = commentService.saveComment(loginUser.getId(), taskId, createCommentRequest);
 
         return ResponseEntity.ok(createCommentResponse);
     }
 
-    @GetMapping
-    public ResponseEntity<Map<Long, TaskCommentResponse>> getAllComments(@RequestBody Long taskId) {
+    @GetMapping("/tasks/{taskId}/comments")
+    public ResponseEntity<Map<Long, TaskCommentResponse>> getAllComments(@PathVariable Long taskId) {
         Map<Long, TaskCommentResponse> allComments = commentService.getAllComments(taskId);
 
         return ResponseEntity.ok(allComments);

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/CommentController.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/CommentController.java
@@ -1,0 +1,37 @@
+package kr.kro.colla.comment.presentation;
+
+import kr.kro.colla.auth.domain.LoginUser;
+import kr.kro.colla.auth.presentation.argument_resolver.Authenticated;
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.comment.presentation.dto.TaskCommentResponse;
+import kr.kro.colla.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/task/comments")
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CreateCommentResponse> saveComment(@Authenticated LoginUser loginUser, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
+        CreateCommentResponse createCommentResponse = commentService.saveComment(loginUser.getId(), createCommentRequest);
+
+        return ResponseEntity.ok(createCommentResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<Long, TaskCommentResponse>> getAllComments(@RequestBody Long taskId) {
+        Map<Long, TaskCommentResponse> allComments = commentService.getAllComments(taskId);
+
+        return ResponseEntity.ok(allComments);
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentRequest.java
@@ -5,15 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class CreateCommentRequest {
-
-    @NotNull
-    private Long taskId;
 
     private Long superCommentId;
 

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentRequest.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentRequest.java
@@ -1,0 +1,23 @@
+package kr.kro.colla.comment.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateCommentRequest {
+
+    @NotNull
+    private Long taskId;
+
+    private Long superCommentId;
+
+    @NotBlank
+    private String contents;
+
+}

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentResponse.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/dto/CreateCommentResponse.java
@@ -1,0 +1,22 @@
+package kr.kro.colla.comment.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CreateCommentResponse {
+
+    private Long id;
+
+    private Long userId;
+
+    private Long superCommentId;
+
+    private String contents;
+
+}

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/dto/TaskCommentResponse.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/dto/TaskCommentResponse.java
@@ -1,0 +1,31 @@
+package kr.kro.colla.comment.presentation.dto;
+
+import kr.kro.colla.comment.domain.Comment;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class TaskCommentResponse {
+
+    private Long id;
+
+    private Long userId;
+
+    private String contents;
+
+    private List<TaskCommentResponse> subComments;
+
+    public TaskCommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.userId = comment.getUser().getId();
+        this.contents = comment.getContents();
+        this.subComments = new ArrayList<>();
+    }
+
+    public void addSubComment(Comment comment) {
+        this.subComments.add(new TaskCommentResponse(comment));
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/comment/presentation/dto/TaskCommentResponse.java
+++ b/backend/src/main/java/kr/kro/colla/comment/presentation/dto/TaskCommentResponse.java
@@ -2,10 +2,12 @@ package kr.kro.colla.comment.presentation.dto;
 
 import kr.kro.colla.comment.domain.Comment;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 public class TaskCommentResponse {
 

--- a/backend/src/main/java/kr/kro/colla/comment/service/CommentService.java
+++ b/backend/src/main/java/kr/kro/colla/comment/service/CommentService.java
@@ -27,9 +27,9 @@ public class CommentService {
     private final TaskService taskService;
     private final CommentRepository commentRepository;
 
-    public CreateCommentResponse saveComment(Long userId, CreateCommentRequest createCommentRequest) {
+    public CreateCommentResponse saveComment(Long userId, Long taskId, CreateCommentRequest createCommentRequest) {
         User user = userService.findUserById(userId);
-        Task task = taskService.findTaskById(createCommentRequest.getTaskId());
+        Task task = taskService.findTaskById(taskId);
         Comment superComment = createCommentRequest.getSuperCommentId() != null
                 ? findCommentById(createCommentRequest.getSuperCommentId())
                 : null;

--- a/backend/src/main/java/kr/kro/colla/comment/service/CommentService.java
+++ b/backend/src/main/java/kr/kro/colla/comment/service/CommentService.java
@@ -1,0 +1,77 @@
+package kr.kro.colla.comment.service;
+
+import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.comment.domain.repository.CommentRepository;
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.comment.presentation.dto.TaskCommentResponse;
+import kr.kro.colla.exception.exception.comment.CommentNotFoundException;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.service.TaskService;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class CommentService {
+
+    private final UserService userService;
+    private final TaskService taskService;
+    private final CommentRepository commentRepository;
+
+    public CreateCommentResponse saveComment(Long userId, CreateCommentRequest createCommentRequest) {
+        User user = userService.findUserById(userId);
+        Task task = taskService.findTaskById(createCommentRequest.getTaskId());
+        Comment superComment = createCommentRequest.getSuperCommentId() != null
+                ? findCommentById(createCommentRequest.getSuperCommentId())
+                : null;
+        Long superCommentId = superComment == null ? null : superComment.getId();
+
+        Comment comment = Comment.builder()
+                .user(user)
+                .task(task)
+                .superComment(superComment)
+                .contents(createCommentRequest.getContents())
+                .build();
+        commentRepository.save(comment);
+
+        return CreateCommentResponse.builder()
+                .id(comment.getId())
+                .userId(user.getId())
+                .superCommentId(superCommentId)
+                .contents(comment.getContents())
+                .build();
+    }
+
+    public Map<Long, TaskCommentResponse> getAllComments(Long taskId) {
+        Task task = taskService.findTaskById(taskId);
+        List<Comment> allComments = commentRepository.findAll(task);
+        Map<Long, TaskCommentResponse> comments = new HashMap<>();
+
+        for (Comment comment : allComments) {
+            if (comment.getSuperComment() == null) {
+                comments.put(comment.getId(), new TaskCommentResponse(comment));
+                continue;
+            }
+
+            comments.get(comment.getSuperComment().getId())
+                    .addSubComment(comment);
+        }
+
+        return comments;
+    }
+
+    public Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/exception/exception/comment/CommentNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/comment/CommentNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.kro.colla.exception.exception.comment;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class CommentNotFoundException extends NotFoundException {
+
+    public CommentNotFoundException() {
+        super("해당하는 댓글을 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/task/tag/domain/Tag.java
+++ b/backend/src/main/java/kr/kro/colla/task/tag/domain/Tag.java
@@ -32,11 +32,11 @@ public class Tag {
             return false;
         }
         Tag tag = (Tag) o;
-        return Objects.equals(id, tag.id);
+        return Objects.equals(name, tag.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(name);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -39,9 +39,6 @@ public class Task {
     @Column
     private String description;
 
-    @Column
-    private String images;
-
     @CreatedDate
     private LocalDateTime createdAt;
 
@@ -106,6 +103,10 @@ public class Task {
     @Override
     public int hashCode() {
         return Objects.hash(id);
+    }
+
+    public void addTags(List<TaskTag> tags) {
+        taskTags.addAll(tags);
     }
 
     public void updateContents(UpdateTaskRequest updateTaskRequest) {

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -60,8 +60,7 @@ public class Task {
     @JoinColumn(name = "story_id")
     private Story story;
 
-    @OneToMany(fetch = FetchType.LAZY)
-    @JoinColumn(name = "task_id")
+    @OneToMany(mappedBy = "task", fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
     @OneToMany(

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskResponse.java
@@ -1,11 +1,15 @@
 package kr.kro.colla.task.task.presentation.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class ProjectTaskResponse {
 

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/UpdateTaskRequest.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/UpdateTaskRequest.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.task.task.presentation.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Max;
@@ -8,6 +9,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+@Builder
 @AllArgsConstructor
 @Getter
 public class UpdateTaskRequest {

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -37,7 +37,7 @@ public class TaskService {
 
     public Long createTask(CreateTaskRequest createTaskRequest) {
         Project project = projectService.findProjectById(createTaskRequest.getProjectId());
-        Story story = createTaskRequest.getStory() != null
+        Story story = !createTaskRequest.getStory().isBlank()
                 ? storyService.findStoryByTitle(createTaskRequest.getStory())
                 : null;
         TaskStatus taskStatus = taskStatusService.findTaskStatusByName(createTaskRequest.getStatus());

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -53,9 +53,8 @@ public class TaskService {
                 .preTasks(createTaskRequest.getPreTasks())
                 .build();
 
-        if (createTaskRequest.getTags() != null) {
-            taskTagService.setTaskTag(task, createTaskRequest.getTags());
-        }
+        List<TaskTag> tags = taskTagService.translateTaskTags(task, createTaskRequest.getTags());
+        task.addTags(tags);
 
         return taskRepository.save(task)
                 .getId();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
     multipart:
       max-file-size: 5MB
       max-request-size: 5MB
+  data:
+    redis:
+      repositories:
+        enabled: false
 
 
 server:

--- a/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/auth/AcceptanceTest.java
@@ -98,7 +98,7 @@ public class AcceptanceTest {
     void 로그아웃_시_Jwt토큰을_삭제한다() {
         // given
         Long id = 1L;
-        String accessToken = auth.로그인(id);
+        String accessToken = auth.토큰을_발급한다(id);
 
         ExtractableResponse<Response> response = RestAssured
                 .given()

--- a/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
@@ -1,10 +1,13 @@
 package kr.kro.colla.comment;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.MapType;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
 import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.comment.presentation.dto.TaskCommentResponse;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
 import kr.kro.colla.user.user.domain.User;
@@ -18,7 +21,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
 
 
+import java.util.HashMap;
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.*;
 
 @ActiveProfiles("test")
@@ -46,6 +53,9 @@ public class AcceptanceTest {
     @Autowired
     private DatabaseCleaner databaseCleaner;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     private Auth auth;
 
     @BeforeEach
@@ -63,7 +73,7 @@ public class AcceptanceTest {
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
         task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
 
-        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, null, "comment contents");
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(null, "comment contents");
 
         given()
                 .contentType(ContentType.JSON)
@@ -72,7 +82,7 @@ public class AcceptanceTest {
 
         // when
         .when()
-                .post("/api/task/comments")
+                .post("/api/tasks/" + 1L + "/comments")
 
         // then
         .then()
@@ -86,30 +96,80 @@ public class AcceptanceTest {
     @Test
     void 사용자가_태스크의_댓글에_대댓글을_작성한다() {
         // given
-        User registeredUser = user.가_로그인을_한다1();
-        String accessToken = auth.토큰을_발급한다(registeredUser.getId());
-        UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
-        CreateCommentResponse registeredComment = comment.를_등록한다(accessToken);
+        User member1 = user.가_로그인을_한다1();
+        String member1AccessToken = auth.토큰을_발급한다(member1.getId());
+        User member2 = user.가_로그인을_한다2();
+        String member2AccessToken = auth.토큰을_발급한다(member2.getId());
 
-        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, registeredComment.getId(), "comment contents");
+        UserProjectResponse createdProject = project.를_생성한다(member1AccessToken);
+        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null);
+        CreateCommentResponse registeredComment = comment.를_등록한다(member2AccessToken, null);
+
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(registeredComment.getId(), "comment contents");
 
         given()
                 .contentType(ContentType.JSON)
-                .cookie("accessToken", accessToken)
+                .cookie("accessToken", member1AccessToken)
                 .body(createCommentRequest)
 
         // when
         .when()
-                .post("/api/task/comments")
+                .post("/api/tasks/" + 1L + "/comments")
 
         // then
         .then()
                 .statusCode(HttpStatus.OK.value())
                 .body("id", notNullValue())
-                .body("userId", equalTo(registeredUser.getId().intValue()))
+                .body("userId", equalTo(member1.getId().intValue()))
                 .body("superCommentId", equalTo(registeredComment.getId().intValue()))
                 .body("contents", equalTo(createCommentRequest.getContents()));
+    }
+
+    @Test
+    void 사용자가_태스트의_댓글과_대댓글을_조회한다() {
+        // given
+        User member1 = user.가_로그인을_한다1();
+        String member1AccessToken = auth.토큰을_발급한다(member1.getId());
+        User member2 = user.가_로그인을_한다2();
+        String member2AccessToken = auth.토큰을_발급한다(member2.getId());
+
+        UserProjectResponse createdProject = project.를_생성한다(member1AccessToken);
+        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null);
+
+        CreateCommentResponse registeredComment1 = comment.를_등록한다(member2AccessToken, null);
+        CreateCommentResponse registeredComment2 = comment.를_등록한다(member2AccessToken, null);
+        CreateCommentResponse subComment = comment.를_등록한다(member1AccessToken, registeredComment2.getId());
+
+        MapType mapType = objectMapper.getTypeFactory()
+                .constructMapType(HashMap.class, Long.class, TaskCommentResponse.class);
+
+        HashMap<Long, TaskCommentResponse> response = given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", member1AccessToken)
+
+        // when
+        .when()
+                .get("/api/tasks/" + 1L + "/comments")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(mapType);
+
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.get(1L).getUserId()).isEqualTo(member2.getId());
+        assertThat(response.get(1L).getContents()).isEqualTo(registeredComment1.getContents());
+        assertThat(response.get(1L).getSubComments().size()).isZero();
+        assertThat(response.get(2L).getUserId()).isEqualTo(member2.getId());
+        assertThat(response.get(2L).getContents()).isEqualTo(registeredComment2.getContents());
+
+        List<TaskCommentResponse> subComments = response.get(2L).getSubComments();
+        assertThat(subComments.size()).isOne();
+        assertThat(subComments.get(0).getUserId()).isEqualTo(member1.getId());
+        assertThat(subComments.get(0).getContents()).isEqualTo(subComment.getContents());
+        assertThat(subComments.get(0).getSubComments()).isEmpty();
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
@@ -1,0 +1,115 @@
+package kr.kro.colla.comment;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.common.database.DatabaseCleaner;
+import kr.kro.colla.common.fixture.*;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.*;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserProvider user;
+
+    @Autowired
+    private ProjectProvider project;
+
+    @Autowired
+    private TaskProvider task;
+
+    @Autowired
+    private CommentProvider comment;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    private Auth auth;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        auth = new Auth(jwtProvider);
+        databaseCleaner.execute();
+    }
+
+    @Test
+    void 사용자가_태스크에_댓글을_등록한다() {
+        // given
+        User registeredUser = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(registeredUser.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, null, "comment contents");
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(createCommentRequest)
+
+        // when
+        .when()
+                .post("/api/task/comments")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", notNullValue())
+                .body("userId", equalTo(registeredUser.getId().intValue()))
+                .body("superCommentId", nullValue())
+                .body("contents", equalTo(createCommentRequest.getContents()));
+    }
+
+    @Test
+    void 사용자가_태스크의_댓글에_대댓글을_작성한다() {
+        // given
+        User registeredUser = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(registeredUser.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        CreateCommentResponse registeredComment = comment.를_등록한다(accessToken);
+
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, registeredComment.getId(), "comment contents");
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(createCommentRequest)
+
+        // when
+        .when()
+                .post("/api/task/comments")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("id", notNullValue())
+                .body("userId", equalTo(registeredUser.getId().intValue()))
+                .body("superCommentId", equalTo(registeredComment.getId().intValue()))
+                .body("contents", equalTo(createCommentRequest.getContents()));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
@@ -66,8 +66,8 @@ class CommentRepositoryTest {
         Project project = projectRepository.save(ProjectProvider.createProject(user.getId()));
         Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0)));
         commentRepository.saveAll(List.of(
-                CommentProvider.createComment1(user, task, null),
-                CommentProvider.createComment2(user, task, null)
+                CommentProvider.createComment(user, task, null, "first comment contents"),
+                CommentProvider.createComment(user, task, null, "second comment contents")
         ));
 
         // when

--- a/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
@@ -1,13 +1,24 @@
 package kr.kro.colla.comment.domain.repository;
 
 import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.common.fixture.CommentProvider;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
 import kr.kro.colla.config.JpaAuditingConfig;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static java.time.LocalDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,14 +31,19 @@ class CommentRepositoryTest {
     @Autowired
     private CommentRepository commentRepository;
 
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskRepository taskRepository;
+
     @Test
     void 댓글_등록에_성공한다() {
         // given
-        User user = User.builder()
-                .githubId("id")
-                .name("name")
-                .avatar("avatar")
-                .build();
+        User user = userRepository.save(UserProvider.createUser());
         Comment comment = Comment.builder()
                 .user(user)
                 .contents("contents")
@@ -37,9 +53,31 @@ class CommentRepositoryTest {
         Comment result = commentRepository.save(comment);
 
         // then
+        assertThat(result.getContents()).isEqualTo(comment.getContents());
         assertThat(result.getCreateAt()).isNotNull();
         assertThat(result.getCreateAt()).isBefore(now());
         assertThat(result.getUpdatedAt()).isBefore(now());
+    }
+
+    @Test
+    void 특정_태스크에_속한_댓글들을_모두_조회한다() {
+        // given
+        User user = userRepository.save(UserProvider.createUser());
+        Project project = projectRepository.save(ProjectProvider.createProject(user.getId()));
+        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0)));
+        commentRepository.saveAll(List.of(
+                CommentProvider.createComment1(user, task, null),
+                CommentProvider.createComment2(user, task, null)
+        ));
+
+        // when
+        List<Comment> allComments = commentRepository.findAll(task);
+
+        // then
+        assertThat(allComments.size()).isEqualTo(2);
+        assertThat(allComments).extracting("contents")
+                .contains("first comment contents", "second comment contents");
+        allComments.forEach(comment -> assertThat(comment.getTask().getId()).isEqualTo(task.getId()));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
@@ -1,0 +1,67 @@
+package kr.kro.colla.comment.presentation;
+
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.common.ControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.Cookie;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest extends ControllerTest {
+
+    @Test
+    void 댓글_등록에_성공한다() throws Exception {
+        // given
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(loginUser.getId(), null, "comment contents");
+        CreateCommentResponse createCommentResponse = CreateCommentResponse.builder()
+                .userId(loginUser.getId())
+                .contents(createCommentRequest.getContents())
+                .build();
+        String content = objectMapper.writeValueAsString(createCommentRequest);
+
+        given(commentService.saveComment(anyLong(), any(CreateCommentRequest.class)))
+                .willReturn(createCommentResponse);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/task/comments")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(loginUser.getId()))
+                .andExpect(jsonPath("$.contents").value(createCommentRequest.getContents()));
+    }
+
+    @Test
+    void 댓글의_내용이_없을_경우_댓글을_등록할_수_없다() throws Exception {
+        // given
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(loginUser.getId(), null, "");
+        String content = objectMapper.writeValueAsString(createCommentRequest);
+
+        // when
+        ResultActions perform = mockMvc.perform(post("/task/comments")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("contents : must not be blank"));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
@@ -1,18 +1,35 @@
 package kr.kro.colla.comment.presentation;
 
+import com.fasterxml.jackson.databind.type.MapType;
+import kr.kro.colla.comment.domain.Comment;
 import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
 import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.comment.presentation.dto.TaskCommentResponse;
 import kr.kro.colla.common.ControllerTest;
+import kr.kro.colla.common.fixture.CommentProvider;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.user.user.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,18 +40,18 @@ class CommentControllerTest extends ControllerTest {
     @Test
     void 댓글_등록에_성공한다() throws Exception {
         // given
-        CreateCommentRequest createCommentRequest = new CreateCommentRequest(loginUser.getId(), null, "comment contents");
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(null, "comment contents");
         CreateCommentResponse createCommentResponse = CreateCommentResponse.builder()
                 .userId(loginUser.getId())
                 .contents(createCommentRequest.getContents())
                 .build();
         String content = objectMapper.writeValueAsString(createCommentRequest);
 
-        given(commentService.saveComment(anyLong(), any(CreateCommentRequest.class)))
+        given(commentService.saveComment(anyLong(), anyLong(), any(CreateCommentRequest.class)))
                 .willReturn(createCommentResponse);
 
         // when
-        ResultActions perform = mockMvc.perform(post("/task/comments")
+        ResultActions perform = mockMvc.perform(post("/tasks/" + 1L + "/comments")
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content));
@@ -44,16 +61,17 @@ class CommentControllerTest extends ControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value(loginUser.getId()))
                 .andExpect(jsonPath("$.contents").value(createCommentRequest.getContents()));
+        verify(commentService, times(1)).saveComment(anyLong(), anyLong(), any(CreateCommentRequest.class));
     }
 
     @Test
     void 댓글의_내용이_없을_경우_댓글을_등록할_수_없다() throws Exception {
         // given
-        CreateCommentRequest createCommentRequest = new CreateCommentRequest(loginUser.getId(), null, "");
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(null, "");
         String content = objectMapper.writeValueAsString(createCommentRequest);
 
         // when
-        ResultActions perform = mockMvc.perform(post("/task/comments")
+        ResultActions perform = mockMvc.perform(post("/tasks/" + 1L + "/comments")
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(content));
@@ -62,6 +80,50 @@ class CommentControllerTest extends ControllerTest {
         perform
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("contents : must not be blank"));
+        verify(commentService, never()).saveComment(anyLong(), anyLong(), any(CreateCommentRequest.class));
+    }
+
+    @Test
+    void 대댓글을_포함한_모든_댓글을_조회한다() throws Exception {
+        // given
+        Map<Long, TaskCommentResponse> allComments = new HashMap<>();
+
+        User user = UserProvider.createUser();
+        Project project = ProjectProvider.createProject(user.getId());
+        Task task = TaskProvider.createTask(user.getId(), project, null);
+
+        Comment comment1 = CommentProvider.createComment(user, task, null, "first comment contents");
+        Comment comment2 = CommentProvider.createComment(user, task, comment1, "first comment's subComment");
+        Comment comment3 = CommentProvider.createComment(user, task, null, "another comment contents");
+
+        allComments.put(1L, new TaskCommentResponse(comment1));
+        allComments.get(1L).addSubComment(comment2);
+        allComments.put(3L, new TaskCommentResponse(comment3));
+
+        given(commentService.getAllComments(anyLong()))
+                .willReturn(allComments);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/tasks/" + 1L + "/comments")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        MvcResult result = perform.andReturn();
+        MapType mapType = objectMapper.getTypeFactory()
+                .constructMapType(HashMap.class, Long.class, TaskCommentResponse.class);
+        Map<Long, TaskCommentResponse> allCommentsResponse = objectMapper.readValue(result.getResponse().getContentAsString(), mapType);
+
+        perform
+                .andExpect(status().isOk());
+
+        List<TaskCommentResponse> subComments = allCommentsResponse.get(1L).getSubComments();
+        assertThat(allCommentsResponse.size()).isEqualTo(2);
+        assertThat(allCommentsResponse.get(1L).getContents()).isEqualTo(comment1.getContents());
+        assertThat(subComments.size()).isEqualTo(1);
+        assertThat(subComments.get(0).getContents()).isEqualTo(comment2.getContents());
+        assertThat(allCommentsResponse.get(3L).getContents()).isEqualTo(comment3.getContents());
+        verify(commentService, times(1)).getAllComments(anyLong());
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/service/CommentServiceTest.java
@@ -1,0 +1,107 @@
+package kr.kro.colla.comment.service;
+
+import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.comment.domain.repository.CommentRepository;
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.common.fixture.CommentProvider;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.service.TaskService;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private TaskService taskService;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    void 댓글_등록에_성공한다() {
+        // given
+        Long userId = 1L, taskId = 1L;
+        User user = UserProvider.createUser();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Project project = ProjectProvider.createProject(user.getId());
+        Task task = TaskProvider.createTask(user.getId(), project, null);
+        ReflectionTestUtils.setField(task, "id", taskId);
+
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(taskId, null, "comment contents");
+
+        given(userService.findUserById(eq(userId)))
+                .willReturn(user);
+        given(taskService.findTaskById(taskId))
+                .willReturn(task);
+
+        // when
+        CreateCommentResponse createCommentResponse = commentService.saveComment(userId, createCommentRequest);
+
+        // then
+        assertThat(createCommentResponse.getUserId()).isEqualTo(userId);
+        assertThat(createCommentResponse.getContents()).isEqualTo(createCommentRequest.getContents());
+        assertThat(createCommentResponse.getSuperCommentId()).isNull();
+        verify(userService, times(1)).findUserById(eq(userId));
+        verify(taskService, times(1)).findTaskById(eq(taskId));
+        verify(commentRepository, times(1)).save(any(Comment.class));
+    }
+
+    @Test
+    void 대댓글_등록에_성공한다() {
+        // given
+        Long userId = 1L, taskId = 5L, superCommentId = 3L;
+        User user = UserProvider.createUser();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        Project project = ProjectProvider.createProject(user.getId());
+        Task task = TaskProvider.createTask(user.getId(), project, null);
+        ReflectionTestUtils.setField(task, "id", taskId);
+
+        Comment superComment = CommentProvider.createComment1(user, task, null);
+        ReflectionTestUtils.setField(superComment, "id", superCommentId);
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(taskId, superCommentId, "comment contents");
+
+        given(userService.findUserById(eq(userId)))
+                .willReturn(user);
+        given(taskService.findTaskById(taskId))
+                .willReturn(task);
+        given(commentRepository.findById(eq(superCommentId)))
+                .willReturn(Optional.of(superComment));
+
+        // when
+        CreateCommentResponse createCommentResponse = commentService.saveComment(userId, createCommentRequest);
+
+        // then
+        assertThat(createCommentResponse.getSuperCommentId()).isEqualTo(superCommentId);
+        verify(commentRepository, times(1)).findById(eq(superCommentId));
+        verify(commentRepository, times(1)).save(any(Comment.class));
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
@@ -3,6 +3,7 @@ package kr.kro.colla.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.auth.domain.LoginUser;
 import kr.kro.colla.auth.service.AuthService;
+import kr.kro.colla.comment.service.CommentService;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.task.service.TaskService;
@@ -52,6 +53,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected NoticeService noticeService;
+
+    @MockBean
+    protected CommentService commentService;
 
     protected String accessToken = "token";
     protected LoginUser loginUser;

--- a/backend/src/test/java/kr/kro/colla/common/database/DatabaseCleaner.java
+++ b/backend/src/test/java/kr/kro/colla/common/database/DatabaseCleaner.java
@@ -1,0 +1,44 @@
+package kr.kro.colla.common.database;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DatabaseCleaner {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @PostConstruct
+    public void getAllTableNames() {
+        tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .filter(entityType -> entityType.getJavaType().getAnnotation(Entity.class) != null)
+                .map(entityType -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, entityType.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/Auth.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/Auth.java
@@ -10,7 +10,7 @@ public class Auth {
         this.jwtProvider = jwtProvider;
     }
 
-    public String 로그인(Long id) {
+    public String 토큰을_발급한다(Long id) {
         return jwtProvider.createAccessToken(id);
     }
 

--- a/backend/src/test/java/kr/kro/colla/common/fixture/CommentProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/CommentProvider.java
@@ -1,0 +1,50 @@
+package kr.kro.colla.common.fixture;
+
+import io.restassured.http.ContentType;
+import kr.kro.colla.comment.domain.Comment;
+import kr.kro.colla.comment.presentation.dto.CreateCommentRequest;
+import kr.kro.colla.comment.presentation.dto.CreateCommentResponse;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.user.user.domain.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+public class CommentProvider {
+
+    public CreateCommentResponse 를_등록한다(String accessToken) {
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, null, "comment contents");
+
+        return given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(createCommentRequest)
+        .when()
+                .post("/api/task/comments")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(CreateCommentResponse.class);
+    }
+
+    public static Comment createComment1(User user, Task task, Comment superComment) {
+        return Comment.builder()
+                .user(user)
+                .task(task)
+                .superComment(superComment)
+                .contents("first comment contents")
+                .build();
+    }
+
+    public static Comment createComment2(User user, Task task, Comment superComment) {
+        return Comment.builder()
+                .user(user)
+                .task(task)
+                .superComment(superComment)
+                .contents("second comment contents")
+                .build();
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/CommentProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/CommentProvider.java
@@ -14,36 +14,27 @@ import static io.restassured.RestAssured.given;
 @Component
 public class CommentProvider {
 
-    public CreateCommentResponse 를_등록한다(String accessToken) {
-        CreateCommentRequest createCommentRequest = new CreateCommentRequest(1L, null, "comment contents");
+    public CreateCommentResponse 를_등록한다(String accessToken, Long superCommendId) {
+        CreateCommentRequest createCommentRequest = new CreateCommentRequest(superCommendId, "comment contents");
 
         return given()
                 .contentType(ContentType.JSON)
                 .cookie("accessToken", accessToken)
                 .body(createCommentRequest)
         .when()
-                .post("/api/task/comments")
+                .post("/api/tasks/" + 1L + "/comments")
         .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(CreateCommentResponse.class);
     }
 
-    public static Comment createComment1(User user, Task task, Comment superComment) {
+    public static Comment createComment(User user, Task task, Comment superComment, String contents) {
         return Comment.builder()
                 .user(user)
                 .task(task)
                 .superComment(superComment)
-                .contents("first comment contents")
-                .build();
-    }
-
-    public static Comment createComment2(User user, Task task, Comment superComment) {
-        return Comment.builder()
-                .user(user)
-                .task(task)
-                .superComment(superComment)
-                .contents("second comment contents")
+                .contents(contents)
                 .build();
     }
 

--- a/backend/src/test/java/kr/kro/colla/common/fixture/NoticeProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/NoticeProvider.java
@@ -1,0 +1,45 @@
+package kr.kro.colla.common.fixture;
+
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
+import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+public class NoticeProvider {
+
+    public void 를_생성한다(String accessToken, Long projectId, String memberGithubId) {
+        ProjectMemberRequest projectMemberRequest = new ProjectMemberRequest(memberGithubId);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(projectMemberRequest)
+        .when()
+                .post("/api/projects/" + projectId + "/members")
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    public List<UserNoticeResponse> 를_조회한다(String accessToken) {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+        .when()
+                .get("/api/users/notices")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(new TypeRef<List<UserNoticeResponse>>() {});
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
@@ -1,18 +1,48 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.domain.repository.ProjectRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
 
 @Component
 public class ProjectProvider {
 
-    @Autowired
-    private ProjectRepository projectRepository;
+    public UserProjectResponse 를_생성한다(String accessToken) {
+        try {
+            MockMultipartFile thumbnail = FileProvider.getTestMultipartFile("thumbnail.png");
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("name", "collaboration");
+            requestBody.put("description", "collaboration tool");
 
-    public Project 를_생성한다(Long managerId) {
-        return projectRepository.save(createProject(managerId));
+            return given()
+                    .contentType(ContentType.MULTIPART)
+                    .accept(MediaType.APPLICATION_JSON_VALUE)
+                    .cookie("accessToken", accessToken)
+                    .multiPart(new MultiPartSpecBuilder(thumbnail.getBytes())
+                            .controlName("thumbnail")
+                            .mimeType("image/png")
+                            .build())
+                    .formParams(requestBody)
+            .when()
+                    .post("/api/users/projects")
+            .then()
+                    .statusCode(HttpStatus.OK.value())
+                    .extract()
+                    .as(UserProjectResponse.class);
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     public static Project createProject(Long managerId) {

--- a/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/ProjectProvider.java
@@ -12,14 +12,16 @@ public class ProjectProvider {
     private ProjectRepository projectRepository;
 
     public Project 를_생성한다(Long managerId) {
-        Project project = Project.builder()
+        return projectRepository.save(createProject(managerId));
+    }
+
+    public static Project createProject(Long managerId) {
+        return Project.builder()
                 .managerId(managerId)
-                .name("project name")
-                .description("project description")
+                .name("collaboration")
+                .description("collaboration tool")
                 .thumbnail("s3_content")
                 .build();
-
-        return projectRepository.save(project);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
@@ -12,14 +12,16 @@ public class StoryProvider {
     @Autowired
     private StoryRepository storyRepository;
 
-    public Story 를_생성한다(Project project) {
-        Story story = Story.builder()
-                .title("story title")
+    public Story 를_생성한다(Project project, String title) {
+        return storyRepository.save(createStory(project, title));
+    }
+
+    public static Story createStory(Project project, String title) {
+        return Story.builder()
+                .title(title)
                 .preStories("[]")
                 .project(project)
                 .build();
-
-        return storyRepository.save(story);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
@@ -1,19 +1,33 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
+import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
 import kr.kro.colla.story.domain.Story;
-import kr.kro.colla.story.domain.repository.StoryRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
 
 @Component
 public class StoryProvider {
 
-    @Autowired
-    private StoryRepository storyRepository;
+    public ProjectStoryResponse 를_생성한다(Long projectId, String accessToken, String title) {
+        CreateStoryRequest createStoryRequest = new CreateStoryRequest(title);
 
-    public Story 를_생성한다(Project project, String title) {
-        return storyRepository.save(createStory(project, title));
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(createStoryRequest)
+        .when()
+                .post("/api/projects/" + projectId + "/stories")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(ProjectStoryResponse.class);
     }
 
     public static Story createStory(Project project, String title) {

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TagProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TagProvider.java
@@ -1,0 +1,31 @@
+package kr.kro.colla.common.fixture;
+
+import io.restassured.http.ContentType;
+import kr.kro.colla.project.project.presentation.dto.CreateTagRequest;
+import kr.kro.colla.project.project.presentation.dto.ProjectTagResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+public class TagProvider {
+
+    public ProjectTagResponse 를_생성한다(String accessToken, Long projectId, String tagName) {
+        CreateTagRequest createTagRequest = new CreateTagRequest(tagName);
+
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(createTagRequest)
+        .when()
+                .post("/api/projects/" + projectId + "/tags")
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .as(ProjectTagResponse.class);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -53,4 +53,17 @@ public class TaskProvider {
                 .build();
     }
 
+    public static Task createTaskForRepository(Long managerId, Project project, Story story, TaskStatus taskStatus) {
+        return Task.builder()
+                .title("task title")
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(taskStatus)
+                .story(story)
+                .preTasks("[]")
+                .build();
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -29,4 +29,17 @@ public class TaskProvider {
         return taskRepository.save(task);
     }
 
+    public static Task createTask(Long managerId, Project project, Story story) {
+        return Task.builder()
+                .title("task title")
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(new TaskStatus("To Do"))
+                .story(story)
+                .preTasks("[]")
+                .build();
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -1,32 +1,43 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task.domain.Task;
-import kr.kro.colla.task.task.domain.repository.TaskRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
 
 @Component
 public class TaskProvider {
 
-    @Autowired
-    private TaskRepository taskRepository;
+    public Map<String, String> 를_생성한다(String accessToken, Long managerId, Long projectId, String story) {
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", "task title");
+        formData.put("description", "task description");
+        formData.put("managerId", managerId != null ? managerId.toString() : null);
+        formData.put("priority", "3");
+        formData.put("status", "To Do");
+        formData.put("tags", "[\"backend\"]");
+        formData.put("projectId", projectId.toString());
+        formData.put("story", story);
+        formData.put("preTasks", "[]");
 
-    public Task 를_생성한다(Long managerId, Project project, Story story) {
-        Task task = Task.builder()
-                .title("task title")
-                .managerId(managerId)
-                .description("task description")
-                .priority(4)
-                .project(project)
-                .taskStatus(project.getTaskStatuses().get(0))
-                .story(story)
-                .preTasks("[]")
-                .build();
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+        .when()
+                .post("/api/projects/tasks")
+        .then()
+                .statusCode(HttpStatus.CREATED.value());
 
-        return taskRepository.save(task);
+        return formData;
     }
 
     public static Task createTask(Long managerId, Project project, Story story) {

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusProvider.java
@@ -1,0 +1,28 @@
+package kr.kro.colla.common.fixture;
+
+import io.restassured.http.ContentType;
+import kr.kro.colla.project.project.presentation.dto.CreateTaskStatusRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import static io.restassured.RestAssured.given;
+
+@Component
+public class TaskStatusProvider {
+
+    public void 를_생성한다(String accessToken, Long projectId, String statusName) {
+        CreateTaskStatusRequest request = new CreateTaskStatusRequest(statusName);
+
+        given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(request)
+        .when()
+                .post("/api/projects/" + projectId + "/statuses")
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
@@ -11,14 +11,26 @@ public class UserProvider {
     @Autowired
     private UserRepository userRepository;
 
-    public User 가_회원가입을_한다() {
+    public User 가_로그인을_한다1() {
         return userRepository.save(createUser());
+    }
+
+    public User 가_로그인을_한다2() {
+        return userRepository.save(createUser2());
     }
 
     public static User createUser() {
         return User.builder()
                 .name("yeongkee")
                 .githubId("kykapple")
+                .avatar("s3_content")
+                .build();
+    }
+
+    public static User createUser2() {
+        return User.builder()
+                .name("subin")
+                .githubId("binimini")
                 .avatar("s3_content")
                 .build();
     }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/UserProvider.java
@@ -12,13 +12,15 @@ public class UserProvider {
     private UserRepository userRepository;
 
     public User 가_회원가입을_한다() {
-        User user = User.builder()
+        return userRepository.save(createUser());
+    }
+
+    public static User createUser() {
+        return User.builder()
                 .name("yeongkee")
                 .githubId("kykapple")
                 .avatar("s3_content")
                 .build();
-
-        return userRepository.save(user);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/TaskTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/TaskTest.java
@@ -1,0 +1,35 @@
+package kr.kro.colla.task.task.domain;
+
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskTest {
+
+    @Test
+    void 태스크의_내용을_수정한다() {
+        // given
+        Project project = ProjectProvider.createProject(1L);
+        Task task = TaskProvider.createTask(1L, project, null);
+        UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
+                .title("new title")
+                .managerId("25")
+                .description("new description")
+                .priority(4)
+                .build();
+
+        // when
+        task.updateContents(updateTaskRequest);
+
+        // then
+        assertThat(task.getTitle()).isEqualTo(updateTaskRequest.getTitle());
+        assertThat(task.getManagerId()).isEqualTo(Long.parseLong(updateTaskRequest.getManagerId()));
+        assertThat(task.getDescription()).isEqualTo(updateTaskRequest.getDescription());
+        assertThat(task.getPriority()).isEqualTo(updateTaskRequest.getPriority());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -1,15 +1,22 @@
 package kr.kro.colla.task.task.service;
 
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.StoryProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.project.task_status.service.TaskStatusService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
+import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
+import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
+import kr.kro.colla.task.task_tag.domain.TaskTag;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
@@ -20,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,16 +64,10 @@ class TaskServiceTest {
     void 프로젝트에_새로운_태스크를_생성한다() {
         // given
         String storyTitle = "user can login with github", taskStatusName = "To Do";
+        Project project = ProjectProvider.createProject(1L);
+        Story story = StoryProvider.createStory(project, storyTitle);
+
         CreateTaskRequest createTaskRequest = new CreateTaskRequest("task title", null, "task description", 4, taskStatusName, "[\"backend\"]", 1L, storyTitle, "[]");
-        Project project = Project.builder()
-                .name("collaboration")
-                .description("collaboration tool")
-                .build();
-        Story story = Story.builder()
-                .title(storyTitle)
-                .preStories("[]")
-                .project(project)
-                .build();
         TaskStatus taskStatus = new TaskStatus(taskStatusName);
         Task task = Task.builder()
                 .title(createTaskRequest.getTitle())
@@ -85,6 +87,8 @@ class TaskServiceTest {
                 .willReturn(story);
         given(taskStatusService.findTaskStatusByName(taskStatusName))
                 .willReturn(taskStatus);
+        given(taskTagService.translateTaskTags(any(Task.class), eq(createTaskRequest.getTags())))
+                .willReturn(List.of(new TaskTag(task, new Tag("backend"))));
         given(taskRepository.save(any(Task.class)))
                 .willReturn(task);
 
@@ -96,7 +100,6 @@ class TaskServiceTest {
         verify(projectService, times(1)).findProjectById(1L);
         verify(storyService, times(1)).findStoryByTitle(storyTitle);
         verify(taskStatusService, times(1)).findTaskStatusByName(taskStatusName);
-        verify(taskTagService, times(1)).setTaskTag(any(Task.class), anyString());
         verify(taskRepository, times(1)).save(any(Task.class));
     }
 
@@ -104,30 +107,12 @@ class TaskServiceTest {
     void 프로젝트의_태스크를_조회한다() {
         // given
         Long taskId = 1L, managerId = 5L;
-        User user = User.builder()
-                .name("yeongkee")
-                .githubId("kykapple")
-                .avatar("s3_content")
-                .build();
-        Project project = Project.builder()
-                .name("collaboration")
-                .description("collaboration tool")
-                .build();
-        Story story = Story.builder()
-                .title("user can login with github")
-                .preStories("[]")
-                .project(project)
-                .build();
-        Task task = Task.builder()
-                .title("task title")
-                .managerId(managerId)
-                .description("task description")
-                .priority(4)
-                .project(project)
-                .taskStatus(new TaskStatus("In Progress"))
-                .story(story)
-                .preTasks("[]")
-                .build();
+        User user = UserProvider.createUser();
+        ReflectionTestUtils.setField(user, "id", managerId);
+
+        Project project = ProjectProvider.createProject(user.getId());
+        Story story = StoryProvider.createStory(project, "user can login with github");
+        Task task = TaskProvider.createTask(user.getId(), project, story);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         given(taskRepository.findById(eq(taskId)))
@@ -151,20 +136,8 @@ class TaskServiceTest {
     void 담당자와_스토리가_없는_태스크를_조회한다() {
         // given
         Long taskId = 1L;
-        Project project = Project.builder()
-                .name("collaboration")
-                .description("collaboration tool")
-                .build();
-        Task task = Task.builder()
-                .title("task title")
-                .managerId(null)
-                .description("task description")
-                .priority(4)
-                .project(project)
-                .taskStatus(new TaskStatus("In Progress"))
-                .story(null)
-                .preTasks("[]")
-                .build();
+        Project project = ProjectProvider.createProject(1L);
+        Task task = TaskProvider.createTask(null, project, null);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         given(taskRepository.findById(eq(taskId)))
@@ -176,6 +149,58 @@ class TaskServiceTest {
         // then
         assertThat(projectTaskResponse.getManager()).isNull();
         assertThat(projectTaskResponse.getStory()).isNull();
+    }
+
+    @Test
+    void 태스크의_내용을_수정한다() {
+        // given
+        Long taskId = 1L;
+        User user = UserProvider.createUser();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        Project project = ProjectProvider.createProject(user.getId());
+        Story story = StoryProvider.createStory(project, "story title");
+        Task task = TaskProvider.createTask(user.getId(), project, story);
+        ReflectionTestUtils.setField(task, "id", taskId);
+        task.addTags(List.of(
+                new TaskTag(task, new Tag("backend")),
+                new TaskTag(task, new Tag("frontend"))
+        ));
+
+        UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
+                .title("new title")
+                .managerId("25")
+                .description("new description")
+                .story("new story")
+                .priority(4)
+                .tags("[\"backend\", \"frontend\"]")
+                .build();
+        List<TaskTag> taskTags = List.of(
+                new TaskTag(task, new Tag("refactoring")),
+                new TaskTag(task, new Tag("backend")),
+                new TaskTag(task, new Tag("bug fix"))
+        );
+        Story newStory = StoryProvider.createStory(project, updateTaskRequest.getStory());
+
+        given(taskRepository.findById(taskId))
+                .willReturn(Optional.of(task));
+        given(taskTagService.translateTaskTags(any(Task.class), eq(updateTaskRequest.getTags())))
+                .willReturn(taskTags);
+        given(storyService.findStoryByTitle(eq(updateTaskRequest.getStory())))
+                .willReturn(newStory);
+
+        // when
+        taskService.updateTask(taskId, updateTaskRequest);
+
+        // then
+        assertThat(task.getTitle()).isEqualTo(updateTaskRequest.getTitle());
+        assertThat(task.getDescription()).isEqualTo(updateTaskRequest.getDescription());
+        assertThat(task.getStory().getTitle()).isEqualTo(newStory.getTitle());
+        assertThat(task.getManagerId()).isNotEqualTo(taskId);
+        assertThat(task.getPriority()).isEqualTo(updateTaskRequest.getPriority());
+        assertThat(task.getTaskTags()).hasSize(3);
+        assertThat(task.getTaskTags()).extracting(taskTag -> taskTag.getTag().getName())
+                .containsExactly("backend", "refactoring", "bug fix");
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task_tag/service/TaskTagServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_tag/service/TaskTagServiceTest.java
@@ -1,5 +1,7 @@
 package kr.kro.colla.task.task_tag.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
@@ -14,14 +16,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class TaskTagServiceTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private TagService tagService;
@@ -33,7 +38,7 @@ class TaskTagServiceTest {
     private TaskTagService taskTagService;
 
     @Test
-    void 태스트에_선택한_태그들을_지정한다() {
+    void 태스크에_선택한_태그들을_지정한다() throws Exception {
         // given
         Task task = Task.builder()
                 .title("task title")
@@ -46,6 +51,8 @@ class TaskTagServiceTest {
                 new Tag("refactoring")
         );
 
+        given(objectMapper.readValue(eq(tags), any(TypeReference.class)))
+                .willReturn(List.of("backend", "refactoring"));
         given(tagService.findTagsByName(any(List.class)))
                 .willReturn(tagList);
 

--- a/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/user/user/AcceptanceTest.java
@@ -82,7 +82,7 @@ public class AcceptanceTest {
                 .build();
         userRepository.save(user);
 
-        accessToken = auth.로그인(user.getId());
+        accessToken = auth.토큰을_발급한다(user.getId());
     }
 
     @AfterEach

--- a/frontend/src/components/Modal/Task/Comment/index.tsx
+++ b/frontend/src/components/Modal/Task/Comment/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { Comment, CommentInput, Container, SaveButton, Title } from './style';
+
+export const CommentContainer = () => (
+    <Container>
+        <Title>댓글</Title>
+        <Comment>
+            <CommentInput />
+            <SaveButton>등록</SaveButton>
+        </Comment>
+    </Container>
+);

--- a/frontend/src/components/Modal/Task/Comment/style.ts
+++ b/frontend/src/components/Modal/Task/Comment/style.ts
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { LiftUp } from '../../../../styles/common';
+
+export const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    width: 530px;
+    min-height: 50px;
+    margin-left: 40px;
+`;
+
+export const Title = styled.div`
+    margin: 0 0 10px 5px;
+`;
+
+export const Comment = styled.div`
+    display: flex;
+    flex-direction: row;
+`;
+
+export const CommentInput = styled.input`
+    border: none;
+    width: 450px;
+    height: 40px;
+    border-radius: 10px;
+    padding-left: 10px;
+    font-size: 15px;
+`;
+
+export const SaveButton = styled.div`
+    margin: 10px 0 0 15px;
+    cursor: pointer;
+
+    ${LiftUp}
+`;

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -4,6 +4,7 @@ import { getTask } from '../../../apis/task';
 import useInputTask from '../../../hooks/useInputTask';
 import { TaskType } from '../../../types/kanban';
 import { BasicInfoContainer } from './Basic';
+import { CommentContainer } from './Comment';
 import { DetailInfoContainer } from './Detail';
 import { Container, ModalContainer, CancelButton, CompleteButton, ButtonContainer } from './style';
 
@@ -34,6 +35,7 @@ export const TaskModal: FC<PropType> = ({ taskId, status, taskList, hideModal })
                 <BasicInfoContainer taskList={taskList} basicInfoInput={basicInfoInput} />
                 <DetailInfoContainer status={status} detailInfoInput={detailInfoInput} />
             </Container>
+            <CommentContainer />
             <ButtonContainer>
                 <CancelButton onClick={() => hideModal()}>취소</CancelButton>
                 <CompleteButton onClick={() => handleCompleteButton(taskId)}>{taskId ? '수정' : '완료'}</CompleteButton>

--- a/frontend/src/components/Modal/Task/style.ts
+++ b/frontend/src/components/Modal/Task/style.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { RED, WHITE } from '../../../styles/color';
+import { LIGHT_GRAY, RED } from '../../../styles/color';
 import { LiftUp } from '../../../styles/common';
 
 export const ModalContainer = styled.div`
@@ -11,7 +11,7 @@ export const ModalContainer = styled.div`
     min-height: 430px;
     margin-top: 70px;
     border-radius: 20px;
-    background-color: ${WHITE};
+    background-color: ${LIGHT_GRAY};
     box-shadow: 0 4px 4px rgba(0, 0, 0, 0.1), 0 4px 20px rgba(0, 0, 0, 0.1);
 `;
 

--- a/frontend/src/styles/color.ts
+++ b/frontend/src/styles/color.ts
@@ -7,4 +7,4 @@ export const DARK_GREEN = 'rgba(203, 218, 204)';
 
 export const RED = `#ff0000`;
 
-export const WHITE = '#f1f1f1';
+export const WHITE = '#fff';


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 태스크 수정 API 테스트 코드 작성
- 댓글 API 구현
- 댓글 API 테스트 코드 작성
- 인수 테스트 리팩토링

### 📑 구현한 내용 목록
- [x] 태스크 수정 API 테스트 코드 작성
- [x] 댓글 API 구현
- [x] 댓글 API 테스트 코드 작성
- [x] 인수 테스트 리팩토링

### 🚧 논의 사항
- 인수 테스트의 given 절 fixture가 너무 중복되고, 복잡해서 리팩토링 하고 싶었는데 드디어 완료하였습니다. fixture를 API 통신으로 구성해주었고, 최대한 가독성 좋게 한글 함수로 구성하였습니다😆
- DatabaseCleaner를 통해 테스트 수행 전에 항상 DB를 초기화해주도록 하였습니다.
- 댓글 API는 구현하였는데, 아직 프론트 작업을 하지 못해 마저 진행하도록 하겠습니다~!

- close #79 
- #80 