### PR TITLE
[#99] feat: 태그 기반 필터링 및 스토리 기반 그룹핑 API 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -22,6 +22,7 @@ import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.domain.UserProject;
 import kr.kro.colla.user_project.service.UserProjectService;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -178,4 +179,14 @@ public class ProjectService {
         return projectRepository.findById(projectId)
                 .orElseThrow(ProjectNotFoundException::new);
     }
+
+    public Project getAllProjectInfo(Long projectId) {
+        Project project = findProjectById(projectId);
+        Hibernate.initialize(project.getMembers());
+        Hibernate.initialize(project.getStories());
+        Hibernate.initialize(project.getTaskStatuses());
+
+        return project;
+    }
+
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -17,10 +17,10 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt asc")
-    List<Task> findByProjectOrderByCreatedAtAsc(@Param("project") Project project);
+    List<Task> findAllOrderByCreatedAtAsc(@Param("project") Project project);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt desc")
-    List<Task> findByProjectOrderByCreatedAtDesc(@Param("project") Project project);
+    List<Task> findAllOrderByCreatedAtDesc(@Param("project") Project project);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority asc")
     List<Task> findAllOrderByPriorityAsc(@Param("project") Project project);

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -71,4 +71,11 @@ public class TaskController {
         return ResponseEntity.ok(taskList);
     }
 
+    @GetMapping("/{projectId}/tasks/story")
+    public ResponseEntity<List<ProjectStoryTaskResponse>> getTasksGroupByStory(@PathVariable Long projectId) {
+        List<ProjectStoryTaskResponse> taskList = taskService.getTasksGroupByStory(projectId);
+
+        return ResponseEntity.ok(taskList);
+    }
+
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -51,15 +51,22 @@ public class TaskController {
     }
 
     @GetMapping("/{projectId}/tasks/created-date")
-    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksSortByCreateDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
-        List<ProjectTaskSimpleResponse> responses = taskService.getTasksOrderByCreatedDate(projectId, ascending);
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksOrderByCreatedDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksOrderByCreatedDate(projectId, ascending);
 
-        return ResponseEntity.ok(responses);
+        return ResponseEntity.ok(taskList);
     }
   
     @GetMapping("/{projectId}/tasks/priority")
     public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksOrderByPriority(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
         List<ProjectTaskSimpleResponse> taskList = taskService.getTasksOrderByPriority(projectId, ascending);
+
+        return ResponseEntity.ok(taskList);
+    }
+
+    @GetMapping("/{projectId}/tasks/tags")
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilteredByTags(@PathVariable Long projectId, @RequestParam List<String> tags) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilteredByTags(projectId, tags);
 
         return ResponseEntity.ok(taskList);
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectStoryTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectStoryTaskResponse.java
@@ -1,0 +1,19 @@
+package kr.kro.colla.task.task.presentation.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ProjectStoryTaskResponse {
+
+    private String story;
+
+    private List<ProjectTaskSimpleResponse> taskList;
+
+    public ProjectStoryTaskResponse(String story, List<ProjectTaskSimpleResponse> taskList) {
+        this.story = story;
+        this.taskList = taskList;
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectStoryTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/ProjectStoryTaskResponse.java
@@ -1,9 +1,11 @@
 package kr.kro.colla.task.task.presentation.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
+@NoArgsConstructor
 @Getter
 public class ProjectStoryTaskResponse {
 

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -7,7 +7,6 @@ import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.project.task_status.service.TaskStatusService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.service.StoryService;
-import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.CreateTaskRequest;
@@ -23,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -140,7 +138,6 @@ public class TaskService {
     public List<ProjectTaskSimpleResponse> getTasksFilteredByTags(Long projectId, List<String> tags) {
         Project project = projectService.getAllProjectInfo(projectId);
         List<Task> taskList = taskRepository.findAllOrderByCreatedAtDesc(project);
-        Collections.sort(tags);
 
         return taskList.stream()
                 .filter(task -> {
@@ -150,7 +147,7 @@ public class TaskService {
                             .sorted()
                             .collect(Collectors.toList());
 
-                    return taskTags.equals(tags);
+                    return taskTags.containsAll(tags);
                 }).map(task -> {
                     User manager = task.getManagerId() != null
                             ? userService.findUserById(task.getManagerId())

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TagProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TagProvider.java
@@ -3,6 +3,7 @@ package kr.kro.colla.common.fixture;
 import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.presentation.dto.CreateTagRequest;
 import kr.kro.colla.project.project.presentation.dto.ProjectTagResponse;
+import kr.kro.colla.task.tag.domain.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,10 @@ public class TagProvider {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .as(ProjectTagResponse.class);
+    }
+
+    public static Tag createTag(String tagName) {
+        return new Tag(tagName);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -64,6 +64,30 @@ public class TaskProvider {
         return formData;
     }
 
+    public Map<String, String> 를_특정_태그와_함께_생성한다(String accessToken, Long managerId, Long projectId, String story, String tags) {
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", "task title");
+        formData.put("description", "task description");
+        formData.put("managerId", managerId != null ? managerId.toString() : null);
+        formData.put("priority", "2");
+        formData.put("status", "To Do");
+        formData.put("tags", tags);
+        formData.put("projectId", projectId.toString());
+        formData.put("story", story);
+        formData.put("preTasks", "[]");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+                .when()
+                .post("/api/projects/tasks")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        return formData;
+    }
+
     public static Task createTask(Long managerId, Project project, Story story) {
         return Task.builder()
                 .title("task title")

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskTagProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskTagProvider.java
@@ -1,0 +1,13 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.task.tag.domain.Tag;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_tag.domain.TaskTag;
+
+public class TaskTagProvider {
+
+    public static TaskTag createTaskTag(Task task, Tag tag) {
+        return new TaskTag(task, tag);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -119,7 +119,7 @@ class TaskRepositoryTest {
         ));
 
         // when
-        List<Task> result = taskRepository.findByProjectOrderByCreatedAtAsc(project);
+        List<Task> result = taskRepository.findAllOrderByCreatedAtAsc(project);
 
         // then
         assertThat(result.size()).isEqualTo(taskList.size());
@@ -140,7 +140,7 @@ class TaskRepositoryTest {
         ));
 
         // when
-        List<Task> result = taskRepository.findByProjectOrderByCreatedAtDesc(project);
+        List<Task> result = taskRepository.findAllOrderByCreatedAtDesc(project);
 
         // then
         assertThat(result.size()).isEqualTo(taskList.size());

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -393,7 +393,7 @@ class TaskServiceTest {
                 TaskProvider.createTask(null, project,null)
         );
 
-        given(projectService.findProjectById(projectId))
+        given(projectService.getAllProjectInfo(projectId))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtAsc(any(Project.class)))
                 .willReturn(tasks);
@@ -426,7 +426,7 @@ class TaskServiceTest {
                 TaskProvider.createTask(null, project, null)
         );
 
-        given(projectService.findProjectById(projectId))
+        given(projectService.getAllProjectInfo(projectId))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(tasks);
@@ -458,7 +458,7 @@ class TaskServiceTest {
         Task task1 = TaskProvider.createTaskWithPriority(memberId, project, null, 3);
         Task task2 = TaskProvider.createTaskWithPriority(memberId, project, null, 1);
 
-        given(projectService.findProjectById(eq(projectId)))
+        given(projectService.getAllProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByPriorityAsc(any(Project.class)))
                 .willReturn(List.of(task2, task1));
@@ -487,7 +487,7 @@ class TaskServiceTest {
         Task task1 = TaskProvider.createTaskWithPriority(memberId, project, null, 5);
         Task task2 = TaskProvider.createTaskWithPriority(memberId, project, null, 3);
 
-        given(projectService.findProjectById(eq(projectId)))
+        given(projectService.getAllProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByPriorityDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2));

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -395,7 +395,7 @@ class TaskServiceTest {
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
-        given(taskRepository.findByProjectOrderByCreatedAtAsc(any(Project.class)))
+        given(taskRepository.findAllOrderByCreatedAtAsc(any(Project.class)))
                 .willReturn(tasks);
         given(userService.findUserById(managerId))
                 .willReturn(user);
@@ -411,8 +411,8 @@ class TaskServiceTest {
                 .collect(Collectors.toList());
 
         assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
-        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtAsc(any());
-        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtDesc(any());
+        verify(taskRepository, times(1)).findAllOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(0)).findAllOrderByCreatedAtDesc(any());
     }
 
     @Test
@@ -428,7 +428,7 @@ class TaskServiceTest {
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
-        given(taskRepository.findByProjectOrderByCreatedAtDesc(any(Project.class)))
+        given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(tasks);
         given(userService.findUserById(managerId))
                 .willReturn(user);
@@ -444,8 +444,8 @@ class TaskServiceTest {
                 .collect(Collectors.toList());
 
         assertThat(names).containsExactlyInAnyOrder(user.getName(), null);
-        verify(taskRepository, times(0)).findByProjectOrderByCreatedAtAsc(any());
-        verify(taskRepository, times(1)).findByProjectOrderByCreatedAtDesc(any());
+        verify(taskRepository, times(0)).findAllOrderByCreatedAtAsc(any());
+        verify(taskRepository, times(1)).findAllOrderByCreatedAtDesc(any());
     }
 
     @Test

--- a/frontend/src/components/Header/style.tsx
+++ b/frontend/src/components/Header/style.tsx
@@ -11,10 +11,11 @@ export const Container = styled.div`
 
 export const ProjectTitle = styled.div`
     overflow: hidden;
-    width: 220px;
+    min-width: 120px;
     white-space: nowrap;
     font-size: 36px;
     text-overflow: ellipsis;
+    margin-left: 20px;
 `;
 
 export const ProjectDesc = styled.div`
@@ -23,6 +24,7 @@ export const ProjectDesc = styled.div`
     font-size: 24px;
     visibility: hidden;
     width: 400px;
+    margin-left: 30px;
 
     ${WidthCenter}
 `;
@@ -51,10 +53,11 @@ export const ProjectManageButton = styled.button`
 `;
 
 export const LeftNav = styled.div`
+    display: flex;
+    justify-content: start;
+    align-items: center;
     flex: 10;
     height: 100%;
-
-    ${Center}
 `;
 
 export const RightNav = styled.div`


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 태그 기반 필터링 API 구현
- 태그 기반 필터링 API 테스트 코드 작성
- 스토리 그룹핑 API 구현
- 스토리 그룹핑 API 테스트 코드 작성

### 📑 구현한 내용 목록
- [x] 태그 기반 필터링 API 구현
- [x] 태그 기반 필터링 API 테스트 코드 작성
- [x] 스토리 그룹핑 API 구현
- [x] 스토리 그룹핑 API 테스트 코드 작성

### 🚧 논의 사항
- 프로젝트의 정보를 가져오는 메서드를 `projectService.getAllProjectInfo()` 로 분리해두었습니다!
- 태그 기반 정렬이나 스토리 그룹핑 API에서 모든 태스크를 뽑아올 때는 생성일 기준으로 뽑아온 다음에 정렬이나 그룹핑해주었습니다!

- close #99 
