### PR TITLE
[#100] feat: 테스크 목록 상태값 필터링 조회 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/task_status/service/TaskStatusService.java
+++ b/backend/src/main/java/kr/kro/colla/project/task_status/service/TaskStatusService.java
@@ -20,4 +20,9 @@ public class TaskStatusService {
                 .orElseThrow(TaskStatusNotFoundException::new);
     }
 
+    public TaskStatus findTaskStatusById(Long statusId) {
+        return taskStatusRepository.findById(statusId)
+                .orElseThrow(TaskStatusNotFoundException::new);
+    }
+
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -17,10 +17,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt asc")
-    List<Task> findByProjectOrderByCreatedAtAsc(@Param("project") Project project);
+    List<Task> findAllOrderByCreatedAtAsc(@Param("project") Project project);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt desc")
-    List<Task> findByProjectOrderByCreatedAtDesc(@Param("project") Project project);
+    List<Task> findAllOrderByCreatedAtDesc(@Param("project") Project project);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority asc")
     List<Task> findAllOrderByPriorityAsc(@Param("project") Project project);
@@ -28,4 +28,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority desc")
     List<Task> findAllOrderByPriorityDesc(@Param("project") Project project);
 
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and t.taskStatus = :taskStatus")
+    List<Task> findAllFilterByTaskStatus(@Param("project") Project project, @Param("taskStatus") TaskStatus taskStatus);
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -29,9 +29,9 @@ public class TaskController {
 
     @GetMapping("/tasks/{taskId}")
     public ResponseEntity<ProjectTaskResponse> getTask(@PathVariable Long taskId) {
-        ProjectTaskResponse projectTaskResponse = taskService.getTask(taskId);
+        ProjectTaskResponse task = taskService.getTask(taskId);
 
-        return ResponseEntity.ok(projectTaskResponse);
+        return ResponseEntity.ok(task);
     }
 
     @PutMapping("/tasks/{taskId}")
@@ -52,14 +52,21 @@ public class TaskController {
 
     @GetMapping("/{projectId}/tasks/created-date")
     public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksSortByCreateDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
-        List<ProjectTaskSimpleResponse> responses = taskService.getTasksOrderByCreatedDate(projectId, ascending);
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksOrderByCreatedDate(projectId, ascending);
 
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(taskList);
     }
   
     @GetMapping("/{projectId}/tasks/priority")
     public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksOrderByPriority(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
         List<ProjectTaskSimpleResponse> taskList = taskService.getTasksOrderByPriority(projectId, ascending);
+
+        return ResponseEntity.ok(taskList);
+    }
+
+    @GetMapping("/{projectId}/tasks/status/{statusId}")
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByStatus(@PathVariable Long projectId, @PathVariable Long statusId) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByStatus(projectId, statusId);
 
         return ResponseEntity.ok(taskList);
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -105,7 +105,6 @@ public class TaskService {
     public List<ProjectTaskSimpleResponse> getTasksOrderByCreatedDate(Long projectId, Boolean ascending) {
         Project project = projectService.findProjectById(projectId);
         Hibernate.initialize(project.getMembers());
-        Hibernate.initialize(project.getStories());
         Hibernate.initialize(project.getTaskStatuses());
 
         List<Task> taskList = ascending
@@ -125,7 +124,6 @@ public class TaskService {
     public List<ProjectTaskSimpleResponse> getTasksOrderByPriority(Long projectId, Boolean ascending) {
         Project project = projectService.findProjectById(projectId);
         Hibernate.initialize(project.getMembers());
-        Hibernate.initialize(project.getStories());
         Hibernate.initialize(project.getTaskStatuses());
 
         List<Task> taskList = ascending
@@ -149,8 +147,10 @@ public class TaskService {
 
     public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, Long statusId) {
         Project project = projectService.findProjectById(projectId);
-        TaskStatus taskStatus = taskStatusService.findTaskStatusById(statusId);
+        Hibernate.initialize(project.getMembers());
+        Hibernate.initialize(project.getTaskStatuses());
 
+        TaskStatus taskStatus = taskStatusService.findTaskStatusById(statusId);
         List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
 
         return taskList.stream()

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -109,8 +109,8 @@ public class TaskService {
         Hibernate.initialize(project.getTaskStatuses());
 
         List<Task> taskList = ascending
-                ? taskRepository.findByProjectOrderByCreatedAtAsc(project)
-                : taskRepository.findByProjectOrderByCreatedAtDesc(project);
+                ? taskRepository.findAllOrderByCreatedAtAsc(project)
+                : taskRepository.findAllOrderByCreatedAtDesc(project);
 
         return taskList.stream()
                 .map(task -> {
@@ -147,4 +147,19 @@ public class TaskService {
                 .orElseThrow(TaskNotFoundException::new);
     }
 
+    public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, Long statusId) {
+        Project project = projectService.findProjectById(projectId);
+        TaskStatus taskStatus = taskStatusService.findTaskStatusById(statusId);
+
+        List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
+
+        return taskList.stream()
+                .map(task -> {
+                    User manager = task.getManagerId() != null
+                            ? userService.findUserById(task.getManagerId())
+                            : null;
+
+                    return TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager);
+                }).collect(Collectors.toList());
+    }
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -56,9 +56,33 @@ public class TaskProvider {
                 .contentType(ContentType.URLENC)
                 .cookie("accessToken", accessToken)
                 .formParams(formData)
-                .when()
+        .when()
                 .post("/api/projects/tasks")
-                .then()
+        .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        return formData;
+    }
+
+    public Map<String, String> 를_생성한다(String accessToken, Long managerId, Long projectId, String story, String statusName) {
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", "task title");
+        formData.put("description", "task description");
+        formData.put("managerId", managerId != null ? managerId.toString() : null);
+        formData.put("priority", "3");
+        formData.put("status", statusName);
+        formData.put("tags", "[\"backend\"]");
+        formData.put("projectId", projectId.toString());
+        formData.put("story", story);
+        formData.put("preTasks", "[]");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+        .when()
+                .post("/api/projects/tasks")
+        .then()
                 .statusCode(HttpStatus.CREATED.value());
 
         return formData;

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.task.task.domain.repository;
 
 import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
 import kr.kro.colla.exception.exception.project.task_status.TaskStatusNotFoundException;
 import kr.kro.colla.exception.exception.task.TaskNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
@@ -9,6 +10,8 @@ import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.project.task_status.domain.repository.TaskStatusRepository;
 import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -34,6 +37,9 @@ class TaskRepositoryTest {
 
     @Autowired
     private TaskStatusRepository taskStatusRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     void 프로젝트에_새로운_태스크를_등록한다() {
@@ -119,7 +125,7 @@ class TaskRepositoryTest {
         ));
 
         // when
-        List<Task> result = taskRepository.findByProjectOrderByCreatedAtAsc(project);
+        List<Task> result = taskRepository.findAllOrderByCreatedAtAsc(project);
 
         // then
         assertThat(result.size()).isEqualTo(taskList.size());
@@ -140,7 +146,7 @@ class TaskRepositoryTest {
         ));
 
         // when
-        List<Task> result = taskRepository.findByProjectOrderByCreatedAtDesc(project);
+        List<Task> result = taskRepository.findAllOrderByCreatedAtDesc(project);
 
         // then
         assertThat(result.size()).isEqualTo(taskList.size());

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -200,4 +200,28 @@ class TaskRepositoryTest {
                 .forEach(idx -> assertThat(result.get(idx).getPriority()).isGreaterThan(result.get(idx + 1).getPriority()));
     }
 
+    @Test
+    void 프로젝트의_테스크를_상태값으로_필터링해서_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(4253123L));
+        User user = userRepository.save(UserProvider.createUser2());
+        TaskStatus taskStatus = taskStatusRepository.save(new TaskStatus("Status To Filtering"));
+        TaskStatus taskStatusDiff = taskStatusRepository.save(new TaskStatus("Status Not Wanted"));
+        List<Task> tasks = List.of(
+                taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, taskStatus)),
+                taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, taskStatus))
+        );
+        taskRepository.save(TaskProvider.createTaskForRepository(user.getId(), project, null, taskStatusDiff));
+
+        // when
+        List<Task> result = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
+
+        // then
+        assertThat(result.size()).isEqualTo(tasks.size());
+        assertThat(result
+                .stream()
+                .filter(task -> !task.getTaskStatus().getName().equals(taskStatus.getName())).count()).isEqualTo(0);
+
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -395,7 +395,7 @@ class TaskServiceTest {
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
-        given(taskRepository.findByProjectOrderByCreatedAtAsc(any(Project.class)))
+        given(taskRepository.findAllOrderByCreatedAtAsc(any(Project.class)))
                 .willReturn(tasks);
         given(userService.findUserById(managerId))
                 .willReturn(user);
@@ -411,8 +411,8 @@ class TaskServiceTest {
                 .collect(Collectors.toList());
 
         assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
-        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtAsc(any());
-        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtDesc(any());
+        verify(taskRepository, times(1)).findAllOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(0)).findAllOrderByCreatedAtDesc(any());
     }
 
     @Test
@@ -428,7 +428,7 @@ class TaskServiceTest {
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
-        given(taskRepository.findByProjectOrderByCreatedAtDesc(any(Project.class)))
+        given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(tasks);
         given(userService.findUserById(managerId))
                 .willReturn(user);
@@ -444,8 +444,8 @@ class TaskServiceTest {
                 .collect(Collectors.toList());
 
         assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
-        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtAsc(any());
-        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtDesc(any());
+        verify(taskRepository, times(0)).findAllOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(1)).findAllOrderByCreatedAtDesc(any());
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -383,7 +383,7 @@ class TaskServiceTest {
     }
 
     @Test
-    void 테스크를_생성_날짜_오름차순으로_조회한다() {
+    void 프로젝트의_테스크들을_생성_날짜_오름차순으로_조회한다() {
         // given
         Long projectId = 132128L, managerId = 9283L;
         Project project = ProjectProvider.createProject(120394L);
@@ -416,7 +416,7 @@ class TaskServiceTest {
     }
 
     @Test
-    void 테스크를_생성_날짜_내림차순으로_조회한다() {
+    void 프로젝트의_테스크들을_생성_날짜_내림차순으로_조회한다() {
         // given
         Long projectId = 132128L, managerId = 9283L;
         Project project = ProjectProvider.createProject(120394L);
@@ -449,7 +449,7 @@ class TaskServiceTest {
     }
 
     @Test
-    void 프로젝트의_태스크를_우선순위_오름차순으로_조회한다() {
+    void 프로젝트의_태스크들을_우선순위_오름차순으로_조회한다() {
         // given
         Long projectId = 1L, memberId = 5L;
         User member = UserProvider.createUser();
@@ -478,7 +478,7 @@ class TaskServiceTest {
     }
 
     @Test
-    void 프로젝트의_태스크를_우선순위_내림차순으로_조회한다() {
+    void 프로젝트의_태스크들을_우선순위_내림차순으로_조회한다() {
         // given
         Long projectId = 1L, memberId = 5L;
         User member = UserProvider.createUser();
@@ -506,4 +506,36 @@ class TaskServiceTest {
         verify(taskRepository, times(1)).findAllOrderByPriorityDesc(any(Project.class));
     }
 
+    @Test
+    void 프로젝트의_테스크들을_상태값으로_필터링해_조회한다() {
+        // given
+        Long projectId = 25234L, statusId = 249394L, managerId = 6345L;
+        Project project = ProjectProvider.createProject(24525L);
+        User user = UserProvider.createUser2();
+        TaskStatus taskStatus = new TaskStatus("**task status to filter**");
+        List<Task> taskList = List.of(
+            TaskProvider.createTaskForRepository(managerId, project, null, taskStatus),
+            TaskProvider.createTaskForRepository(managerId, project, null, taskStatus)
+        );
+
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
+        given(taskStatusService.findTaskStatusById(statusId))
+                .willReturn(taskStatus);
+        given(taskRepository.findAllFilterByTaskStatus(any(Project.class), any(TaskStatus.class)))
+                .willReturn(taskList);
+        given(userService.findUserById(managerId))
+                .willReturn(user);
+
+        // when
+        List<ProjectTaskSimpleResponse> result = taskService.getTasksFilterByStatus(projectId, statusId);
+
+        // then
+        assertThat(result.size()).isEqualTo(taskList.size());
+        result.forEach(response -> {
+                assertThat(response.getManagerName()).isEqualTo(user.getName());
+                assertThat(response.getStatus()).isEqualTo(taskStatus.getName());
+            });
+        verify(taskRepository, times(1)).findAllFilterByTaskStatus(any(Project.class), any(TaskStatus.class));
+    }
 }


### PR DESCRIPTION
### 🔨 작업 내용 설명

상태값에 따라 필터링된 테스크 목록을 조회하는 API 구현했습니다

오늘 헷갈리는 개념 정리하면서 개발했더니 개발 분량이 많지 않네요 😅

### 📑 구현한 내용 목록

- [x] 테스크 목록 필터링 API 구현
- [x] 테스트 코드 작성

### 🚧 논의 사항
- 테스크 목록 관련 조회에서 스토리 영속화는 필요 없어서 제거했습니다~
- fetch join 이용해서 구현했는데 해당 방식으로 계속 구현하게 되면 
 조회 조건이 달라질때마다 새로운 레포지토리 함수로 쿼리를 작성해야해서 더 나은 구현 방식이 없을지 고민되네요 🙁
- close #100 
