### PR TITLE
[#94] refactor: Notice Service 리팩토링 및 코드 리뷰 반영

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotReceiverException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/user/UserNotReceiverException.java
@@ -1,0 +1,8 @@
+package kr.kro.colla.exception.exception.user;
+
+import kr.kro.colla.exception.exception.ForbiddenException;
+
+public class UserNotReceiverException extends ForbiddenException {
+
+    public UserNotReceiverException() { super("해당 사용자가 접근하는 알림의 수신자가 아닙니다.");}
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -16,14 +16,16 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query("update Task t set t.taskStatus = :to where t.taskStatus = :from")
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
 
-    List<Task> findByProjectOrderByCreatedAtAsc(Project project);
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt asc")
+    List<Task> findByProjectOrderByCreatedAtAsc(@Param("project") Project project);
 
-    List<Task> findByProjectOrderByCreatedAtDesc(Project project);
-  
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt desc")
+    List<Task> findByProjectOrderByCreatedAtDesc(@Param("project") Project project);
+
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority asc")
-    List<Task> findAllOrderByPriorityAsc(@Param("project")Project project);
+    List<Task> findAllOrderByPriorityAsc(@Param("project") Project project);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority desc")
-    List<Task> findAllOrderByPriorityDesc(@Param("project")Project project);
+    List<Task> findAllOrderByPriorityDesc(@Param("project") Project project);
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -50,7 +50,7 @@ public class TaskController {
                 .build();
     }
 
-    @GetMapping("/{projectId}/tasks/sorting/created-date")
+    @GetMapping("/{projectId}/tasks/created-date")
     public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksSortByCreateDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
         List<ProjectTaskSimpleResponse> responses = taskService.getTasksOrderByCreatedDate(projectId, ascending);
 

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -104,6 +104,10 @@ public class TaskService {
 
     public List<ProjectTaskSimpleResponse> getTasksOrderByCreatedDate(Long projectId, Boolean ascending) {
         Project project = projectService.findProjectById(projectId);
+        Hibernate.initialize(project.getMembers());
+        Hibernate.initialize(project.getStories());
+        Hibernate.initialize(project.getTaskStatuses());
+
         List<Task> taskList = ascending
                 ? taskRepository.findByProjectOrderByCreatedAtAsc(project)
                 : taskRepository.findByProjectOrderByCreatedAtDesc(project);

--- a/backend/src/test/java/kr/kro/colla/common/fixture/NoticeProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/NoticeProvider.java
@@ -3,7 +3,10 @@ package kr.kro.colla.common.fixture;
 import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.presentation.dto.ProjectMemberRequest;
+import kr.kro.colla.user.notice.domain.Notice;
+import kr.kro.colla.user.notice.domain.NoticeType;
 import kr.kro.colla.user.user.presentation.dto.UserNoticeResponse;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -40,6 +43,21 @@ public class NoticeProvider {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(new TypeRef<List<UserNoticeResponse>>() {});
+    }
+
+    public static Notice createInviteNotice() {
+        return Notice.builder()
+                .noticeType(NoticeType.INVITE_USER)
+                .projectName("project to invite")
+                .projectId(234243L)
+                .build();
+    }
+
+    public static Notice createMentionNotice() {
+        return Notice.builder()
+                .noticeType(NoticeType.MENTION_USER)
+                .mentionedURL("url to mention")
+                .build();
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -355,7 +355,7 @@ public class AcceptanceTest {
 
         // when
         .when()
-                .get("/api/projects/" + createdProject.getId() + "/tasks/sorting/created-date?ascending=true")
+                .get("/api/projects/" + createdProject.getId() + "/tasks/created-date?ascending=true")
 
         // then
         .then().log().all()

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -145,7 +145,7 @@ class TaskControllerTest extends ControllerTest {
                 .willReturn(responses);
       
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/sorting/created-date?ascending=true")
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/created-date?ascending=true")
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
       
@@ -178,7 +178,7 @@ class TaskControllerTest extends ControllerTest {
                 .willReturn(responses);
 
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/sorting/created-date")
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/created-date")
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 

--- a/frontend/src/components/Header/style.tsx
+++ b/frontend/src/components/Header/style.tsx
@@ -3,13 +3,18 @@ import { Center, WidthCenter } from '../../styles/common';
 
 export const Container = styled.div`
     display: flex;
-    width: 100vw - 150px;
+    width: 80vw;
     height: 100px;
-    margin-left: 150px;
+    margin-left: 15vw;
+    justify-content: space-between;
 `;
 
 export const ProjectTitle = styled.div`
+    overflow: hidden;
+    width: 220px;
+    white-space: nowrap;
     font-size: 36px;
+    text-overflow: ellipsis;
 `;
 
 export const ProjectDesc = styled.div`
@@ -48,7 +53,6 @@ export const ProjectManageButton = styled.button`
 export const LeftNav = styled.div`
     flex: 10;
     height: 100%;
-    margin-right: 1000px;
 
     ${Center}
 `;


### PR DESCRIPTION
### 🔨 작업 내용 설명
이전에 코드 리뷰로 이야기했던 내용 반영했습니다 ✨

미뤄두었던 Notice Service 리팩토링을 진행했습니다! 

리팩토링하면서 확인해보니 Notice Service 테스트에  알림 확인을 처리하는 테스트가 빠져있어서 
(저번에 임시 조치하면서 삭제했던 부분인 거 같아요) 추가하고 변경된 로직 및 Provider 적용하도록 수정했습니다~

놋북 바꿨더니 전체 테스트 짱 빨리 돌아가요! ⚡️⚡️ 완전 대박임!!
### 📑 구현한 내용 목록

- [x] 테스크 목록 생성 일자 기준 조회 코드 리뷰 반영 (url 변경, 영속성 처리, fetch join)
- [x] Notice Service 리팩토링
- [x] Project Service 프로젝트 초대 수락/거절 로직 리팩토링
- [x] 관련 테스트 수정 및 추가

### 🚧 논의 사항

- 기존에 임시적으로 Notice Service에 존재하던 (순환 참조로 인해서... 😅) 
프로젝트 초대 수락/거절 로직을 Project Service에서 처리하도록 변경하고 
(기존에도 ProjectService -> Notice Service 자체 흐름은 같았지만 로직이 모두 Notice Service에 위치)
Notice Service는 다른 서비스의 사용 없이 순수하게 알림 읽기, 조회, 생성을 User 객체 자체로 받아 처리하도록 리팩토링 했습니다 🌈

- close #94 
