### PR TITLE
[#94] feat: 생성 날짜 기준 정렬 테스크 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/Task.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EntityListeners(EntityListeners.class)
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 public class Task {
 

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.task.task.domain.repository;
 
+import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,8 +8,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface TaskRepository extends JpaRepository<Task, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Task t SET t.taskStatus = :to WHERE  t.taskStatus = :from")
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
+
+    List<Task> findByProjectOrderByCreatedAtAsc(Project project);
+
+    List<Task> findByProjectOrderByCreatedAtDesc(Project project);
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -1,9 +1,6 @@
 package kr.kro.colla.task.task.presentation;
 
-import kr.kro.colla.task.task.presentation.dto.UpdateTaskStatusRequest;
-import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
-import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
-import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
+import kr.kro.colla.task.task.presentation.dto.*;
 import kr.kro.colla.task.task.service.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +9,16 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
+import java.util.List;
 
 @RequiredArgsConstructor
-@RequestMapping("/projects/tasks")
+@RequestMapping("/projects")
 @Controller
 public class TaskController {
 
     private final TaskService taskService;
 
-    @PostMapping
+    @PostMapping("/tasks")
     public ResponseEntity<Void> createTask(@Valid CreateTaskRequest createTaskRequest) {
         Long taskId = taskService.createTask(createTaskRequest);
         URI redirectUrl = URI.create("/api/projects/tasks/" + taskId);
@@ -29,14 +27,14 @@ public class TaskController {
                 .build();
     }
 
-    @GetMapping("/{taskId}")
+    @GetMapping("/tasks/{taskId}")
     public ResponseEntity<ProjectTaskResponse> getTask(@PathVariable Long taskId) {
         ProjectTaskResponse projectTaskResponse = taskService.getTask(taskId);
 
         return ResponseEntity.ok(projectTaskResponse);
     }
 
-    @PutMapping("/{taskId}")
+    @PutMapping("/tasks/{taskId}")
     public ResponseEntity<Void> updateTask(@PathVariable Long taskId, @Valid UpdateTaskRequest updateTaskRequest) {
         taskService.updateTask(taskId, updateTaskRequest);
 
@@ -44,7 +42,7 @@ public class TaskController {
                 .build();
     }
 
-    @PatchMapping("/{taskId}")
+    @PatchMapping("/tasks/{taskId}")
     public ResponseEntity<Void> updateTaskStatus(@PathVariable Long taskId, @Valid @RequestBody UpdateTaskStatusRequest request) {
         taskService.updateTaskStatus(taskId, request.getStatusName());
 
@@ -52,4 +50,10 @@ public class TaskController {
                 .build();
     }
 
+    @GetMapping("/{projectId}/tasks/sorting/create-date")
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksSortByCreateDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
+        List<ProjectTaskSimpleResponse> responses = taskService.getTasksOrderByCreateDate(projectId, ascending);
+
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskSimpleResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectTaskSimpleResponse.java
@@ -1,0 +1,48 @@
+package kr.kro.colla.task.task.presentation.dto;
+
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.user.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProjectTaskSimpleResponse {
+
+    private Long id;
+
+    private String managerName;
+
+    private String managerAvatar;
+
+    private String title;
+
+    private String description;
+
+    private Integer priority;
+
+    private String status;
+
+    private List<String> tags;
+
+    public ProjectTaskSimpleResponse(Task task, User manager) {
+        this.id = task.getId();
+        this.title = task.getTitle();
+        this.description = task.getDescription();
+        this.priority = task.getPriority();
+        this.status = task.getTaskStatus().getName();
+        this.tags = task.getTaskTags()
+                .stream()
+                .map(taskTag -> taskTag.getTag().getName())
+                .collect(Collectors.toList());
+        if (manager!=null){
+            this.managerName = manager.getName();
+            this.managerAvatar = manager.getAvatar();
+        }
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -11,6 +11,7 @@ import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
@@ -115,5 +116,22 @@ public class TaskService {
         Task task = findTaskById(taskId);
         TaskStatus taskStatus = taskStatusService.findTaskStatusByName(statusName);
         task.updateTaskStatus(taskStatus);
+    }
+
+    public List<ProjectTaskSimpleResponse> getTasksOrderByCreateDate(Long projectId, Boolean asc) {
+        Project project = projectService.findProjectById(projectId);
+        List<Task> result = asc ?
+                taskRepository.findByProjectOrderByCreatedAtAsc(project) :
+                taskRepository.findByProjectOrderByCreatedAtDesc(project);
+
+        return result.stream()
+                .map(task -> {
+                    User user = null;
+                    if (task.getManagerId()!=null) {
+                        user = userService.findUserById(task.getManagerId());
+                    }
+                    return new ProjectTaskSimpleResponse(task, user);
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -1,13 +1,17 @@
 package kr.kro.colla.task.task;
 
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
+import kr.kro.colla.project.project.presentation.dto.ProjectResponse;
 import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.UpdateTaskStatusRequest;
 import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.presentation.dto.CreateProjectRequest;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,10 +22,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
 
@@ -329,5 +337,35 @@ public class AcceptanceTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
                 .body("message", equalTo("statusName : 널이어서는 안됩니다"));
+    }
+
+    @Test
+    void 사용자는_프로젝트의_테스크를_생성_날짜_오름차순으로_조회할_수_있다() {
+        // given
+        User loginedUser = user.가_로그인을_한다2();
+        String accessToken = auth.토큰을_발급한다(loginedUser.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        task.를_생성한다(accessToken, loginedUser.getId(), createdProject.getId(), null);
+        task.를_생성한다(accessToken, null, createdProject.getId(), null);
+        List<ProjectTaskSimpleResponse> responses = given()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + createdProject.getId() + "/tasks/sorting/create-date?ascending=true")
+
+        // then
+        .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<ProjectTaskSimpleResponse>>() {});
+        assertThat(responses.size()).isEqualTo(2);
+        assertThat(responses
+                        .stream()
+                        .map(ProjectTaskSimpleResponse::getManagerName)
+                        .collect(Collectors.toList()).containsAll(Arrays.asList(loginedUser.getName(), null)));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -12,13 +12,18 @@ import kr.kro.colla.task.task.domain.Task;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @DataJpaTest
+@EnableJpaAuditing
 class TaskRepositoryTest {
 
     @Autowired
@@ -119,4 +124,49 @@ class TaskRepositoryTest {
         assertThat(result2.getTaskStatus().getId()).isEqualTo(taskStatus2.getId());
     }
 
+    @Test
+    void 프로젝트의_테스크들을_생성_날짜_오름차순으로_정렬해_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(234234L));
+        TaskStatus taskStatus = taskStatusRepository.save(new TaskStatus("new TaskStatus for Test"));
+        List<Task> tasks = List.of(
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus)),
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus)),
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus))
+        );
+
+        // when
+        List<Task> result = taskRepository.findByProjectOrderByCreatedAtAsc(project);
+
+        // then
+        assertThat(result.size()).isEqualTo(tasks.size());
+        IntStream.range(0, result.size())
+                .filter(idx -> idx != 0)
+                .forEach(idx -> {
+                    assertThat(result.get(idx).getCreatedAt().isBefore(result.get(idx-1).getCreatedAt()));
+                });
+    }
+
+    @Test
+    void 프로젝트의_테스크들을_생성_날짜_내림차순으로_정렬해_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(234234L));
+        TaskStatus taskStatus = taskStatusRepository.save(new TaskStatus("new TaskStatus for Test"));
+        List<Task> tasks = List.of(
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus)),
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus)),
+                taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus))
+        );
+
+        // when
+        List<Task> result = taskRepository.findByProjectOrderByCreatedAtDesc(project);
+
+        // then
+        assertThat(result.size()).isEqualTo(tasks.size());
+        IntStream.range(0, result.size())
+                .filter(idx -> idx != 0)
+                .forEach(idx -> {
+                    assertThat(result.get(idx).getCreatedAt().isAfter(result.get(idx-1).getCreatedAt()));
+                });
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -2,8 +2,13 @@ package kr.kro.colla.task.task.presentation;
 
 import io.restassured.mapper.ObjectMapper;
 import kr.kro.colla.common.ControllerTest;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
