### PR TITLE
[#93] feat: 백로그 태스크 중요도순 정렬 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -141,11 +141,6 @@ public class ProjectService {
         return noticeService.decideInvitation(loginUserId, project, projectMemberDecision);
     }
 
-    public Project findProjectById(Long projectId) {
-        return projectRepository.findById(projectId)
-                .orElseThrow(ProjectNotFoundException::new);
-    }
-
     public TaskStatus createTaskStatus(Long projectId, String name) {
         Project project = findProjectById(projectId);
 
@@ -169,5 +164,10 @@ public class ProjectService {
                 .stream()
                 .map(ProjectTaskStatusResponse::new)
                 .collect(Collectors.toList());
+    }
+
+    public Project findProjectById(Long projectId) {
+        return projectRepository.findById(projectId)
+                .orElseThrow(ProjectNotFoundException::new);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/domain/TaskStatus.java
@@ -21,7 +21,7 @@ public class TaskStatus {
     @Column
     private String name;
 
-    @OneToMany(mappedBy = "taskStatus", fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "taskStatus", fetch = FetchType.LAZY)
     private List<Task> tasks = new ArrayList<>();
 
     public TaskStatus(String name){

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.task.task.domain.repository;
 
+import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,8 +8,15 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
+
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Task t SET t.taskStatus = :to WHERE  t.taskStatus = :from")
+    @Query("update Task t set t.taskStatus = :to where t.taskStatus = :from")
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
+
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority asc")
+    List<Task> findAllOrderByPriority(@Param("project")Project project);
+
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -1,9 +1,6 @@
 package kr.kro.colla.task.task.presentation;
 
-import kr.kro.colla.task.task.presentation.dto.UpdateTaskStatusRequest;
-import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
-import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
-import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.*;
 import kr.kro.colla.task.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/projects/tasks")
@@ -50,6 +48,13 @@ public class TaskController {
 
         return ResponseEntity.ok()
                 .build();
+    }
+
+    @GetMapping("/priority")
+    public ResponseEntity<List<ProjectTaskResponse>> getTasksOrderByPriority(@Valid @RequestBody ProjectTaskRequest projectTaskRequest) {
+        List<ProjectTaskResponse> taskList = taskService.getTasksOrderByPriority(projectTaskRequest.getProjectId());
+
+        return ResponseEntity.ok(taskList);
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskRequest.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskRequest.java
@@ -1,10 +1,12 @@
 package kr.kro.colla.task.task.presentation.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 public class ProjectTaskRequest {

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskRequest.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskRequest.java
@@ -1,0 +1,15 @@
+package kr.kro.colla.task.task.presentation.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@Getter
+public class ProjectTaskRequest {
+
+    @NotNull
+    private Long projectId;
+
+}

--- a/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/AcceptanceTest.java
@@ -71,7 +71,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null, 3);
 
         CreateCommentRequest createCommentRequest = new CreateCommentRequest(null, "comment contents");
 
@@ -103,7 +103,7 @@ public class AcceptanceTest {
         String member2AccessToken = auth.토큰을_발급한다(member2.getId());
 
         UserProjectResponse createdProject = project.를_생성한다(member1AccessToken);
-        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null);
+        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null, 3);
         CreateCommentResponse registeredComment = comment.를_등록한다(member2AccessToken, null);
 
         CreateCommentRequest createCommentRequest = new CreateCommentRequest(registeredComment.getId(), "comment contents");
@@ -136,7 +136,7 @@ public class AcceptanceTest {
         String member2AccessToken = auth.토큰을_발급한다(member2.getId());
 
         UserProjectResponse createdProject = project.를_생성한다(member1AccessToken);
-        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null);
+        task.를_생성한다(member1AccessToken, member1.getId(), createdProject.getId(), null, 3);
 
         CreateCommentResponse registeredComment1 = comment.를_등록한다(member2AccessToken, null);
         CreateCommentResponse registeredComment2 = comment.를_등록한다(member2AccessToken, null);
@@ -177,7 +177,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null, 3);
         CreateCommentResponse createdComment = comment.를_등록한다(accessToken, null);
 
         UpdateCommentRequest updateCommentRequest = new UpdateCommentRequest("new contents");
@@ -203,7 +203,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null, 2);
         CreateCommentResponse createdComment = comment.를_등록한다(accessToken, null);
 
         UpdateCommentRequest updateCommentRequest = new UpdateCommentRequest("");

--- a/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/domain/repository/CommentRepositoryTest.java
@@ -70,7 +70,7 @@ class CommentRepositoryTest {
         // given
         User user = userRepository.save(UserProvider.createUser());
         Project project = projectRepository.save(ProjectProvider.createProject(user.getId()));
-        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0)));
+        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0), 3));
         commentRepository.saveAll(List.of(
                 CommentProvider.createComment(user, task, null, "first comment contents"),
                 CommentProvider.createComment(user, task, null, "second comment contents")
@@ -91,7 +91,7 @@ class CommentRepositoryTest {
         // given
         User user = userRepository.save(UserProvider.createUser());
         Project project = projectRepository.save(ProjectProvider.createProject(user.getId()));
-        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0)));
+        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0), 3));
         Comment comment = commentRepository.save(CommentProvider.createComment(user, task, null, "comment contents"));
 
         // when
