### PR TITLE
[#108] feat: 테스크 목록 필터링 API 다중 선택으로 수정 및 프론트엔드와 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -30,8 +30,8 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.priority desc")
     List<Task> findAllOrderByPriorityDesc(@Param("project") Project project);
 
-    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and t.taskStatus = :taskStatus")
-    List<Task> findAllFilterByTaskStatus(@Param("project") Project project, @Param("taskStatus") TaskStatus taskStatus);
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and t.taskStatus.name in :taskStatuses")
+    List<Task> findAllFilterByTaskStatus(@Param("project") Project project, @Param("taskStatuses") List<String> taskStatuses);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and ((:managerId is null and t.managerId is null) or t.managerId = :managerId)")
     List<Task> findAllFilterByManager(@Param("project") Project project, @Param("managerId") Long managerId);

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -33,6 +33,6 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and t.taskStatus.name in :taskStatuses")
     List<Task> findAllFilterByTaskStatus(@Param("project") Project project, @Param("taskStatuses") List<String> taskStatuses);
 
-    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and ((:managerId is null and t.managerId is null) or t.managerId = :managerId)")
-    List<Task> findAllFilterByManager(@Param("project") Project project, @Param("managerId") Long managerId);
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project and ((:canNull = true and t.managerId is null) or t.managerId in :managers)")
+    List<Task> findAllFilterByManager(@Param("project") Project project, @Param("managers") List<Long> managers, @Param("canNull") Boolean canNull);
 }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -72,8 +72,8 @@ public class TaskController {
     }
 
     @GetMapping("/{projectId}/tasks/managers")