+import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.UpdateTaskStatusRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -16,8 +21,10 @@ import org.springframework.test.web.servlet.ResultActions;
 import javax.servlet.http.Cookie;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -120,5 +127,61 @@ class TaskControllerTest extends ControllerTest {
                     .andExpect(jsonPath("$.message").value("statusName : must not be null"));
         verify(taskService, times(0)).updateTaskStatus(eq(taskId), anyString());
 
+    }
+
+    @Test
+    void 테스크_목록을_생성_날짜_오름차순으로_조회한다() throws Exception {
+        // given
+        Long projectId = 52494L;
+        Project project = ProjectProvider.createProject(92348L);
+        TaskProvider.createTask(null, project, null);
+        List<ProjectTaskSimpleResponse> responses = List.of(
+                new ProjectTaskSimpleResponse(TaskProvider.createTask(null, project, null), null),
+                new ProjectTaskSimpleResponse(TaskProvider.createTask(82349L, project, null), UserProvider.createUser())
+        );
+
+        given(taskService.getTasksOrderByCreateDate(projectId, true))
+                .willReturn(responses);
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/sorting/create-date?ascending=true")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(responses.size()))
+                .andExpect(jsonPath("$[*].title").value(containsInAnyOrder(responses
+                        .stream()
+                        .map(r -> r.getTitle())
+                        .toArray())))
+                .andExpect(jsonPath("$[*].managerName").value(containsInAnyOrder(responses
+                        .stream()
+                        .map(r -> r.getManagerName())
+                        .toArray())));
+        verify(taskService, times(1)).getTasksOrderByCreateDate(projectId, true);
+    }
+
+    @Test
+    void 테스크_목록을_생성_날짜_내림차순으로_조회한다() throws Exception {
+        // given
+        Long projectId = 52494L;
+        Project project = ProjectProvider.createProject(92348L);
+        TaskProvider.createTask(null, project, null);
+        List<ProjectTaskSimpleResponse> responses = List.of(
+                new ProjectTaskSimpleResponse(TaskProvider.createTask(null, project, null), null),
+                new ProjectTaskSimpleResponse(TaskProvider.createTask(82349L, project, null), UserProvider.createUser())
+        );
+
+        given(taskService.getTasksOrderByCreateDate(projectId, false))
+                .willReturn(responses);
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/sorting/create-date")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(responses.size()));
+        verify(taskService, times(1)).getTasksOrderByCreateDate(projectId, false);
     }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -15,6 +15,7 @@ import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
