### PR TITLE
[#103] feat: 필터링 UI 다중선택 구현 및 API 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -180,10 +180,9 @@ public class ProjectService {
                 .orElseThrow(ProjectNotFoundException::new);
     }
 
-    public Project getAllProjectInfo(Long projectId) {
+    public Project initializeProjectInfo(Long projectId) {
         Project project = findProjectById(projectId);
         Hibernate.initialize(project.getMembers());
-        Hibernate.initialize(project.getStories());
         Hibernate.initialize(project.getTaskStatuses());
 
         return project;

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -64,9 +64,9 @@ public class TaskController {
         return ResponseEntity.ok(taskList);
     }
 
-    @GetMapping("/{projectId}/tasks/status/{statusId}")
-    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByStatus(@PathVariable Long projectId, @PathVariable Long statusId) {
-        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByStatus(projectId, statusId);
+    @GetMapping("/{projectId}/tasks/statuses")
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByStatus(@PathVariable Long projectId, @RequestParam List<String> statuses) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByStatus(projectId, statuses);
 
         return ResponseEntity.ok(taskList);
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -16,6 +16,7 @@ import kr.kro.colla.task.task_tag.service.TaskTagService;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -102,7 +103,7 @@ public class TaskService {
     }
 
     public List<ProjectTaskSimpleResponse> getTasksOrderByCreatedDate(Long projectId, Boolean ascending) {
-        Project project = projectService.getAllProjectInfo(projectId);
+        Project project = projectService.initializeProjectInfo(projectId);
 
         List<Task> taskList = ascending
                 ? taskRepository.findAllOrderByCreatedAtAsc(project)
@@ -119,7 +120,7 @@ public class TaskService {
     }
 
     public List<ProjectTaskSimpleResponse> getTasksOrderByPriority(Long projectId, Boolean ascending) {
-        Project project = projectService.getAllProjectInfo(projectId);
+        Project project = projectService.initializeProjectInfo(projectId);
 
         List<Task> taskList = ascending
                 ? taskRepository.findAllOrderByPriorityAsc(project)
@@ -136,7 +137,7 @@ public class TaskService {
     }
 
     public List<ProjectTaskSimpleResponse> getTasksFilterByTags(Long projectId, List<String> tags) {
-        Project project = projectService.getAllProjectInfo(projectId);
+        Project project = projectService.initializeProjectInfo(projectId);
         List<Task> taskList = taskRepository.findAllOrderByCreatedAtDesc(project);
 
         return taskList.stream()
@@ -158,8 +159,9 @@ public class TaskService {
     }
 
     public List<ProjectStoryTaskResponse> getTasksGroupByStory(Long projectId) {
-        Project project = projectService.getAllProjectInfo(projectId);
+        Project project = projectService.initializeProjectInfo(projectId);
         List<Task> taskList = taskRepository.findAllOrderByCreatedAtDesc(project);
+        Hibernate.initialize(project.getStories());
 
         List<ProjectStoryTaskResponse> projectStoryTaskResponseList = new ArrayList<>();
         Map<String, List<ProjectTaskSimpleResponse>> taskMap = new HashMap<>();
@@ -192,13 +194,8 @@ public class TaskService {
         return projectStoryTaskResponseList;
     }
 
-    public Task findTaskById(Long taskId) {
-        return taskRepository.findById(taskId)
-                .orElseThrow(TaskNotFoundException::new);
-    }
-
     public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, Long statusId) {
-        Project project = projectService.getAllProjectInfo(projectId);
+        Project project = projectService.initializeProjectInfo(projectId);
 
         TaskStatus taskStatus = taskStatusService.findTaskStatusById(statusId);
         List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
@@ -211,5 +208,10 @@ public class TaskService {
 
                     return TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager);
                 }).collect(Collectors.toList());
+    }
+
+    public Task findTaskById(Long taskId) {
+        return taskRepository.findById(taskId)
+                .orElseThrow(TaskNotFoundException::new);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -194,13 +194,13 @@ public class TaskService {
         return projectStoryTaskResponseList;
     }
 
-    public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, Long statusId) {
+    public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, List<String> statuses) {
         Project project = projectService.initializeProjectInfo(projectId);
-
-        TaskStatus taskStatus = taskStatusService.findTaskStatusById(statusId);
-        List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
+        List<Task> taskList = taskRepository.findAllOrderByCreatedAtDesc(project);
+        Hibernate.initialize(project.getTaskStatuses());
 
         return taskList.stream()
+                .filter(task -> statuses.contains(task.getTaskStatus().getName()))
                 .map(task -> {
                     User manager = task.getManagerId() != null
                             ? userService.findUserById(task.getManagerId())

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -448,7 +448,6 @@ public class AcceptanceTest {
     @Test
     void 사용자가_프로젝트의_테스크들을_상태값으로_필터링해_조회한다() {
         // given
-        Long statusId = 4L;
         String nameToFilter = "sTatuSToFiLteR", nameToIgnore = "sTatUStOiGNOre";
         User loginUser = user.가_로그인을_한다2();
         String accessToken = auth.토큰을_발급한다(loginUser.getId());
@@ -469,7 +468,7 @@ public class AcceptanceTest {
 
         // when
         .when()
-                .get("/api/projects/" + createdProject.getId() + "/tasks/status/" + statusId)
+                .get("/api/projects/" + createdProject.getId() + "/tasks/statuses?statuses=" + nameToFilter)
 
         // then
         .then()
@@ -478,12 +477,12 @@ public class AcceptanceTest {
                 .body()
                 .as(new TypeRef<List<ProjectTaskSimpleResponse>>() {});
 
-            assertThat(result.size()).isEqualTo(filteredTasks.size());
-            result.forEach(task -> {
-                assertThat(task.getId()).isNotNull();
-                assertThat(task.getStatus()).isEqualTo(nameToFilter);
-            });
-        }
+        assertThat(result.size()).isEqualTo(filteredTasks.size());
+        result.forEach(task -> {
+            assertThat(task.getId()).isNotNull();
+            assertThat(task.getStatus()).isEqualTo(nameToFilter);
+        });
+    }
 
     void 사용자가_특정_태그들을_선택해_태스크들을_필터링한다() {
         // given

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -260,11 +260,11 @@ class TaskControllerTest extends ControllerTest {
                 TaskResponseConverter.convertToProjectTaskSimpleResponse(TaskProvider.createTaskForRepository(null, project, null, taskStatus), user)
         );
 
-        given(taskService.getTasksFilterByStatus(projectId, statusId))
+        given(taskService.getTasksFilterByStatus(eq(projectId), any(List.class)))
                 .willReturn(taskList);
 
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/status/" + statusId)
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/statuses?statuses=" +taskStatus.getName())
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -274,7 +274,7 @@ class TaskControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.length()").value(taskList.size()))
                 .andExpect(jsonPath("$[*].managerName", contains(null, user.getName())))
                 .andExpect(jsonPath("$[*].status", contains(taskStatus.getName(), taskStatus.getName())));
-        verify(taskService, times(1)).getTasksFilterByStatus(projectId, statusId);
+        verify(taskService, times(1)).getTasksFilterByStatus(anyLong(), any(List.class));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -388,7 +388,7 @@ class TaskServiceTest {
                 TaskProvider.createTask(null, project,null)
         );
 
-        given(projectService.getAllProjectInfo(projectId))
+        given(projectService.initializeProjectInfo(projectId))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtAsc(any(Project.class)))
                 .willReturn(tasks);
@@ -421,7 +421,7 @@ class TaskServiceTest {
                 TaskProvider.createTask(null, project, null)
         );
 
-        given(projectService.getAllProjectInfo(projectId))
+        given(projectService.initializeProjectInfo(projectId))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(tasks);
@@ -453,7 +453,7 @@ class TaskServiceTest {
         Task task1 = TaskProvider.createTaskWithPriority(memberId, project, null, 3);
         Task task2 = TaskProvider.createTaskWithPriority(memberId, project, null, 1);
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByPriorityAsc(any(Project.class)))
                 .willReturn(List.of(task2, task1));
@@ -482,7 +482,7 @@ class TaskServiceTest {
         Task task1 = TaskProvider.createTaskWithPriority(memberId, project, null, 5);
         Task task2 = TaskProvider.createTaskWithPriority(memberId, project, null, 3);
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByPriorityDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2));
@@ -513,7 +513,7 @@ class TaskServiceTest {
             TaskProvider.createTaskForRepository(managerId, project, null, taskStatus)
         );
 
-        given(projectService.getAllProjectInfo(projectId))
+        given(projectService.initializeProjectInfo(projectId))
                 .willReturn(project);
         given(taskStatusService.findTaskStatusById(statusId))
                 .willReturn(taskStatus);
@@ -564,7 +564,7 @@ class TaskServiceTest {
                 TaskTagProvider.createTaskTag(task3, tags.get(2))
         ));
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2, task3));
@@ -594,7 +594,7 @@ class TaskServiceTest {
         Task task2 = TaskProvider.createTask(memberId, project, null);
         task2.addTags(List.of(TaskTagProvider.createTaskTag(task2, tags.get(1))));
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2));
@@ -618,7 +618,7 @@ class TaskServiceTest {
         Task task2 = TaskProvider.createTask(memberId, project, null);
         Task task3 = TaskProvider.createTask(memberId, project, story);
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2, task3));
@@ -643,7 +643,7 @@ class TaskServiceTest {
         Task task1 = TaskProvider.createTask(memberId, project, null);
         Task task2 = TaskProvider.createTask(memberId, project, null);
 
-        given(projectService.getAllProjectInfo(eq(projectId)))
+        given(projectService.initializeProjectInfo(eq(projectId)))
                 .willReturn(project);
         given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(List.of(task1, task2));

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -504,7 +504,7 @@ class TaskServiceTest {
     @Test
     void 프로젝트의_테스크들을_상태값으로_필터링해_조회한다() {
         // given
-        Long projectId = 25234L, statusId = 249394L, managerId = 6345L;
+        Long projectId = 25234L, managerId = 6345L;
         Project project = ProjectProvider.createProject(24525L);
         User user = UserProvider.createUser2();
         TaskStatus taskStatus = new TaskStatus("**task status to filter**");
@@ -515,23 +515,20 @@ class TaskServiceTest {
 
         given(projectService.initializeProjectInfo(projectId))
                 .willReturn(project);
-        given(taskStatusService.findTaskStatusById(statusId))
-                .willReturn(taskStatus);
-        given(taskRepository.findAllFilterByTaskStatus(any(Project.class), any(TaskStatus.class)))
+        given(taskRepository.findAllOrderByCreatedAtDesc(any(Project.class)))
                 .willReturn(taskList);
         given(userService.findUserById(managerId))
                 .willReturn(user);
 
         // when
-        List<ProjectTaskSimpleResponse> result = taskService.getTasksFilterByStatus(projectId, statusId);
+        List<ProjectTaskSimpleResponse> result = taskService.getTasksFilterByStatus(projectId, new ArrayList<>(List.of(taskStatus.getName())));
 
         // then
         assertThat(result.size()).isEqualTo(taskList.size());
         result.forEach(response -> {
                 assertThat(response.getManagerName()).isEqualTo(user.getName());
                 assertThat(response.getStatus()).isEqualTo(taskStatus.getName());
-            });
-        verify(taskRepository, times(1)).findAllFilterByTaskStatus(any(Project.class), any(TaskStatus.class));
+        });
     }
 
     @Test

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -45,6 +45,7 @@
     "no-unused-vars": "error",
     "no-param-reassign": "off",
     "no-unused-expressions": "off",
+    "no-unneeded-ternary": "off",
     "dot-notation": "off",
     "no-use-before-define": ["error", { "variables": false }],
     "import/prefer-default-export": "off",

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -1,4 +1,4 @@
-import { TaskResponseType } from '../types/task';
+import { StoryTaskType, TaskResponseType } from '../types/task';
 import { client } from './common';
 
 export const createTask = async (data: FormData) => {
@@ -25,6 +25,12 @@ export const updateTask = async (taskId: number, data: FormData) => {
 
 export const updateTaskStatus = async (taskId: number, statusName: string) => {
     const response = await client.patch(`/projects/tasks/${taskId}`, { statusName });
+
+    return response;
+};
+
+export const getTasksGroupByStory = async (projectId: number) => {
+    const response = await client.get<Array<StoryTaskType>>(`/projects/${projectId}/tasks/story`);
 
     return response;
 };

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -1,4 +1,4 @@
-import { StoryTaskType, TaskResponseType } from '../types/task';
+import { SimpleTaskType, StoryTaskType, TaskResponseType } from '../types/task';
 import { client } from './common';
 
 export const createTask = async (data: FormData) => {
@@ -31,6 +31,26 @@ export const updateTaskStatus = async (taskId: number, statusName: string) => {
 
 export const getTasksGroupByStory = async (projectId: number) => {
     const response = await client.get<Array<StoryTaskType>>(`/projects/${projectId}/tasks/story`);
+
+    return response;
+};
+
+export const getTasksFilterByStatus = async (projectId: number, statuses: string) => {
+    const response = await client.get<Array<SimpleTaskType>>(
+        `/projects/${projectId}/tasks/statuses?statuses=${statuses}`,
+    );
+
+    return response;
+};
+
+export const getTasksFilterByManager = async (projectId: number, managers: string) => {
+    const response = await client.get<Array<SimpleTaskType>>(`/projects/${projectId}/tasks/tags?managers=${managers}`);
+
+    return response;
+};
+
+export const getTasksFilterByTags = async (projectId: number, tags: string) => {
+    const response = await client.get<Array<SimpleTaskType>>(`/projects/${projectId}/tasks/tags?tags=${tags}`);
 
     return response;
 };

--- a/frontend/src/components/BacklogFeature/index.tsx
+++ b/frontend/src/components/BacklogFeature/index.tsx
@@ -1,11 +1,15 @@
-import React, { useState } from 'react';
+import React, { FC, useState } from 'react';
 
 import SearchButtonImg from '../../../public/assets/images/search-button.svg';
 import { SortCriteria } from '../DropDown/SortCriteria';
 import { Filter } from '../Modal/Filter';
 import { Container, Feature, FeatureContainer, SearchBar, SearchIcon, SearchInput } from './style';
 
-export const BacklogFeature = () => {
+interface PropType {
+    setBacklogTaskList: Function;
+}
+
+export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
     const features = ['Story', 'Filter', 'Sort'];
     const [criteriaVisible, setCriteriaVisible] = useState<number>(0);
 
@@ -19,7 +23,9 @@ export const BacklogFeature = () => {
                 {features.map((feature, idx) => (
                     <Feature key={idx}>
                         <span onClick={() => showCriteria(idx)}>{feature}</span>
-                        {feature === 'Filter' && criteriaVisible === idx ? <Filter /> : null}
+                        {feature === 'Filter' && criteriaVisible === idx ? (
+                            <Filter setBacklogTaskList={setBacklogTaskList} />
+                        ) : null}
                         {feature === 'Sort' && criteriaVisible === idx ? <SortCriteria /> : null}
                     </Feature>
                 ))}

--- a/frontend/src/components/BacklogFeature/index.tsx
+++ b/frontend/src/components/BacklogFeature/index.tsx
@@ -1,6 +1,9 @@
 import React, { FC, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
 import SearchButtonImg from '../../../public/assets/images/search-button.svg';
+import { getTasksGroupByStory } from '../../apis/task';
+import { StateType } from '../../types/project';
 import { SortCriteria } from '../DropDown/SortCriteria';
 import { Filter } from '../Modal/Filter';
 import { Container, Feature, FeatureContainer, SearchBar, SearchIcon, SearchInput } from './style';
@@ -10,6 +13,7 @@ interface PropType {
 }
 
 export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
+    const { state } = useLocation<StateType>();
     const features = ['Story', 'Filter', 'Sort'];
     const [criteriaVisible, setCriteriaVisible] = useState<number>(0);
 
@@ -17,12 +21,19 @@ export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
         setCriteriaVisible((prev) => (prev === idx ? 0 : idx));
     };
 
+    const getTasksAboutStory = async () => {
+        const res = await getTasksGroupByStory(state.projectId);
+        setBacklogTaskList(res.data);
+    };
+
     return (
         <Container>
             <FeatureContainer>
                 {features.map((feature, idx) => (
                     <Feature key={idx}>
-                        <span onClick={() => showCriteria(idx)}>{feature}</span>
+                        <span onClick={feature === 'Story' ? () => getTasksAboutStory() : () => showCriteria(idx)}>
+                            {feature}
+                        </span>
                         {feature === 'Filter' && criteriaVisible === idx ? (
                             <Filter setBacklogTaskList={setBacklogTaskList} />
                         ) : null}

--- a/frontend/src/components/Issue/index.tsx
+++ b/frontend/src/components/Issue/index.tsx
@@ -14,7 +14,7 @@ interface PropType {
 const Issue: FC<PropType> = ({ story, title, priority, manager, tags }) => (
     <>
         <Wrapper story={story}>
-            {title}
+            {title ? title : '스토리에 속해있지 않은 태스크 목록'}
             {!story ? (
                 <Attributes>
                     <Tags>

--- a/frontend/src/components/Issue/style.tsx
+++ b/frontend/src/components/Issue/style.tsx
@@ -1,27 +1,28 @@
 import styled from '@emotion/styled';
 
 import { GREEN, LIGHT_GRAY, WHITE } from '../../styles/color';
+import { LiftUp } from '../../styles/common';
 
 interface Props {
     story?: boolean;
 }
 
 const BASE = 900;
-const EXTRA = 100;
+const EXTRA = 150;
 
 export const Wrapper = styled.div<Props>`
     position: relative;
     display: flex;
     align-items: center;
-    padding-left: 20px;
+    padding: 15px 0 15px 20px;
     width: ${({ story }) => (story ? `${BASE + EXTRA}px` : `${BASE}px`)};
-    height: 50px;
     border-radius: 20px;
     background: ${({ story }) => (story ? GREEN : WHITE)};
-    margin-left: ${({ story }) => (story ? '0px' : `${EXTRA}px`)};
-    margin-top: 13px;
-    margin-bottom: 13px;
+    margin: 13px 40px 13px ${({ story }) => (story ? '0px' : `${EXTRA}px`)};
     font-size: 20px;
+    cursor: pointer;
+
+    ${LiftUp}
 `;
 
 export const Attributes = styled.div`

--- a/frontend/src/components/Modal/Filter/index.tsx
+++ b/frontend/src/components/Modal/Filter/index.tsx
@@ -4,12 +4,9 @@ import { useLocation } from 'react-router-dom';
 import CheckImg from '../../../../public/assets/images/down.png';
 import { getProjectMembers, getProjectStatus, getProjectTags } from '../../../apis/project';
 import { getTasksFilterByManager, getTasksFilterByStatus, getTasksFilterByTags } from '../../../apis/task';
+import { StateType } from '../../../types/project';
 import { Avatar, Name } from '../../Task/style';
 import { CheckMark, Container, CriteriaElements, Element, FilterCriteria } from './style';
-
-interface StateType {
-    projectId: number;
-}
 
 interface ElementType {
     name: string;

--- a/frontend/src/components/Modal/Filter/style.ts
+++ b/frontend/src/components/Modal/Filter/style.ts
@@ -45,3 +45,7 @@ export const Element = styled.div`
         cursor: pointer;
     }
 `;
+
+export const CheckMark = styled.img`
+    margin-left: auto;
+`;

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -6,7 +6,7 @@ import { BacklogFeature } from '../../components/BacklogFeature';
 import Header from '../../components/Header';
 import Issue from '../../components/Issue';
 import { SideBar } from '../../components/SideBar';
-import { StoryTaskType } from '../../types/task';
+import { SimpleTaskType, StoryTaskType } from '../../types/task';
 import { Container, Wrapper } from './style';
 
 interface StateType {
@@ -15,12 +15,12 @@ interface StateType {
 
 const Backlog = () => {
     const { state } = useLocation<StateType>();
-    const [storyTaskList, setStoryTaskList] = useState<Array<StoryTaskType>>([]);
+    const [backlogTaskList, setBacklogTaskList] = useState<Array<StoryTaskType | SimpleTaskType>>([]);
 
     useEffect(() => {
         (async () => {
             const res = await getTasksGroupByStory(state.projectId);
-            setStoryTaskList(res.data);
+            setBacklogTaskList(res.data);
         })();
     }, []);
 
@@ -28,17 +28,35 @@ const Backlog = () => {
         <>
             <Header />
             <SideBar />
-            <BacklogFeature />
+            <BacklogFeature setBacklogTaskList={setBacklogTaskList} />
             <Container>
                 <Wrapper>
-                    {storyTaskList.map(({ story, taskList }: StoryTaskType, idx) => (
-                        <>
-                            <Issue key={idx} title={story} story />
-                            {taskList.map(({ id, title, priority, managerAvatar, tags }: any) => (
-                                <Issue key={id} title={title} priority={priority} manager={managerAvatar} tags={tags} />
-                            ))}
-                        </>
-                    ))}
+                    {backlogTaskList.length > 0 && 'story' in backlogTaskList[0]
+                        ? (backlogTaskList as Array<StoryTaskType>).map(({ story, taskList }: StoryTaskType, idx) => (
+                              <>
+                                  <Issue key={idx} title={story} story />
+                                  {taskList.map(({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (
+                                      <Issue
+                                          key={id}
+                                          title={title}
+                                          priority={priority}
+                                          manager={managerAvatar}
+                                          tags={tags}
+                                      />
+                                  ))}
+                              </>
+                          ))
+                        : (backlogTaskList as Array<SimpleTaskType>).map(
+                              ({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (
+                                  <Issue
+                                      key={id}
+                                      title={title}
+                                      priority={priority}
+                                      manager={managerAvatar}
+                                      tags={tags}
+                                  />
+                              ),
+                          )}
                 </Wrapper>
             </Container>
         </>

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -6,12 +6,9 @@ import { BacklogFeature } from '../../components/BacklogFeature';
 import Header from '../../components/Header';
 import Issue from '../../components/Issue';
 import { SideBar } from '../../components/SideBar';
+import { StateType } from '../../types/project';
 import { SimpleTaskType, StoryTaskType } from '../../types/task';
 import { Container, Wrapper } from './style';
-
-interface StateType {
-    projectId: number;
-}
 
 const Backlog = () => {
     const { state } = useLocation<StateType>();

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -1,60 +1,48 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
+import { getTasksGroupByStory } from '../../apis/task';
 import { BacklogFeature } from '../../components/BacklogFeature';
 import Header from '../../components/Header';
 import Issue from '../../components/Issue';
 import { SideBar } from '../../components/SideBar';
+import { StoryTaskType } from '../../types/task';
 import { Container, Wrapper } from './style';
 
-const dummy = [
-    {
-        title: 'story',
-        tasks: [
-            {
-                id: 1,
-                title: 'task1',
-                priority: 3,
-                tags: ['backend', 'frontend', 'etc'],
-            },
-            {
-                id: 2,
-                title: 'task2',
-                priority: 5,
-                manager: 'https://avatars.githubusercontent.com/u/69030160?v=4',
-                tags: ['bug'],
-            },
-            {
-                id: 3,
-                title: 'task3',
-                priority: 1,
-                tags: ['refactor'],
-            },
-        ],
-    },
-    {
-        title: 'another story',
-        tasks: [],
-    },
-];
+interface StateType {
+    projectId: number;
+}
 
-const Backlog = () => (
-    <>
-        <Header />
-        <SideBar />
-        <BacklogFeature />
-        <Container>
-            <Wrapper>
-                {dummy.map(({ title, tasks }: any, idx) => (
-                    <>
-                        <Issue key={idx} title={title} story />
-                        {tasks.map(({ id, title, priority, manager, tags }: any) => (
-                            <Issue key={id} title={title} priority={priority} manager={manager} tags={tags} />
-                        ))}
-                    </>
-                ))}
-            </Wrapper>
-        </Container>
-    </>
-);
+const Backlog = () => {
+    const { state } = useLocation<StateType>();
+    const [storyTaskList, setStoryTaskList] = useState<Array<StoryTaskType>>([]);
+
+    useEffect(() => {
+        (async () => {
+            const res = await getTasksGroupByStory(state.projectId);
+            setStoryTaskList(res.data);
+        })();
+    }, []);
+
+    return (
+        <>
+            <Header />
+            <SideBar />
+            <BacklogFeature />
+            <Container>
+                <Wrapper>
+                    {storyTaskList.map(({ story, taskList }: StoryTaskType, idx) => (
+                        <>
+                            <Issue key={idx} title={story} story />
+                            {taskList.map(({ id, title, priority, managerAvatar, tags }: any) => (
+                                <Issue key={id} title={title} priority={priority} manager={managerAvatar} tags={tags} />
+                            ))}
+                        </>
+                    ))}
+                </Wrapper>
+            </Container>
+        </>
+    );
+};
 
 export default Backlog;

--- a/frontend/src/pages/Backlog/style.tsx
+++ b/frontend/src/pages/Backlog/style.tsx
@@ -14,10 +14,15 @@ export const Wrapper = styled.div`
     border-radius: 20px;
     overflow-y: scroll;
     background: ${LIGHT_GRAY};
-    align-items: center;
+    align-items: end;
 
     &::-webkit-scrollbar {
-        display: none;
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #bbbbbb;
+        border-radius: 10px;
     }
 
     ${Column}

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -11,15 +11,12 @@ import { SideBar } from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { projectState } from '../../stores/projectState';
 import { TaskType } from '../../types/kanban';
+import { StateType } from '../../types/project';
 import { Wrapper, Container, KanbanStatusAddButton, KanbanAddImage } from './style';
-
-interface stateType {
-    projectId: number;
-}
 
 const Kanban = () => {
     const history = useHistory();
-    const { state } = useLocation<stateType>();
+    const { state } = useLocation<StateType>();
     const [taskList, setTaskList] = useState<Array<TaskType>>([]);
     const [taskStatuses, setTaskStatuses] = useState<Array<string>>([]);
     const setProject = useSetRecoilState(projectState);

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -25,3 +25,7 @@ export interface ProjectMemberType {
     name: string;
     avatar: string;
 }
+
+export interface StateType {
+    projectId: number;
+}

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -36,3 +36,16 @@ export interface TaskResponseType {
     story: string;
     preTasks: string;
 }
+
+export interface SimpleTaskType {
+    id: number;
+    title: string;
+    priority: number;
+    managerAvatar: string;
+    tags: Array<string>;
+}
+
+export interface StoryTaskType {
+    story: string;
+    taskList: Array<SimpleTaskType>;
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 필터링 UI 다중선택 구현
- 필터링 API 연동

### 📑 구현한 내용 목록
- [x] 필터링 UI 다중선택 구현
- [x] 필터링 API 연동

### 🚧 논의 사항
- 필터링 UI에서 상태값, 태그 등 다중 선택이 가능하도록 하였습니다.
- `IN` 절을 사용해보았는데, `backend`, `refactoring` 으로 필터 시 `backend`만 가지고 있거나 `refactoring`만 가지고 있는 태스크도 뽑히게 되어 그냥 서비스 단에서 필터링 해주었습니다!
```
task1 - backend
task2 - backend, refactoring
task3 - refactoring

backend로 필터 시 -> task1, task2 
refactoring으로 필터 시 -> task2, task3
backend, refactoring으로 필터 시 -> task2
와 같은 결과를 내야 하기 때문에 IN 절보다는 서비스 단에서 필터링 해주는 것이 좋아보임.
```
- 상태값도 다중 선택을 반영하여서 서비스단 로직을 수정하였습니다!

- close #103 