-    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByManagers(@PathVariable Long projectId, @RequestParam(required = false) Long managerId) {
-        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByManager(projectId, managerId);
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByManagers(@PathVariable Long projectId, @RequestParam(required = false, defaultValue ="") List<Long> managers, @RequestParam(defaultValue = "false") Boolean notSelected) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByManager(projectId, managers, notSelected);
 
         return ResponseEntity.ok(taskList);
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -65,8 +65,8 @@ public class TaskController {
     }
 
     @GetMapping("/{projectId}/tasks/statuses")
-    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByStatuses(@PathVariable Long projectId, @RequestParam String status) {
-        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByStatus(projectId, status);
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByStatuses(@PathVariable Long projectId, @RequestParam List<String> statuses) {
+        List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByStatus(projectId, statuses);
 
         return ResponseEntity.ok(taskList);
     }

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -72,7 +72,7 @@ public class TaskController {
     }
 
     @GetMapping("/{projectId}/tasks/managers")
-    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByManagers(@PathVariable Long projectId, @RequestParam(required = false, defaultValue ="") List<Long> managers, @RequestParam(defaultValue = "false") Boolean notSelected) {
+    public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksFilterByManagers(@PathVariable Long projectId, @RequestParam(defaultValue ="") List<Long> managers, @RequestParam(defaultValue = "false") Boolean notSelected) {
         List<ProjectTaskSimpleResponse> taskList = taskService.getTasksFilterByManager(projectId, managers, notSelected);
 
         return ResponseEntity.ok(taskList);

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -158,11 +158,10 @@ public class TaskService {
                 }).collect(Collectors.toList());
     }
 
-    public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, String statusName) {
+    public List<ProjectTaskSimpleResponse> getTasksFilterByStatus(Long projectId, List<String> statuses) {
         Project project = projectService.initializeProjectInfo(projectId);
 
-        TaskStatus taskStatus = taskStatusService.findTaskStatusByName(statusName);
-        List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, taskStatus);
+        List<Task> taskList = taskRepository.findAllFilterByTaskStatus(project, statuses);
 
         return taskList.stream()
                 .map(task -> {

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -20,10 +20,7 @@ import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -173,9 +170,10 @@ public class TaskService {
                 }).collect(Collectors.toList());
     }
 
-    public List<ProjectTaskSimpleResponse> getTasksFilterByManager(Long projectId, Long managerId) {
+    public List<ProjectTaskSimpleResponse> getTasksFilterByManager(Long projectId, List<Long> managers, Boolean notSelected) {
         Project project = projectService.initializeProjectInfo(projectId);
-        List<Task> taskList = taskRepository.findAllFilterByManager(project, managerId);
+
+        List<Task> taskList = taskRepository.findAllFilterByManager(project, managers, notSelected);
 
         return taskList.stream()
                 .map(task -> {

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -248,22 +248,23 @@ class TaskControllerTest extends ControllerTest {
     }
 
     @Test
-    void 프로젝트의_테스크들을_상태값으로_필터링해_조회한다() throws Exception {
+    void 프로젝트의_테스크들을_상태값들으로_필터링해_조회한다() throws Exception {
         // given
         Long projectId = 23424L, statusId = 9501L;
         Project project = ProjectProvider.createProject(3462L);
         User user = UserProvider.createUser2();
-        TaskStatus taskStatus = new TaskStatus("status)_)to)_)filter");
+        TaskStatus taskStatus1 = new TaskStatus("To Do");
+        TaskStatus taskStatus2 = new TaskStatus("Done");
         List<ProjectTaskSimpleResponse> taskList = List.of(
-                TaskResponseConverter.convertToProjectTaskSimpleResponse(TaskProvider.createTaskForRepository(null, project, null, taskStatus), null),
-                TaskResponseConverter.convertToProjectTaskSimpleResponse(TaskProvider.createTaskForRepository(null, project, null, taskStatus), user)
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(TaskProvider.createTaskForRepository(null, project, null, taskStatus1), null),
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(TaskProvider.createTaskForRepository(null, project, null, taskStatus2), user)
         );
 
-        given(taskService.getTasksFilterByStatus(projectId, taskStatus.getName()))
+        given(taskService.getTasksFilterByStatus(eq(projectId), any(List.class)))
                 .willReturn(taskList);
 
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/statuses?status=" + taskStatus.getName())
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/statuses?statuses=To Do, Done")
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -272,8 +273,8 @@ class TaskControllerTest extends ControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(taskList.size()))
                 .andExpect(jsonPath("$[*].managerName", contains(null, user.getName())))
-                .andExpect(jsonPath("$[*].status", contains(taskStatus.getName(), taskStatus.getName())));
-        verify(taskService, times(1)).getTasksFilterByStatus(projectId, taskStatus.getName());
+                .andExpect(jsonPath("$[*].status", contains(taskStatus1.getName(), taskStatus2.getName())));
+        verify(taskService, times(1)).getTasksFilterByStatus(eq(projectId), any(List.class));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -363,20 +363,21 @@ class TaskControllerTest extends ControllerTest {
     @Test
     void 프로젝트들의_테스크들을_담당자로_필터링해_조회한다() throws Exception {
         // given
-        Long projectId = 5553L, managerId = 25234L;
+        Long projectId = 5553L, managerId1 = 25234L, managerId2 = 6592L;
         Project project = ProjectProvider.createProject(111L);
         User manager = UserProvider.createUser();
-        Task task = TaskProvider.createTask(managerId, project, null);
+        Task task1 = TaskProvider.createTask(managerId1, project, null);
+        Task task2 = TaskProvider.createTask(managerId2, project, null);
         List<ProjectTaskSimpleResponse> taskList = List.of(
-                TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager),
-                TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager),
-                TaskResponseConverter.convertToProjectTaskSimpleResponse(task, manager)
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(task1, manager),
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(task2, manager),
+                TaskResponseConverter.convertToProjectTaskSimpleResponse(task1, manager)
         );
 
-        given(taskService.getTasksFilterByManager(projectId, managerId))
+        given(taskService.getTasksFilterByManager(eq(projectId), anyList(), eq(false)))
                 .willReturn(taskList);
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers?managerId=" + managerId)
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers?managers=" + managerId1 + ", " + managerId2)
                 .cookie(new Cookie("accessToken", this.accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -384,9 +385,8 @@ class TaskControllerTest extends ControllerTest {
         perform
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(taskList.size()))
-                .andExpect(jsonPath("$[0].title").value(task.getTitle()))
                 .andExpect(jsonPath("$[*].managerAvatar", contains(manager.getAvatar(), manager.getAvatar(), manager.getAvatar())));
-        verify(taskService, times(1)).getTasksFilterByManager(projectId, managerId);
+        verify(taskService, times(1)).getTasksFilterByManager(eq(projectId), anyList(), eq(false));
     }
 
     @Test
@@ -394,17 +394,17 @@ class TaskControllerTest extends ControllerTest {
         // given
         Long projectId = 5553L;
         Project project = ProjectProvider.createProject(111L);
-        User manager = UserProvider.createUser();
         Task task = TaskProvider.createTask(null, project, null);
         List<ProjectTaskSimpleResponse> taskList = List.of(
                 TaskResponseConverter.convertToProjectTaskSimpleResponse(task, null),
                 TaskResponseConverter.convertToProjectTaskSimpleResponse(task, null)
         );
 
-        given(taskService.getTasksFilterByManager(projectId, null))
+        given(taskService.getTasksFilterByManager(eq(projectId), anyList(), eq(true)))
                 .willReturn(taskList);
         // when
-        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers")
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/tasks/managers?notSelected=true")
+
                 .cookie(new Cookie("accessToken", this.accessToken))
                 .contentType(MediaType.APPLICATION_JSON));
 
@@ -415,6 +415,6 @@ class TaskControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$[0].title").value(task.getTitle()))
                 .andExpect(jsonPath("$[*].managerAvatar", contains(null, null)))
                 .andExpect(jsonPath("$[*].managerName", contains(null, null)));
-        verify(taskService, times(1)).getTasksFilterByManager(projectId, null);
+        verify(taskService, times(1)).getTasksFilterByManager(eq(projectId), anyList(), eq(true));
     }
 }

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -56,3 +56,19 @@ export const getTasksFilterByTags = async (projectId: number, tags: string) => {
 
     return response;
 };
+
+export const getTasksOrderByCreatedDate = async (projectId: number, ascending: boolean) => {
+    const response = await client.get<Array<SimpleTaskType>>(
+        `/projects/${projectId}/tasks/created-date?ascending=${ascending}`,
+    );
+
+    return response;
+};
+
+export const getTasksOrderByPriority = async (projectId: number, ascending: boolean) => {
+    const response = await client.get<Array<SimpleTaskType>>(
+        `/projects/${projectId}/tasks/priority?ascending=${ascending}`,
+    );
+
+    return response;
+};

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -43,8 +43,10 @@ export const getTasksFilterByStatus = async (projectId: number, statuses: string
     return response;
 };
 
-export const getTasksFilterByManager = async (projectId: number, managers: string) => {
-    const response = await client.get<Array<SimpleTaskType>>(`/projects/${projectId}/tasks/tags?managers=${managers}`);
+export const getTasksFilterByManager = async (projectId: number, managers: string, includeNoManager: boolean) => {
+    const response = await client.get<Array<SimpleTaskType>>(
+        `/projects/${projectId}/tasks/managers?managers=${managers}&notSelected=${includeNoManager}`,
+    );
 
     return response;
 };

--- a/frontend/src/components/BacklogFeature/index.tsx
+++ b/frontend/src/components/BacklogFeature/index.tsx
@@ -16,7 +16,6 @@ export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
     const { state } = useLocation<StateType>();
     const features = ['Story', 'Filter', 'Sort'];
     const [criteriaVisible, setCriteriaVisible] = useState<number>(0);
-    const [select, setSelect] = useState('');
     const showCriteria = (idx: number) => {
         setCriteriaVisible((prev) => (prev === idx ? 0 : idx));
     };
@@ -38,7 +37,7 @@ export const BacklogFeature: FC<PropType> = ({ setBacklogTaskList }) => {
                             <Filter setBacklogTaskList={setBacklogTaskList} />
                         ) : null}
                         {feature === 'Sort' && criteriaVisible === idx ? (
-                            <SortCriteria select={select} setSelect={setSelect} />
+                            <SortCriteria setBacklogTaskList={setBacklogTaskList} />
                         ) : null}
                     </Feature>
                 ))}

--- a/frontend/src/components/DropDown/SortCriteria/index.tsx
+++ b/frontend/src/components/DropDown/SortCriteria/index.tsx
@@ -1,21 +1,26 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import ascImg from '../../../../public/assets/images/ascending.svg';
 import descImg from '../../../../public/assets/images/descending.svg';
+import { getTasksOrderByCreatedDate, getTasksOrderByPriority } from '../../../apis/task';
+import { StateType } from '../../../types/project';
 import { Container, Criteria, CriteriaTitle } from './style';
 
 interface PropType {
-    select: string;
-    setSelect: Function;
+    setBacklogTaskList: Function;
 }
 
-const CREATED_AT = 'SORT.CREATED_AT';
-const PRIORITY = 'SORT.PRIORITY';
+const CREATED_DATE = 'CREATED_DATE';
+const PRIORITY = 'PRIORITY';
 
 const orderImage = (asc: boolean) => (asc ? <img src={ascImg} /> : <img src={descImg} />);
 
-export const SortCriteria: FC<PropType> = ({ select, setSelect }) => {
+export const SortCriteria: FC<PropType> = ({ setBacklogTaskList }) => {
+    const { state } = useLocation<StateType>();
+    const { projectId } = state;
     const [asc, setAsc] = useState(true);
+    const [select, setSelect] = useState('');
 
     const toggleAsc = () => setAsc(!asc);
 
@@ -28,11 +33,24 @@ export const SortCriteria: FC<PropType> = ({ select, setSelect }) => {
         setAsc(true);
     };
 
+    const getSortedTaskList = async () => {
+        if (select === '') return;
+        const res =
+            select === CREATED_DATE
+                ? await getTasksOrderByCreatedDate(projectId, asc)
+                : await getTasksOrderByPriority(projectId, asc);
+
+        setBacklogTaskList(res.data);
+    };
+
+    useEffect(() => {
+        getSortedTaskList();
+    }, [select, asc]);
     return (
         <Container>
-            <Criteria onClick={() => handleClick(CREATED_AT)}>
-                <CriteriaTitle selected={select === CREATED_AT}>생성날짜</CriteriaTitle>
-                {select === CREATED_AT ? orderImage(asc) : null}
+            <Criteria onClick={() => handleClick(CREATED_DATE)}>
+                <CriteriaTitle selected={select === CREATED_DATE}>생성날짜</CriteriaTitle>
+                {select === CREATED_DATE ? orderImage(asc) : null}
             </Criteria>
             <Criteria onClick={() => handleClick(PRIORITY)}>
                 <CriteriaTitle selected={select === PRIORITY}>중요도</CriteriaTitle>

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -30,8 +30,8 @@ const Backlog = () => {
                 <Wrapper>
                     {backlogTaskList.length > 0 && 'story' in backlogTaskList[0]
                         ? (backlogTaskList as Array<StoryTaskType>).map(({ story, taskList }: StoryTaskType, idx) => (
-                              <>
-                                  <Issue key={idx} title={story} story />
+                              <div key={idx}>
+                                  <Issue title={story} story />
                                   {taskList.map(({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (
                                       <Issue
                                           key={id}
@@ -41,7 +41,7 @@ const Backlog = () => {
                                           tags={tags}
                                       />
                                   ))}
-                              </>
+                              </div>
                           ))
                         : (backlogTaskList as Array<SimpleTaskType>).map(
                               ({ id, title, priority, managerAvatar, tags }: SimpleTaskType) => (


### PR DESCRIPTION
### 🔨 작업 내용 설명

테스크 목록 정렬 API 프론트엔드를 연동했습니다~

필터링하는 API 리스트로 받아서 다중 선택할 수 있도록 쿼리 IN 방식으로 수정하고,
담당자 필터링이 되도록 완전히 연동했습니다!

### 📑 구현한 내용 목록

- [x]  정렬 API 프론트엔드 연동
- [x]  필터링하는 API 다중 선택으로 수정
- [x]  관련 테스트 수정

### 🚧 논의 사항
- 담당자가 없는 테스크를 필터링 할 일이 있을 수 있다고 판단해서 (담당자 할당되지 않은 테스크 보고 할당해주는 등..)
 담당자가 다중 선택될 수 있고 테스크의 managerId가 null인 테스크도 선택할 수 있도록 구현했습니다.
 `@RequestParam`으로 List<Long>에 null 값을 할당할 수 없어 담당자가 없는 경우를 포함하고자 하는 경우를
 추가적인 쿼리스트링(`notSelected=true`시 담당자 미선택 포함)을 통해 구분했습니다.
- close #108 