@@ -108,7 +108,7 @@ class CommentRepositoryTest {
         // given
         User user = userRepository.save(UserProvider.createUser());
         Project project = projectRepository.save(ProjectProvider.createProject(user.getId()));
-        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0)));
+        Task task = taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, project.getTaskStatuses().get(0), 3));
         Comment superComment = commentRepository.save(CommentProvider.createComment(user, task, null, "super comment contents"));
         Comment subComment = commentRepository.save(CommentProvider.createComment(user, task, superComment, "sub comment contents"));
 

--- a/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/presentation/CommentControllerTest.java
@@ -95,7 +95,7 @@ class CommentControllerTest extends ControllerTest {
 
         User user = UserProvider.createUser();
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(user.getId(), project, null);
+        Task task = TaskProvider.createTask(user.getId(), project, null, 3);
 
         Comment comment1 = CommentProvider.createComment(user, task, null, "first comment contents");
         Comment comment2 = CommentProvider.createComment(user, task, comment1, "first comment's subComment");

--- a/backend/src/test/java/kr/kro/colla/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/comment/service/CommentServiceTest.java
@@ -54,7 +54,7 @@ class CommentServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(user.getId(), project, null);
+        Task task = TaskProvider.createTask(user.getId(), project, null, 3);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         CreateCommentRequest createCommentRequest = new CreateCommentRequest(null, "comment contents");
@@ -84,7 +84,7 @@ class CommentServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(user.getId(), project, null);
+        Task task = TaskProvider.createTask(user.getId(), project, null, 4);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         Comment superComment = CommentProvider.createComment(user, task, null, "first comment contents");
@@ -115,7 +115,7 @@ class CommentServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(user.getId(), project, null);
+        Task task = TaskProvider.createTask(user.getId(), project, null, 2);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         Comment comment1 = CommentProvider.createComment(user, task, null, "first comment contents");

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -16,12 +16,12 @@ import static io.restassured.RestAssured.given;
 @Component
 public class TaskProvider {
 
-    public Map<String, String> 를_생성한다(String accessToken, Long managerId, Long projectId, String story) {
+    public Map<String, String> 를_생성한다(String accessToken, Long managerId, Long projectId, String story, int priority) {
         Map<String, String> formData = new HashMap<>();
         formData.put("title", "task title");
         formData.put("description", "task description");
         formData.put("managerId", managerId != null ? managerId.toString() : null);
-        formData.put("priority", "3");
+        formData.put("priority", String.valueOf(priority));
         formData.put("status", "To Do");
         formData.put("tags", "[\"backend\"]");
         formData.put("projectId", projectId.toString());
@@ -40,12 +40,12 @@ public class TaskProvider {
         return formData;
     }
 
-    public static Task createTask(Long managerId, Project project, Story story) {
+    public static Task createTask(Long managerId, Project project, Story story, int priority) {
         return Task.builder()
                 .title("task title")
                 .managerId(managerId)
                 .description("task description")
-                .priority(4)
+                .priority(priority)
                 .project(project)
                 .taskStatus(new TaskStatus("To Do"))
                 .story(story)
@@ -53,12 +53,12 @@ public class TaskProvider {
                 .build();
     }
 
-    public static Task createTaskForRepository(Long managerId, Project project, Story story, TaskStatus taskStatus) {
+    public static Task createTaskForRepository(Long managerId, Project project, Story story, TaskStatus taskStatus, int priority) {
         return Task.builder()
                 .title("task title")
                 .managerId(managerId)
                 .description("task description")
-                .priority(4)
+                .priority(priority)
                 .project(project)
                 .taskStatus(taskStatus)
                 .story(story)

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -545,12 +545,9 @@ public class AcceptanceTest {
                 .extract()
                 .body()
                 .as(new TypeRef<List<ProjectTaskStatusResponse>>(){});
+
         assertThat(response.size()).isEqualTo(3);
-        response
-                .stream()
-                .forEach(s -> assertThat(s.getId()).isNotNull());
-        response
-                .stream()
-                .forEach(s -> assertThat(List.of("To Do","In Progress", "Done").contains(s.getName())));
+        response.forEach(s -> assertThat(s.getId()).isNotNull());
+        response.forEach(s -> assertThat(List.of("To Do","In Progress", "Done").contains(s.getName())));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -1,11 +1,14 @@
 package kr.kro.colla.task.task;
 
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
 import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
 import kr.kro.colla.task.task.presentation.dto.UpdateTaskStatusRequest;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
@@ -19,9 +22,11 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 
@@ -124,7 +129,7 @@ public class AcceptanceTest {
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
         ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
-        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle());
+        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle(), 3);
 
         given()
                 .contentType(ContentType.JSON)
@@ -151,7 +156,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        Map<String, String> createdTask = task.를_생성한다(accessToken, null, createdProject.getId(), null);
+        Map<String, String> createdTask = task.를_생성한다(accessToken, null, createdProject.getId(), null, 3);
 
         given()
                 .contentType(ContentType.JSON)
@@ -176,7 +181,7 @@ public class AcceptanceTest {
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
         ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
-        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle());
+        task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle(), 3);
 
         Map<String, String> formData = new HashMap<>();
         formData.put("title", "new title");
@@ -208,7 +213,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null, 3);
 
         ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
         createdTask.put("story", createdStory.getTitle());
@@ -235,7 +240,7 @@ public class AcceptanceTest {
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
         ProjectStoryResponse oldStory = story.를_생성한다(createdProject.getId(), accessToken, "old story");
-        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), oldStory.getTitle());
+        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), oldStory.getTitle(), 3);
 
         ProjectStoryResponse newStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
         createdTask.put("story", newStory.getTitle());
@@ -261,7 +266,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
+        Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null, 3);
 
         createdTask.put("story", "");
 
@@ -288,7 +293,7 @@ public class AcceptanceTest {
         User loginedUser = user.가_로그인을_한다2();
         String accessToken = auth.토큰을_발급한다(loginedUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, null, createdProject.getId(), null);
+        task.를_생성한다(accessToken, null, createdProject.getId(), null, 3);
         taskStatus.를_생성한다(accessToken, createdProject.getId(), newStatusName);
 
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest(newStatusName);
@@ -312,7 +317,7 @@ public class AcceptanceTest {
         User loginedUser = user.가_로그인을_한다2();
         String accessToken = auth.토큰을_발급한다(loginedUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        task.를_생성한다(accessToken, null, createdProject.getId(), null);
+        task.를_생성한다(accessToken, null, createdProject.getId(), null, 3);
 
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest();
 
@@ -330,4 +335,41 @@ public class AcceptanceTest {
                 .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
                 .body("message", equalTo("statusName : 널이어서는 안됩니다"));
     }
+
+    @Test
+    void 사용자가_프로젝트의_태스크를_중요도순으로_조회한다() {
+        // given
+        User member1 = user.가_로그인을_한다1();
+        User member2 = user.가_로그인을_한다2();
+        String accessToken = auth.토큰을_발급한다(member1.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        task.를_생성한다(accessToken, member1.getId(), createdProject.getId(), null, 2);
+        task.를_생성한다(accessToken, member2.getId(), createdProject.getId(), null, 1);
+
+        ProjectTaskRequest projectTaskRequest = new ProjectTaskRequest(createdProject.getId());
+
+        List<ProjectTaskResponse> response = given()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+                .body(projectTaskRequest)
+
+        // when
+        .when()
+                .get("/api/projects/tasks/priority")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<ProjectTaskResponse>>() {});
+
+        assertThat(response.size()).isEqualTo(2);
+        assertThat(response.get(0).getManager()).isEqualTo(member2.getName());
+        assertThat(response.get(1).getManager()).isEqualTo(member1.getName());
+        assertThat(response.get(0).getId()).isEqualTo(2L);
+        assertThat(response.get(1).getId()).isEqualTo(1L);
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/TaskTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/TaskTest.java
@@ -14,7 +14,7 @@ class TaskTest {
     void 태스크의_내용을_수정한다() {
         // given
         Project project = ProjectProvider.createProject(1L);
-        Task task = TaskProvider.createTask(1L, project, null);
+        Task task = TaskProvider.createTask(1L, project, null, 5);
         UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
                 .title("new title")
                 .managerId("25")

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -1,6 +1,5 @@
 package kr.kro.colla.task.task.presentation;
 
-import io.restassured.mapper.ObjectMapper;
 import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
@@ -92,11 +91,13 @@ class TaskControllerTest extends ControllerTest {
         Long taskId = 13494L;
         String statusNameToUpdate = "새로운~상태~값~입니다~";
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest(statusNameToUpdate);
+
         // when
         ResultActions perform = mockMvc.perform(patch("/projects/tasks/"+taskId)
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
+
         // then
         perform
                 .andExpect(status().isOk());
@@ -108,17 +109,19 @@ class TaskControllerTest extends ControllerTest {
         // given
         Long taskId = 13494L;
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest();
+
         // when
         ResultActions perform = mockMvc.perform(patch("/projects/tasks/"+taskId)
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
+
         // then
         perform
                 .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.message").value("statusName : must not be null"));
         verify(taskService, times(0)).updateTaskStatus(eq(taskId), anyString());
-
     }
+
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -111,7 +111,7 @@ class TaskServiceTest {
 
         Project project = ProjectProvider.createProject(user.getId());
         Story story = StoryProvider.createStory(project, "user can login with github");
-        Task task = TaskProvider.createTask(user.getId(), project, story);
+        Task task = TaskProvider.createTask(user.getId(), project, story, 3);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         given(taskRepository.findById(eq(taskId)))
@@ -136,7 +136,7 @@ class TaskServiceTest {
         // given
         Long taskId = 1L;
         Project project = ProjectProvider.createProject(1L);
-        Task task = TaskProvider.createTask(null, project, null);
+        Task task = TaskProvider.createTask(null, project, null, 3);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         given(taskRepository.findById(eq(taskId)))
@@ -159,7 +159,7 @@ class TaskServiceTest {
 
         Project project = ProjectProvider.createProject(user.getId());
         Story story = StoryProvider.createStory(project, "story title");
-        Task task = TaskProvider.createTask(user.getId(), project, story);
+        Task task = TaskProvider.createTask(user.getId(), project, story, 3);
         ReflectionTestUtils.setField(task, "id", taskId);
         task.addTags(List.of(
                 new TaskTag(task, new Tag("backend")),
@@ -210,7 +210,7 @@ class TaskServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(null, project, null);
+        Task task = TaskProvider.createTask(null, project, null, 5);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
@@ -245,7 +245,7 @@ class TaskServiceTest {
 
         Project project = ProjectProvider.createProject(user.getId());
         Story oldStory = StoryProvider.createStory(project, "old story");
-        Task task = TaskProvider.createTask(null, project, oldStory);
+        Task task = TaskProvider.createTask(null, project, oldStory, 4);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
@@ -281,7 +281,7 @@ class TaskServiceTest {
 
         Project project = ProjectProvider.createProject(user.getId());
         Story oldStory = StoryProvider.createStory(project, "old story");
-        Task task = TaskProvider.createTask(null, project, oldStory);
+        Task task = TaskProvider.createTask(null, project, oldStory, 1);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
@@ -310,7 +310,7 @@ class TaskServiceTest {
         ReflectionTestUtils.setField(user, "id", userId);
 
         Project project = ProjectProvider.createProject(user.getId());
-        Task task = TaskProvider.createTask(null, project, null);
+        Task task = TaskProvider.createTask(null, project, null, 3);
         ReflectionTestUtils.setField(task, "id", taskId);
 
         UpdateTaskRequest updateTaskRequest = UpdateTaskRequest.builder()
@@ -366,7 +366,7 @@ class TaskServiceTest {
         Long taskId = 482593L;
         TaskStatus before = new TaskStatus("기존_상태값");
         TaskStatus after = new TaskStatus("변경_후_새로운_상태값");
-        Task task = TaskProvider.createTaskForRepository(2345L, null, null, before);
+        Task task = TaskProvider.createTaskForRepository(2345L, null, null, before, 3);
 
         given(taskRepository.findById(taskId))
                 .willReturn(Optional.of(task));
@@ -378,4 +378,31 @@ class TaskServiceTest {
         // then
         assertThat(task.getTaskStatus().getName()).isEqualTo(after.getName());
     }
+
+    @Test
+    void 프로젝트의_태스크를_중요도순_으로_정렬하여_조회한다() {
+        // given
+        Long projectId = 1L, memberId = 5L;
+        User member = UserProvider.createUser();
+        Project project = ProjectProvider.createProject(memberId);
+
+        Task task1 = TaskProvider.createTask(memberId, project, null, 3);
+        Task task2 = TaskProvider.createTask(memberId, project, null, 1);
+
+        given(projectService.findProjectById(eq(projectId)))
+                .willReturn(project);
+        given(taskRepository.findAllOrderByPriority(any(Project.class)))
+                .willReturn(List.of(task2, task1));
+        given(userService.findUserById(eq(memberId)))
+                .willReturn(member);
+
+        // when
+        List<ProjectTaskResponse> taskList = taskService.getTasksOrderByPriority(projectId);
+
+        // then
+        assertThat(taskList.size()).isEqualTo(2);
+        assertThat(taskList.get(0).getTitle()).isEqualTo(task2.getTitle());
+        assertThat(taskList.get(1).getTitle()).isEqualTo(task1.getTitle());
+    }
+
 }


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 백로그 태스크 중요도 정렬 API 구현
- 테스트 코드 작성

### 📑 구현한 내용 목록
- [x] 백로그 태스크 중요도 정렬 API 구현
- [x] 테스트 코드 작성

### 🚧 논의 사항
- 프로젝트의 모든 태스크를 중요도 순으로 조회해오는 로직에서 조회해온 태스크를 DTO로 변환하는데, 지연로딩으로 설정된 각 엔티티들을 끌어오면서 29번의 쿼리가 발생하는 것을 확인하였습니다. 그 후 해결책을 고민해보다가 프로젝트와 관련된 멤버, 스토리, 태스크 상태값을 미리 영속성 컨텍스트에 로딩해두면 어떨까하는 생각에 `Hibernate.initialize(Object proxy)`를 통해 미리 로딩해두었고, 그 결과 5번으로 줄일 수 있었습니다.
- 테스트 코드를 작성할 때 `TaskProvider`에서 생성하는 태스크들의 중요도가 다 똑같아 매개변수로 중요도를 받을 수 있도록 수정하였습니다. 처음에는 메소드를 변경하지 않고 시도해보았는데, 결국 중복되는 로직을 가진 `create` 함수가 계속 늘어나 매개변수로 받도록 수정하였습니다.
- 현재 중요도 정렬 URL을 GET인데 일단 body를 받도록 두었는데, projectId를 받기 위해서 TaskController url을 바꿔도 좋을 것 같은데 어떻게 생각하시나요!?

- close #93 