+import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.UpdateTaskRequest;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
@@ -29,6 +30,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -377,5 +379,69 @@ class TaskServiceTest {
 
         // then
         assertThat(task.getTaskStatus().getName()).isEqualTo(after.getName());
+    }
+
+    @Test
+    void 테스크를_생성_날짜_오름차순으로_조회한다() {
+        // given
+        Long projectId = 132128L, managerId = 9283L;
+        Project project = ProjectProvider.createProject(120394L);
+        User user = UserProvider.createUser2();
+        List<Task> tasks = List.of(
+                TaskProvider.createTask(managerId,project,null),
+                TaskProvider.createTask(null,project,null)
+        );
+
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
+        given(taskRepository.findByProjectOrderByCreatedAtAsc(any(Project.class)))
+                .willReturn(tasks);
+        given(userService.findUserById(managerId))
+                .willReturn(user);
+
+        // when
+        List<ProjectTaskSimpleResponse> result = taskService.getTasksOrderByCreateDate(projectId, true);
+
+        // then
+        assertThat(result.size()).isEqualTo(tasks.size());
+        List<String> names = result
+                .stream()
+                .map(response -> response.getManagerName())
+                .collect(Collectors.toList());
+        assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
+        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtDesc(any());
+    }
+
+    @Test
+    void 테스크를_생성_날짜_내림차순으로_조회한다() {
+        // given
+        Long projectId = 132128L, managerId = 9283L;
+        Project project = ProjectProvider.createProject(120394L);
+        User user = UserProvider.createUser2();
+        List<Task> tasks = List.of(
+                TaskProvider.createTask(managerId,project,null),
+                TaskProvider.createTask(null,project,null)
+        );
+
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
+        given(taskRepository.findByProjectOrderByCreatedAtDesc(any(Project.class)))
+                .willReturn(tasks);
+        given(userService.findUserById(managerId))
+                .willReturn(user);
+
+        // when
+        List<ProjectTaskSimpleResponse> result = taskService.getTasksOrderByCreateDate(projectId, false);
+
+        // then
+        assertThat(result.size()).isEqualTo(tasks.size());
+        List<String> names = result
+                .stream()
+                .map(response -> response.getManagerName())
+                .collect(Collectors.toList());
+        assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
+        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtDesc(any());
     }
 }


### PR DESCRIPTION
### 🔨 작업 내용 설명
프로젝트의 전체 테스크 목록을 날짜 기준 오름차순/내림차순 조회 API를 구현했습니다.

### 📑 구현한 내용 목록

- [x] 레포지토리 테스크 목록 정렬 조회 함수 추가
- [x] 서비스, 컨트롤러 함수 추가
- [x] 관련 테스트 추가

### 🚧 논의 사항
- Task 전체 정보를 그대로 넘겨주기에는 백로그 페이지에서 사용하지 않는 속성이 많고 오가는 데이터 양이 늘어나 
 ProjectTaskSimpleResponse DTO로 필요하지 않는 속성은 제외하고 반환하도록 했습니다!

- Task 정보를 반환을 위해 DTO로 변환하면서 manager User 객체를 Task마다 확인할 수 있어 
 셀렉트 쿼리가 지나치게 늘어날 수 있는 문제는 어떻게 방지할 수 있을까요? 🤔

- 프로젝트의 전체 테스크 목록 조회는 projectId를 필요로 하는데 GET 요청은 body를 가질 수 없고
 projectId를 `/tasks` 하위로 넘겨주는 것은 의미상 올바르지 않기 때문에 TaskController의 기본 url을 '/projects'로 수정해
 `/projects/{projectId}/tasks/sorting/create-date?ascending=true`와 같은 url로 GET 요청을 보내도록 구현했습니다
 (url 네이밍 괜찮은지 확인해주세요 😃)

- close #94 
