### PR TITLE
[#107] feat: 백로그 태스크 모달창 연동 및 태스크 검색 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -3,8 +3,6 @@ package kr.kro.colla.task.task.domain.repository;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.task.domain.Task;
-import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
-import kr.kro.colla.user.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -35,4 +33,7 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and ((:managerId is null and t.managerId is null) or t.managerId = :managerId)")
     List<Task> findAllFilterByManager(@Param("project") Project project, @Param("managerId") Long managerId);
+
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and t.title like %:keyword%")
+    List<Task> findTasksSearchByKeyword(@Param("project") Project project, @Param("keyword") String keyword);
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -92,4 +92,11 @@ public class TaskController {
         return ResponseEntity.ok(taskList);
     }
 
+    @GetMapping("{projectId}/tasks/search")
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> searchTasksByKeyword(@PathVariable Long projectId, @RequestParam String keyword) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.searchTasksByKeyword(projectId, keyword);
+
+        return ResponseEntity.ok(taskList);
+    }
+
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -224,6 +224,20 @@ public class TaskService {
         return projectStoryTaskResponseList;
     }
 
+    public List<ProjectTaskSimpleResponse> searchTasksByKeyword(Long projectId, String keyword) {
+        Project project = projectService.initializeProjectInfo(projectId);
+        List<Task> taskList = taskRepository.findTasksSearchByKeyword(project, keyword);
+
+        return taskList.stream()
+                .map(task -> {
+                    User manager = task.getManagerId() != null
+                            ? userService.findUserById(task.getManagerId())
+                            : null;
+
+                    return TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager);
+                }).collect(Collectors.toList());
+    }
+
     public Task findTaskById(Long taskId) {
         return taskRepository.findById(taskId)
                 .orElseThrow(TaskNotFoundException::new);

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -151,6 +151,19 @@ public class TaskProvider {
                 .build();
     }
 
+    public static Task createTaskWithTitleForRepository(Long managerId, Project project, Story story, TaskStatus taskStatus, String title) {
+        return Task.builder()
+                .title(title)
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(taskStatus)
+                .story(story)
+                .preTasks("[]")
+                .build();
+    }
+
     public static Task createTaskWithPriorityForRepository(Long managerId, Project project, Story story, TaskStatus taskStatus, int priority) {
         return Task.builder()
                 .title("task title")

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -40,6 +40,30 @@ public class TaskProvider {
         return formData;
     }
 
+    public Map<String, String> 를_특정_제목과_함께_생성한다(String accessToken, Long managerId, Long projectId, String story, String title) {
+        Map<String, String> formData = new HashMap<>();
+        formData.put("title", title);
+        formData.put("description", "task description");
+        formData.put("managerId", managerId != null ? managerId.toString() : null);
+        formData.put("priority", "3");
+        formData.put("status", "To Do");
+        formData.put("tags", "[\"backend\"]");
+        formData.put("projectId", projectId.toString());
+        formData.put("story", story);
+        formData.put("preTasks", "[]");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParams(formData)
+        .when()
+                .post("/api/projects/tasks")
+        .then()
+                .statusCode(HttpStatus.CREATED.value());
+
+        return formData;
+    }
+
     public Map<String, String> 를_특정_우선순위로_생성한다(String accessToken, Long managerId, Long projectId, String story, int priority) {
         Map<String, String> formData = new HashMap<>();
         formData.put("title", "task title");
@@ -104,9 +128,9 @@ public class TaskProvider {
                 .contentType(ContentType.URLENC)
                 .cookie("accessToken", accessToken)
                 .formParams(formData)
-                .when()
+        .when()
                 .post("/api/projects/tasks")
-                .then()
+        .then()
                 .statusCode(HttpStatus.CREATED.value());
 
         return formData;

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskProvider.java
@@ -125,6 +125,19 @@ public class TaskProvider {
                 .build();
     }
 
+    public static Task createTaskWithTitle(Long managerId, Project project, Story story, String title) {
+        return Task.builder()
+                .title(title)
+                .managerId(managerId)
+                .description("task description")
+                .priority(4)
+                .project(project)
+                .taskStatus(new TaskStatus("To Do"))
+                .story(story)
+                .preTasks("[]")
+                .build();
+    }
+
     public static Task createTaskWithPriority(Long managerId, Project project, Story story, int priority) {
         return Task.builder()
                 .title("task title")

--- a/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/domain/repository/TaskRepositoryTest.java
@@ -261,4 +261,39 @@ class TaskRepositoryTest {
         assertThat(result.size()).isEqualTo(2);
         result.forEach(task -> assertThat(task.getManagerId()).isNull());
     }
+
+    @Test
+    void 검색한_키워드를_포함하는_제목을_가진_태스크를_조회한다() {
+        // given
+        String keyword = "dropdown";
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        TaskStatus taskStatus = taskStatusRepository.save(new TaskStatus("To Do"));
+        taskRepository.save(TaskProvider.createTaskWithTitleForRepository(null, project, null, taskStatus, "implement filtering dropdown"));
+        taskRepository.save(TaskProvider.createTaskWithTitleForRepository(null, project, null, taskStatus, "Decorate README.md"));
+        taskRepository.save(TaskProvider.createTaskWithTitleForRepository(null, project, null, taskStatus, "refactor task dropdown"));
+
+        // when
+        List<Task> taskList = taskRepository.findTasksSearchByKeyword(project, keyword);
+
+        // then
+        assertThat(taskList).hasSize(2);
+        taskList.forEach(task -> assertThat(task.getTitle()).contains(keyword));
+    }
+
+    @Test
+    void 검색한_키워드를_포함하고_있는_태스크가_없다면_아무것도_반환하지_않는다() {
+        // given
+        String keyword = "api";
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        TaskStatus taskStatus = taskStatusRepository.save(new TaskStatus("To Do"));
+        taskRepository.save(TaskProvider.createTaskWithTitleForRepository(null, project, null, taskStatus, "Set up CI/CD"));
+        taskRepository.save(TaskProvider.createTaskWithTitleForRepository(null, project, null, taskStatus, "Write test code"));
+
+        // when
+        List<Task> taskList = taskRepository.findTasksSearchByKeyword(project, keyword);
+
+        // then
+        assertThat(taskList.size()).isZero();
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -347,7 +348,7 @@ class TaskControllerTest extends ControllerTest {
 
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/story")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -376,7 +377,7 @@ class TaskControllerTest extends ControllerTest {
                 .willReturn(taskList);
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers?managerId=" + managerId)
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -404,7 +405,7 @@ class TaskControllerTest extends ControllerTest {
                 .willReturn(taskList);
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers")
-                .cookie(new Cookie("accessToken", this.accessToken))
+                .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -415,5 +416,35 @@ class TaskControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$[*].managerAvatar", contains(null, null)))
                 .andExpect(jsonPath("$[*].managerName", contains(null, null)));
         verify(taskService, times(1)).getTasksFilterByManager(projectId, null);
+    }
+
+    @Test
+    void 검색한_키워드를_포함하는_제목을_가진_태스크를_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        String keyword = "refactor";
+        Project project = ProjectProvider.createProject(5L);
+        Task task1 = TaskProvider.createTaskWithTitle(null, project, null, "refactor kanban ui");
+        Task task2 = TaskProvider.createTaskWithTitle(null, project, null, "refactor backlog task filter query");
+
+        List<ProjectTaskSimpleResponse> taskList = List.of(
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(task1, null),
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(task2, null)
+        );
+
+        given(taskService.searchTasksByKeyword(eq(projectId), eq(keyword)))
+                .willReturn(taskList);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/search?keyword=" + keyword)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(taskList.size()))
+                .andExpect(jsonPath("$[0].title", containsString(keyword)))
+                .andExpect(jsonPath("$[1].title", containsString(keyword)));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -714,4 +714,30 @@ class TaskServiceTest {
         verify(userService, never()).findUserById(anyLong());
         verify(taskRepository, times(1)).findAllFilterByManager(any(Project.class), isNull());
     }
+
+    @Test
+    void 검색한_키워드를_포함하는_제목을_가진_태스크를_조회한다() {
+        // given
+        Long projectId = 1L;
+        String keyword = "api";
+        Project project = ProjectProvider.createProject(5L);
+        List<Task> taskList = List.of(
+                TaskProvider.createTaskWithTitle(null, project, null, "implement backlog task search api"),
+                TaskProvider.createTaskWithTitle(null, project, null, "refactor backlog filter api")
+        );
+
+        given(projectService.initializeProjectInfo(eq(projectId)))
+                .willReturn(project);
+        given(taskRepository.findTasksSearchByKeyword(any(Project.class), eq(keyword)))
+                .willReturn(taskList);
+
+        // when
+        List<ProjectTaskSimpleResponse> result = taskService.searchTasksByKeyword(projectId, keyword);
+
+        // then
+        assertThat(result).hasSize(2);
+        result.forEach(task -> assertThat(task.getTitle().contains(keyword)));
+        verify(taskRepository, times(1)).findTasksSearchByKeyword(any(Project.class), anyString());
+    }
+
 }

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -54,3 +54,9 @@ export const getTasksFilterByTags = async (projectId: number, tags: string) => {
 
     return response;
 };
+
+export const searchTasksByKeyword = async (projectId: number, keyword: string) => {
+    const response = await client.get(`/projects/${projectId}/tasks/search?keyword=${keyword}`);
+
+    return response;
+};

--- a/frontend/src/components/BacklogFeature/index.tsx
+++ b/frontend/src/components/BacklogFeature/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 import SearchButtonImg from '../../../public/assets/images/search-button.svg';
-import { getTasksGroupByStory } from '../../apis/task';
+import { getTasksGroupByStory, searchTasksByKeyword } from '../../apis/task';
 import { StateType } from '../../types/project';
 import { SortCriteria } from '../DropDown/SortCriteria';
 import { Filter } from '../Modal/Filter';
@@ -15,14 +15,27 @@ interface PropType {
 export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
     const { state } = useLocation<StateType>();
     const features = ['Story', 'Filter', 'Sort'];
-    const [criteriaVisible, setCriteriaVisible] = useState<number>(0);
     const [select, setSelect] = useState('');
+    const [searchKeyword, setSearchKeyword] = useState('');
+    const [criteriaVisible, setCriteriaVisible] = useState<number>(0);
+
     const showCriteria = (idx: number) => {
         setCriteriaVisible((prev) => (prev === idx ? 0 : idx));
     };
 
     const getTasksAboutStory = async () => {
         const res = await getTasksGroupByStory(state.projectId);
+        setBacklogTaskList(res.data);
+    };
+
+    const changeSearchKeyword = (e: React.ChangeEvent) => {
+        setSearchKeyword((e.target as HTMLInputElement).value);
+    };
+
+    const searchTasks = async (e: React.KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+
+        const res = await searchTasksByKeyword(state.projectId, searchKeyword);
         setBacklogTaskList(res.data);
     };
 
@@ -43,7 +56,11 @@ export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
                     </Feature>
                 ))}
                 <SearchBar>
-                    <SearchInput />
+                    <SearchInput
+                        value={searchKeyword}
+                        onChange={(e) => changeSearchKeyword(e)}
+                        onKeyPress={(e) => searchTasks(e)}
+                    />
                     <SearchIcon src={SearchButtonImg} />
                 </SearchBar>
             </FeatureContainer>

--- a/frontend/src/components/BacklogFeature/style.ts
+++ b/frontend/src/components/BacklogFeature/style.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { Center } from '../../styles/common';
+import { Center, LiftUp } from '../../styles/common';
 
 export const Container = styled.div`
     flex-direction: column;
@@ -46,4 +46,6 @@ export const SearchIcon = styled.img`
     width: 24px;
     height: 24px;
     margin: 10px 0 0 -35px;
+
+    ${LiftUp}
 `;

--- a/frontend/src/components/DropDown/PreTask/index.tsx
+++ b/frontend/src/components/DropDown/PreTask/index.tsx
@@ -2,11 +2,12 @@ import React, { FC } from 'react';
 
 import StarImgSrc from '../../../../public/assets/images/star.png';
 import { TaskType } from '../../../types/kanban';
+import { SimpleTaskType } from '../../../types/task';
 import { Star } from '../../Task/style';
 import { Priority, Task, TaskList, TaskTitle } from './style';
 
 interface PropType {
-    taskList: TaskType[];
+    taskList: Array<TaskType | SimpleTaskType>;
     handleChangePreTasks: Function;
     setPreTaskVisible: Function;
 }

--- a/frontend/src/components/Issue/index.tsx
+++ b/frontend/src/components/Issue/index.tsx
@@ -5,15 +5,18 @@ import { Attributes, Manager, Priority, Star, Tag, Tags, Wrapper } from './style
 
 interface PropType {
     story?: boolean;
+    id?: number;
     title: string;
     priority?: number;
     manager?: string;
     tags?: Array<string>;
+    status?: string;
+    showTaskModal?: Function;
 }
 
-const Issue: FC<PropType> = ({ story, title, priority, manager, tags }) => (
+const Issue: FC<PropType> = ({ story, id, title, priority, manager, tags, status, showTaskModal }) => (
     <>
-        <Wrapper story={story}>
+        <Wrapper story={story} onClick={story ? () => {} : (event) => showTaskModal!(event, id, status)}>
             {title ? title : '스토리에 속해있지 않은 태스크 목록'}
             {!story ? (
                 <Attributes>

--- a/frontend/src/components/KanbanCol/index.tsx
+++ b/frontend/src/components/KanbanCol/index.tsx
@@ -84,7 +84,7 @@ const KanbanCol: FC<PropType> = ({ statuses, status, taskList, tasks, changeColu
                 </KanbanIssue>
             </Wrapper>
             <Modal>
-                <TaskModal taskId={taskId} status={status} taskList={taskList} hideModal={setModal} />
+                <TaskModal taskId={taskId} status={status} taskList={taskList} hideModal={setModal} page="kanban" />
             </Modal>
             <StatusModal>
                 <DeleteTaskStatusModal statuses={statuses} status={status} />

--- a/frontend/src/components/List/PreTaskList/index.tsx
+++ b/frontend/src/components/List/PreTaskList/index.tsx
@@ -3,13 +3,14 @@ import React, { FC } from 'react';
 import DeleteIconSrc from '../../../../public/assets/images/delete.png';
 import StarImgSrc from '../../../../public/assets/images/star.png';
 import { TaskType } from '../../../types/kanban';
+import { SimpleTaskType } from '../../../types/task';
 import { Task, TaskTitle } from '../../DropDown/PreTask/style';
 import { Star } from '../../Task/style';
 import { Container, DeleteButton, PreTask } from './style';
 
 interface PropType {
     preTaskList: Array<number>;
-    taskList: Array<TaskType>;
+    taskList: Array<TaskType | SimpleTaskType>;
     handleDeletePreTask: Function;
 }
 

--- a/frontend/src/components/Modal/Task/Basic/index.tsx
+++ b/frontend/src/components/Modal/Task/Basic/index.tsx
@@ -2,7 +2,7 @@ import React, { FC, useState } from 'react';
 
 import DownIconSrc from '../../../../../public/assets/images/down.png';
 import { TaskType } from '../../../../types/kanban';
-import { BasicInputType } from '../../../../types/task';
+import { BasicInputType, SimpleTaskType } from '../../../../types/task';
 import { PreTaskDropDown } from '../../../DropDown/PreTask';
 import { StoryDropDown } from '../../../DropDown/Story';
 import { PreTaskList } from '../../../List/PreTaskList';
@@ -11,7 +11,7 @@ import { DownIcon } from '../style';
 import { AddButton, DescriptionArea, DropDown, TaskComponent, TaskContainer, Title, TitleInput } from './style';
 
 interface PropType {
-    taskList: Array<TaskType>;
+    taskList: Array<TaskType | SimpleTaskType>;
     basicInfoInput: BasicInputType;
 }
 

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect } from 'react';
 import { getTask } from '../../../apis/task';
 import useInputTask from '../../../hooks/useInputTask';
 import { TaskType } from '../../../types/kanban';
+import { SimpleTaskType } from '../../../types/task';
 import { BasicInfoContainer } from './Basic';
 import { CommentContainer } from './Comment';
 import { DetailInfoContainer } from './Detail';
@@ -11,7 +12,7 @@ import { Container, ModalContainer, CancelButton, CompleteButton, ButtonContaine
 interface PropType {
     taskId: number | null;
     status: string;
-    taskList: TaskType[];
+    taskList: Array<TaskType | SimpleTaskType>;
     hideModal: Function;
 }
 

--- a/frontend/src/components/Modal/Task/index.tsx
+++ b/frontend/src/components/Modal/Task/index.tsx
@@ -14,9 +14,10 @@ interface PropType {
     status: string;
     taskList: Array<TaskType | SimpleTaskType>;
     hideModal: Function;
+    page: string;
 }
 
-export const TaskModal: FC<PropType> = ({ taskId, status, taskList, hideModal }) => {
+export const TaskModal: FC<PropType> = ({ taskId, status, taskList, hideModal, page }) => {
     const { basicInfoInput, detailInfoInput, handleCompleteButton, setSelectedTask } = useInputTask();
 
     useEffect(() => {
@@ -39,7 +40,9 @@ export const TaskModal: FC<PropType> = ({ taskId, status, taskList, hideModal })
             {taskId ? <CommentContainer taskId={taskId} /> : null}
             <ButtonContainer>
                 <CancelButton onClick={() => hideModal()}>취소</CancelButton>
-                <CompleteButton onClick={() => handleCompleteButton(taskId)}>{taskId ? '수정' : '완료'}</CompleteButton>
+                <CompleteButton onClick={() => handleCompleteButton(taskId, page)}>
+                    {taskId ? '수정' : '완료'}
+                </CompleteButton>
             </ButtonContainer>
         </ModalContainer>
     );

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
 
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import EmptySrc from '../../../public/assets/images/empty.png';
 import { projectState } from '../../stores/projectState';
-import { ProjectType } from '../../types/project';
+import { ProjectType, StateType } from '../../types/project';
 import {
     ProjectIcon,
     VerticalBar,
@@ -34,7 +34,8 @@ const MENU = [
 
 export const SideBar = ({ props, project }: Props) => {
     const history = useHistory();
-    const [currentProjectState, setProjectState] = useRecoilState(projectState);
+    const { state } = useLocation<StateType>();
+    const setProjectState = useSetRecoilState(projectState);
 
     const enterProject = (project: ProjectType) => {
         const { id, name, description, thumbnail } = project;
@@ -54,7 +55,7 @@ export const SideBar = ({ props, project }: Props) => {
     const handleClickSideBar = (path: string) => {
         history.push({
             pathname: path,
-            state: { projectId: currentProjectState.id },
+            state: { projectId: state.projectId },
         });
     };
 

--- a/frontend/src/hooks/useInputTask.ts
+++ b/frontend/src/hooks/useInputTask.ts
@@ -19,7 +19,7 @@ const useInputTask = () => {
     });
     const { title, description, managerId, priority, status, selectedTags, story, preTasks } = taskInput;
 
-    const handleCompleteButton = async (taskId: number | null) => {
+    const handleCompleteButton = async (taskId: number | null, page: string) => {
         const formData = new FormData();
         formData.append('title', title);
         formData.append('description', description);
@@ -32,7 +32,7 @@ const useInputTask = () => {
         formData.append('preTasks', JSON.stringify(preTasks));
 
         taskId ? await updateTask(taskId!, formData) : await createTask(formData);
-        window.location.replace('/kanban');
+        window.location.replace(`/${page}`);
     };
 
     const handleChangeTitle = (e: React.ChangeEvent) => {

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -97,6 +97,7 @@ const Backlog = () => {
                             status={taskInfo!.status}
                             taskList={preTaskList}
                             hideModal={setModal}
+                            page="backlog"
                         />
                     ) : null}
                 </Modal>

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -5,19 +5,44 @@ import { getTasksGroupByStory } from '../../apis/task';
 import { BacklogFeature } from '../../components/BacklogFeature';
 import Header from '../../components/Header';
 import Issue from '../../components/Issue';
+import { TaskModal } from '../../components/Modal/Task';
 import { SideBar } from '../../components/SideBar';
+import useModal from '../../hooks/useModal';
 import { StateType } from '../../types/project';
 import { SimpleTaskType, StoryTaskType } from '../../types/task';
-import { Container, Wrapper } from './style';
+import { Container, TaskModalContainer, Wrapper } from './style';
+
+interface TaskInfoType {
+    taskId: number;
+    status: string;
+}
 
 const Backlog = () => {
     const { state } = useLocation<StateType>();
     const [backlogTaskList, setBacklogTaskList] = useState<Array<StoryTaskType | SimpleTaskType>>([]);
+    const { Modal, setModal } = useModal();
+    const [taskInfo, setTaskInfo] = useState<TaskInfoType | null>(null);
+    const [preTaskList, setPreTaskList] = useState<Array<SimpleTaskType>>([]);
+
+    const showTaskModal = (event: React.MouseEventHandler, taskId: number, status: string) => {
+        setTaskInfo({
+            taskId,
+            status,
+        });
+        setModal(event);
+    };
 
     useEffect(() => {
         (async () => {
             const res = await getTasksGroupByStory(state.projectId);
-            setBacklogTaskList(res.data);
+            const storyTasks = res.data;
+
+            setBacklogTaskList(storyTasks);
+            setPreTaskList(() => {
+                const preTasks: Array<SimpleTaskType> = [];
+                storyTasks.map((storyTask) => storyTask.taskList).forEach((taskList) => preTasks.concat(taskList));
+                return preTasks;
+            });
         })();
     }, []);
 
@@ -32,30 +57,50 @@ const Backlog = () => {
                         ? (backlogTaskList as Array<StoryTaskType>).map(({ story, taskList }: StoryTaskType, idx) => (
                               <>
                                   <Issue key={idx} title={story} story />
-                                  {taskList.map(({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (
-                                      <Issue
-                                          key={id}
-                                          title={title}
-                                          priority={priority}
-                                          manager={managerAvatar}
-                                          tags={tags}
-                                      />
-                                  ))}
+                                  {taskList.map(
+                                      ({ id, title, priority, managerAvatar, tags, status }: SimpleTaskType) => (
+                                          <Issue
+                                              key={id}
+                                              id={id}
+                                              title={title}
+                                              priority={priority}
+                                              manager={managerAvatar}
+                                              tags={tags}
+                                              status={status}
+                                              showTaskModal={showTaskModal}
+                                          />
+                                      ),
+                                  )}
                               </>
                           ))
                         : (backlogTaskList as Array<SimpleTaskType>).map(
-                              ({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (
+                              ({ id, title, priority, managerAvatar, tags, status }: SimpleTaskType) => (
                                   <Issue
                                       key={id}
+                                      id={id}
                                       title={title}
                                       priority={priority}
                                       manager={managerAvatar}
                                       tags={tags}
+                                      status={status}
+                                      showTaskModal={showTaskModal}
                                   />
                               ),
                           )}
                 </Wrapper>
             </Container>
+            <TaskModalContainer>
+                <Modal>
+                    {taskInfo ? (
+                        <TaskModal
+                            taskId={taskInfo!.taskId}
+                            status={taskInfo!.status}
+                            taskList={preTaskList}
+                            hideModal={setModal}
+                        />
+                    ) : null}
+                </Modal>
+            </TaskModalContainer>
         </>
     );
 };

--- a/frontend/src/pages/Backlog/style.tsx
+++ b/frontend/src/pages/Backlog/style.tsx
@@ -27,3 +27,9 @@ export const Wrapper = styled.div`
 
     ${Column}
 `;
+
+export const TaskModalContainer = styled.div`
+    position: absolute;
+    top: 100px;
+    left: 300px;
+`;

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -43,6 +43,7 @@ export interface SimpleTaskType {
     priority: number;
     managerAvatar: string;
     tags: Array<string>;
+    status: string;
 }
 
 export interface StoryTaskType {


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 백로그 태스크 모달창 연동
- 태스크 검색 구현

### 📑 구현한 내용 목록
- [x] 백로그 태스크 모달창 연동
- [x] 태스크 검색 구현

### 🚧 논의 사항
- 백로그 태스크 클릭 시 태스크 모달창을 띄워주도록 하였고, 수정 시 현재 페이지로 새로고침되도록 하였습니다!
- 태스크 검색 기능은 백로그에서 표시되는 태스크 제목에 대한 키워드 검색으로 구현하였습니다!

- close #107 