### PR TITLE
[#112] feat: 로드맵 스토리/태스크 목록 UI, API 구현 및 연동

### DIFF
--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/ProjectController.java
@@ -50,15 +50,15 @@ public class ProjectController {
     }
 
     @PostMapping("/{projectId}/stories")
-    public ResponseEntity<ProjectStoryResponse> createStory(@PathVariable Long projectId, @Valid @RequestBody CreateStoryRequest createStoryRequest) {
+    public ResponseEntity<ProjectStorySimpleResponse> createStory(@PathVariable Long projectId, @Valid @RequestBody CreateStoryRequest createStoryRequest) {
         Story story = storyService.createStory(projectId, createStoryRequest);
 
-        return ResponseEntity.ok(new ProjectStoryResponse(story));
+        return ResponseEntity.ok(new ProjectStorySimpleResponse(story));
     }
 
     @GetMapping("/{projectId}/stories")
-    public ResponseEntity<List<ProjectStoryResponse>> getProjectStories(@PathVariable Long projectId) {
-        List<ProjectStoryResponse> projectStories = projectService.getProjectStories(projectId);
+    public ResponseEntity<List<ProjectStorySimpleResponse>> getProjectStories(@PathVariable Long projectId) {
+        List<ProjectStorySimpleResponse> projectStories = projectService.getProjectStories(projectId);
 
         return ResponseEntity.ok(projectStories);
     }

--- a/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectStorySimpleResponse.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/presentation/dto/ProjectStorySimpleResponse.java
@@ -6,11 +6,11 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-public class ProjectStoryResponse {
+public class ProjectStorySimpleResponse {
 
     private String title;
 
-    public ProjectStoryResponse(Story story) {
+    public ProjectStorySimpleResponse(Story story) {
         this.title = story.getTitle();
     }
 

--- a/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/service/ProjectService.java
@@ -9,7 +9,6 @@ import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.project.service.dto.ProjectTaskResponse;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
-import kr.kro.colla.project.task_status.service.TaskStatusService;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
@@ -98,10 +97,10 @@ public class ProjectService {
                 .build();
     }
 
-    public List<ProjectStoryResponse> getProjectStories(Long projectId) {
+    public List<ProjectStorySimpleResponse> getProjectStories(Long projectId) {
         return findProjectById(projectId).getStories()
                 .stream()
-                .map(ProjectStoryResponse::new)
+                .map(ProjectStorySimpleResponse::new)
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/kr/kro/colla/story/domain/Story.java
+++ b/backend/src/main/java/kr/kro/colla/story/domain/Story.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.story.domain;
 
 import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.story.presentation.dto.UpdateStoryPeriodRequest;
 import kr.kro.colla.task.task.domain.Task;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,6 +28,12 @@ public class Story {
     @Column
     private String preStories;
 
+    @Column
+    private LocalDate startAt;
+
+    @Column
+    private LocalDate endAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_id")
     private Project project;
@@ -38,6 +46,11 @@ public class Story {
         this.title = title;
         this.preStories = preStories;
         this.project = project;
+    }
+
+    public void updatePeriod(UpdateStoryPeriodRequest updateStoryPeriodRequest) {
+        this.startAt = updateStoryPeriodRequest.getStartAt();
+        this.endAt = updateStoryPeriodRequest.getEndAt();
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
+++ b/backend/src/main/java/kr/kro/colla/story/domain/repository/StoryRepository.java
@@ -1,12 +1,19 @@
 package kr.kro.colla.story.domain.repository;
 
+import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.story.domain.Story;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
 
     Optional<Story> findByTitle(String title);
+
+    @Query("select s from Story s where s.project = :project")
+    List<Story> findProjectStories(@Param("project")Project project);
 
 }

--- a/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
@@ -1,0 +1,34 @@
+package kr.kro.colla.story.presentation;
+
+import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.story.presentation.dto.UpdateStoryPeriodRequest;
+import kr.kro.colla.story.service.StoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+@RestController
+public class StoryController {
+
+    private final StoryService storyService;
+
+    @GetMapping("/{projectId}/stories")
+    public ResponseEntity<List<ProjectStoryResponse>> getProjectStories(@PathVariable Long projectId) {
+        List<ProjectStoryResponse> storyList = storyService.findProjectStories(projectId);
+
+        return ResponseEntity.ok(storyList);
+    }
+
+    @PatchMapping("/stories/{storyId}/period")
+    public ResponseEntity<Void> updateStoryPeriod(@PathVariable Long storyId, UpdateStoryPeriodRequest updateStoryPeriodRequest) {
+        storyService.updateStoryPeriod(storyId, updateStoryPeriodRequest);
+
+        return ResponseEntity.ok()
+                .build();
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
@@ -16,9 +16,9 @@ public class StoryController {
 
     private final StoryService storyService;
 
-    @GetMapping("/{projectId}/stories")
+    @GetMapping("/{projectId}/all-stories")
     public ResponseEntity<List<ProjectStoryResponse>> getProjectStories(@PathVariable Long projectId) {
-        List<ProjectStoryResponse> storyList = storyService.findProjectStories(projectId);
+        List<ProjectStoryResponse> storyList = storyService.getProjectStories(projectId);
 
         return ResponseEntity.ok(storyList);
     }

--- a/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/StoryController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -24,7 +25,7 @@ public class StoryController {
     }
 
     @PatchMapping("/stories/{storyId}/period")
-    public ResponseEntity<Void> updateStoryPeriod(@PathVariable Long storyId, UpdateStoryPeriodRequest updateStoryPeriodRequest) {
+    public ResponseEntity<Void> updateStoryPeriod(@PathVariable Long storyId, @Valid UpdateStoryPeriodRequest updateStoryPeriodRequest) {
         storyService.updateStoryPeriod(storyId, updateStoryPeriodRequest);
 
         return ResponseEntity.ok()

--- a/backend/src/main/java/kr/kro/colla/story/presentation/dto/ProjectStoryResponse.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/dto/ProjectStoryResponse.java
@@ -1,0 +1,29 @@
+package kr.kro.colla.story.presentation.dto;
+
+import kr.kro.colla.story.domain.Story;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class ProjectStoryResponse {
+
+    private Long id;
+
+    private String title;
+
+    private String preStories;
+
+    private LocalDate startAt;
+
+    private LocalDate endAt;
+
+    public ProjectStoryResponse(Story story) {
+        this.id = story.getId();
+        this.title = story.getTitle();
+        this.preStories = story.getPreStories();
+        this.startAt = story.getStartAt();
+        this.endAt = story.getEndAt();
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/story/presentation/dto/ProjectStoryResponse.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/dto/ProjectStoryResponse.java
@@ -2,9 +2,11 @@ package kr.kro.colla.story.presentation.dto;
 
 import kr.kro.colla.story.domain.Story;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+@NoArgsConstructor
 @Getter
 public class ProjectStoryResponse {
 

--- a/backend/src/main/java/kr/kro/colla/story/presentation/dto/UpdateStoryPeriodRequest.java
+++ b/backend/src/main/java/kr/kro/colla/story/presentation/dto/UpdateStoryPeriodRequest.java
@@ -1,0 +1,22 @@
+package kr.kro.colla.story.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@AllArgsConstructor
+@Getter
+public class UpdateStoryPeriodRequest {
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startAt;
+
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endAt;
+
+}

--- a/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
+++ b/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
@@ -39,7 +39,7 @@ public class StoryService {
         story.updatePeriod(updateStoryPeriodRequest);
     }
 
-    public List<ProjectStoryResponse> findProjectStories(Long projectId) {
+    public List<ProjectStoryResponse> getProjectStories(Long projectId) {
         Project project = projectService.findProjectById(projectId);
         List<Story> storyList = storyRepository.findProjectStories(project);
 

--- a/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
+++ b/backend/src/main/java/kr/kro/colla/story/service/StoryService.java
@@ -6,10 +6,14 @@ import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.domain.repository.StoryRepository;
+import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.story.presentation.dto.UpdateStoryPeriodRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +32,25 @@ public class StoryService {
                 .build();
 
         return storyRepository.save(story);
+    }
+
+    public void updateStoryPeriod(Long storyId, UpdateStoryPeriodRequest updateStoryPeriodRequest) {
+        Story story = findStoryById(storyId);
+        story.updatePeriod(updateStoryPeriodRequest);
+    }
+
+    public List<ProjectStoryResponse> findProjectStories(Long projectId) {
+        Project project = projectService.findProjectById(projectId);
+        List<Story> storyList = storyRepository.findProjectStories(project);
+
+        return storyList.stream()
+                .map(ProjectStoryResponse::new)
+                .collect(Collectors.toList());
+    }
+
+    public Story findStoryById(Long id) {
+        return storyRepository.findById(id)
+                .orElseThrow(StoryNotFoundException::new);
     }
 
     public Story findStoryByTitle(String title) {

--- a/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/domain/repository/TaskRepository.java
@@ -2,6 +2,7 @@ package kr.kro.colla.task.task.domain.repository;
 
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.task.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -15,6 +16,9 @@ public interface TaskRepository extends JpaRepository<Task, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Task t set t.taskStatus = :to where t.taskStatus = :from")
     void bulkUpdateTaskStatusToAnother(@Param("from") TaskStatus from, @Param("to")TaskStatus to);
+
+    @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.story = :story")
+    List<Task> findStoryTasks(@Param("story") Story story);
 
     @Query("select distinct t from Task t left join fetch t.taskTags tt left join fetch tt.tag where t.project = :project order by t.createdAt asc")
     List<Task> findAllOrderByCreatedAtAsc(@Param("project") Project project);

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -50,6 +50,13 @@ public class TaskController {
                 .build();
     }
 
+    @GetMapping("/{projectId}/stories/{storyId}/tasks")
+    public ResponseEntity<List<RoadmapTaskResponse>> getStoryTasks(@PathVariable("projectId") Long projectId, @PathVariable("storyId") Long storyId) {
+        List<RoadmapTaskResponse> taskList = taskService.getStoryTasks(projectId, storyId);
+
+        return ResponseEntity.ok(taskList);
+    }
+
     @GetMapping("/{projectId}/tasks/created-date")
     public ResponseEntity<List<ProjectTaskSimpleResponse>> getTasksOrderByCreatedDate(@PathVariable Long projectId, @RequestParam(defaultValue = "false") Boolean ascending) {
         List<ProjectTaskSimpleResponse> taskList = taskService.getTasksOrderByCreatedDate(projectId, ascending);

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/RoadmapTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/RoadmapTaskResponse.java
@@ -1,11 +1,15 @@
 package kr.kro.colla.task.task.presentation.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class RoadmapTaskResponse {
 

--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/RoadmapTaskResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/dto/RoadmapTaskResponse.java
@@ -1,0 +1,18 @@
+package kr.kro.colla.task.task.presentation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class RoadmapTaskResponse {
+
+    private String title;
+
+    private String manager;
+
+    private List<String> tags;
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/TaskService.java
@@ -99,6 +99,22 @@ public class TaskService {
         task.updateTaskStatus(taskStatus);
     }
 
+    public List<RoadmapTaskResponse> getStoryTasks(Long projectId, Long storyId) {
+        Project project = projectService.findProjectById(projectId);
+        Story story = storyService.findStoryById(storyId);
+        List<Task> taskList = taskRepository.findStoryTasks(story);
+        Hibernate.initialize(project.getMembers());
+
+        return taskList.stream()
+                .map(task -> {
+                    User manager = task.getManagerId() != null
+                            ? userService.findUserById(task.getManagerId())
+                            : null;
+
+                    return TaskResponseConverter.convertToRoadmapTaskResponse(task, manager);
+                }).collect(Collectors.toList());
+    }
+
     public List<ProjectTaskSimpleResponse> getTasksOrderByCreatedDate(Long projectId, Boolean ascending) {
         Project project = projectService.initializeProjectInfo(projectId);
 

--- a/backend/src/main/java/kr/kro/colla/task/task/service/converter/TaskResponseConverter.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/service/converter/TaskResponseConverter.java
@@ -3,6 +3,7 @@ package kr.kro.colla.task.task.service.converter;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskResponse;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
+import kr.kro.colla.task.task.presentation.dto.RoadmapTaskResponse;
 import kr.kro.colla.user.user.domain.User;
 
 import java.util.stream.Collectors;
@@ -34,6 +35,17 @@ public class TaskResponseConverter {
                 .manager(user != null ? user.getName() : null)
                 .status(task.getTaskStatus().getName())
                 .priority(task.getPriority())
+                .tags(task.getTaskTags()
+                        .stream()
+                        .map(taskTag -> taskTag.getTag().getName())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    public static RoadmapTaskResponse convertToRoadmapTaskResponse(Task task, User user) {
+        return RoadmapTaskResponse.builder()
+                .title(task.getTitle())
+                .manager(user != null ? user.getName() : null)
                 .tags(task.getTaskTags()
                         .stream()
                         .map(taskTag -> taskTag.getTag().getName())

--- a/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
@@ -3,7 +3,7 @@ package kr.kro.colla.common.fixture;
 import io.restassured.http.ContentType;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
-import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.project.project.presentation.dto.ProjectStorySimpleResponse;
 import kr.kro.colla.story.domain.Story;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -14,7 +14,7 @@ import static io.restassured.RestAssured.given;
 @Component
 public class StoryProvider {
 
-    public ProjectStoryResponse 를_생성한다(Long projectId, String accessToken, String title) {
+    public ProjectStorySimpleResponse 를_생성한다(Long projectId, String accessToken, String title) {
         CreateStoryRequest createStoryRequest = new CreateStoryRequest(title);
 
         return given()
@@ -27,7 +27,7 @@ public class StoryProvider {
         .then()
                 .statusCode(HttpStatus.OK.value())
                 .extract()
-                .as(ProjectStoryResponse.class);
+                .as(ProjectStorySimpleResponse.class);
     }
 
     public static Story createStory(Project project, String title) {

--- a/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/StoryProvider.java
@@ -30,6 +30,18 @@ public class StoryProvider {
                 .as(ProjectStorySimpleResponse.class);
     }
 
+    public void 의_진행_기간을_설정한다(Long storyId, String accessToken, String startAt, String endAt) {
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParam("startAt", startAt)
+                .formParam("endAt", endAt)
+        .when()
+                .patch("/api/projects/stories/" + storyId + "/period")
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
     public static Story createStory(Project project, String title) {
         return Story.builder()
                 .title(title)

--- a/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/AcceptanceTest.java
@@ -211,7 +211,7 @@ public class AcceptanceTest {
         String storyTitle = "story title";
         story.를_생성한다(createdProject.getId(), accessToken, storyTitle);
 
-        List<ProjectStoryResponse> response = given()
+        List<ProjectStorySimpleResponse> response = given()
                 .contentType(ContentType.JSON)
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .cookie("accessToken", accessToken)
@@ -225,7 +225,7 @@ public class AcceptanceTest {
                 .statusCode(HttpStatus.OK.value())
                 .extract()
                 .body()
-                .as(new TypeRef<List<ProjectStoryResponse>>() {});
+                .as(new TypeRef<List<ProjectStorySimpleResponse>>() {});
 
         assertThat(response.size()).isEqualTo(1);
         assertThat(response.get(0).getTitle()).isEqualTo(storyTitle);

--- a/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/presentation/ProjectControllerTest.java
@@ -244,10 +244,10 @@ class ProjectControllerTest extends ControllerTest {
                 .title("story title")
                 .preStories("[]")
                 .build();
-        List<ProjectStoryResponse> projectStoryResponses = List.of(new ProjectStoryResponse(story));
+        List<ProjectStorySimpleResponse> projectStorySimpleRespons = List.of(new ProjectStorySimpleResponse(story));
 
         given(projectService.getProjectStories(projectId))
-                .willReturn(projectStoryResponses);
+                .willReturn(projectStorySimpleRespons);
 
         // when
         ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/stories")
@@ -257,13 +257,13 @@ class ProjectControllerTest extends ControllerTest {
         // then
         MvcResult result = perform.andReturn();
         CollectionType collectionType = objectMapper.getTypeFactory()
-                .constructCollectionType(List.class, ProjectStoryResponse.class);
-        List<ProjectStoryResponse> projectStoryResponseList = objectMapper.readValue(result.getResponse().getContentAsString(), collectionType);
+                .constructCollectionType(List.class, ProjectStorySimpleResponse.class);
+        List<ProjectStorySimpleResponse> projectStorySimpleResponseList = objectMapper.readValue(result.getResponse().getContentAsString(), collectionType);
 
         perform
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].title").value(story.getTitle()));
-        assertThat(projectStoryResponseList.size()).isEqualTo(1);
+        assertThat(projectStorySimpleResponseList.size()).isEqualTo(1);
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/project/project/service/ProjectServiceTest.java
@@ -11,11 +11,9 @@ import kr.kro.colla.project.project.domain.profile.ProjectProfileStorage;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.project.project.presentation.dto.*;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
-import kr.kro.colla.project.task_status.service.TaskStatusService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.tag.service.TagService;
-import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
 import kr.kro.colla.user.notice.service.NoticeService;
@@ -174,10 +172,10 @@ class ProjectServiceTest {
                 .willReturn(Optional.of(project));
 
         // when
-        List<ProjectStoryResponse> result = projectService.getProjectStories(id);
+        List<ProjectStorySimpleResponse> result = projectService.getProjectStories(id);
 
         // then
-        ProjectStoryResponse response = result.get(0);
+        ProjectStorySimpleResponse response = result.get(0);
         assertThat(result.size()).isEqualTo(1);
         assertThat(response.getTitle()).isEqualTo(story.getTitle());
         verify(projectRepository, times(1)).findById(1L);

--- a/backend/src/test/java/kr/kro/colla/story/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/AcceptanceTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 @ActiveProfiles("test")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -84,6 +86,81 @@ public class AcceptanceTest {
         assertThat(response).hasSize(2);
         assertThat(response.get(0).getTitle()).isEqualTo(story1.getTitle());
         assertThat(response.get(1).getTitle()).isEqualTo(story2.getTitle());
+    }
+
+    @Test
+    void 사용자가_스토리의_진행_기간을_설정한다() {
+        // given
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        story.를_생성한다(createdProject.getId(), accessToken, "first story");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+                .formParam("startAt", "2022-03-09")
+                .formParam("endAt", "2022-03-12")
+
+        // when
+        .when()
+                .patch("/api/projects/stories/" + 1L + "/period")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 사용자가_스토리의_진행_기간을_설정한_뒤_조회한다() {
+        // given
+        String startAt = "2022-03-09", endAt = "2022-03-12";
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        story.를_생성한다(createdProject.getId(), accessToken, "first story");
+        story.의_진행_기간을_설정한다(1L, accessToken, startAt, endAt);
+
+        List<ProjectStoryResponse> response = given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("api/projects/" + createdProject.getId() + "/all-stories")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<ProjectStoryResponse>>() {});
+
+        assertThat(response.get(0).getStartAt()).isEqualTo(startAt);
+        assertThat(response.get(0).getEndAt()).isEqualTo(endAt);
+    }
+
+    @Test
+    void 사용자가_스토리_진행_기간_설정_시_아무것도_입력하지_않으면_설정에_실패한다() {
+        // given
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        story.를_생성한다(createdProject.getId(), accessToken, "first story");
+
+        given()
+                .contentType(ContentType.URLENC)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .patch("/api/projects/stories/" + 1L + "/period")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
+                .body("message", containsString("널이어서는 안됩니다"));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/story/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/AcceptanceTest.java
@@ -1,0 +1,89 @@
+package kr.kro.colla.story;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.common.database.DatabaseCleaner;
+import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.StoryProvider;
+import kr.kro.colla.common.fixture.UserProvider;
+import kr.kro.colla.project.project.presentation.dto.ProjectStorySimpleResponse;
+import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserProvider user;
+
+    @Autowired
+    private ProjectProvider project;
+
+    @Autowired
+    private StoryProvider story;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    private Auth auth;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        auth = new Auth(jwtProvider);
+        databaseCleaner.execute();
+    }
+
+    @Test
+    void 사용자가_프로젝트에_속한_모든_스토리를_조회한다() {
+        // given
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        ProjectStorySimpleResponse story1 = story.를_생성한다(createdProject.getId(), accessToken, "first story");
+        ProjectStorySimpleResponse story2 = story.를_생성한다(createdProject.getId(), accessToken, "second story");
+
+        List<ProjectStoryResponse> response = given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + createdProject.getId() + "/all-stories")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<ProjectStoryResponse>>() {});
+
+        assertThat(response).hasSize(2);
+        assertThat(response.get(0).getTitle()).isEqualTo(story1.getTitle());
+        assertThat(response.get(1).getTitle()).isEqualTo(story2.getTitle());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/story/domain/repository/StoryRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/domain/repository/StoryRepositoryTest.java
@@ -1,11 +1,17 @@
 package kr.kro.colla.story.domain.repository;
 
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.StoryProvider;
 import kr.kro.colla.exception.exception.story.StoryNotFoundException;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import kr.kro.colla.story.domain.Story;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,6 +21,9 @@ class StoryRepositoryTest {
 
     @Autowired
     private StoryRepository storyRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
 
     @Test
     void 스토리를_제목으로_조회한다() {
@@ -31,6 +40,23 @@ class StoryRepositoryTest {
 
         // then
         assertThat(result.getTitle()).isEqualTo(title);
+    }
+
+    @Test
+    void 프로젝트에_속한_모든_스토리를_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        Story story1 = StoryProvider.createStory(project, "first story");
+        Story story2 = StoryProvider.createStory(project, "second story");
+        storyRepository.saveAll(List.of(story1, story2));
+
+        // when
+        List<Story> storyList = storyRepository.findProjectStories(project);
+
+        // then
+        assertThat(storyList).hasSize(2);
+        assertThat(storyList.get(0).getTitle()).isEqualTo(story1.getTitle());
+        assertThat(storyList.get(1).getTitle()).isEqualTo(story2.getTitle());
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/story/presentation/StoryControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/presentation/StoryControllerTest.java
@@ -5,18 +5,22 @@ import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.common.fixture.StoryProvider;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.story.presentation.dto.UpdateStoryPeriodRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 import java.util.List;
 
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.contains;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -50,6 +54,39 @@ class StoryControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.length()").value(storyList.size()))
                 .andExpect(jsonPath("$[*].title", contains(storyList.get(0).getTitle(), storyList.get(1).getTitle())));
         verify(storyService, times(1)).getProjectStories(anyLong());
+    }
+
+    @Test
+    void 스토리의_진행_기간을_설정한다() throws Exception {
+        // given
+        willDoNothing()
+                .given(storyService)
+                .updateStoryPeriod(anyLong(), any(UpdateStoryPeriodRequest.class));
+
+        // when
+        ResultActions perform = mockMvc.perform(patch("/projects/stories/" + 1L + "/period")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("startAt", "2022-03-09")
+                .param("endAt", "2022-03-12"));
+
+        // then
+        perform.andExpect(status().isOk());
+        verify(storyService, times(1)).updateStoryPeriod(anyLong(), any(UpdateStoryPeriodRequest.class));
+    }
+
+    @Test
+    void 스토리의_진행_기간이_비어있다면_설정에_실패한다() throws Exception {
+        // when
+        ResultActions perform = mockMvc.perform(patch("/projects/stories/" + 1L + "/period")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message").value(anyOf(is("startAt : must not be null"), is("endAt : must not be null"))));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/story/presentation/StoryControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/presentation/StoryControllerTest.java
@@ -1,0 +1,55 @@
+package kr.kro.colla.story.presentation;
+
+import kr.kro.colla.common.ControllerTest;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.StoryProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.Cookie;
+import java.util.List;
+
+import static org.hamcrest.Matchers.contains;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StoryController.class)
+class StoryControllerTest extends ControllerTest {
+
+    @Test
+    void 프로젝트의_모든_스토리를_조회한다() throws Exception {
+        // given
+        Long projectId = 5L;
+        Project project = ProjectProvider.createProject(1L);
+        List<ProjectStoryResponse> storyList = List.of(
+                new ProjectStoryResponse(StoryProvider.createStory(project, "first story")),
+                new ProjectStoryResponse(StoryProvider.createStory(project, "second story"))
+        );
+
+        given(storyService.getProjectStories(eq(projectId)))
+                .willReturn(storyList);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/all-stories")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(storyList.size()))
+                .andExpect(jsonPath("$[*].title", contains(storyList.get(0).getTitle(), storyList.get(1).getTitle())));
+        verify(storyService, times(1)).getProjectStories(anyLong());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
@@ -1,11 +1,14 @@
 package kr.kro.colla.story.service;
 
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.StoryProvider;
 import kr.kro.colla.exception.exception.story.StoryNotFoundException;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.presentation.dto.CreateStoryRequest;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.domain.repository.StoryRepository;
+import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,11 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -96,6 +100,32 @@ class StoryServiceTest {
         // when, then
         assertThatThrownBy(() -> storyService.findStoryByTitle(title))
                 .isInstanceOf(StoryNotFoundException.class);
+    }
+
+    @Test
+    void 프로젝트에_속한_스토리를_모두_조회한다() {
+        // given
+        Long projectId = 5L;
+        Project project = ProjectProvider.createProject(1L);
+        List<Story> storyList = List.of(
+                StoryProvider.createStory(project, "first story"),
+                StoryProvider.createStory(project, "second story")
+        );
+
+        given(projectService.findProjectById(eq(projectId)))
+                .willReturn(project);
+        given(storyRepository.findProjectStories(any(Project.class)))
+                .willReturn(storyList);
+
+        // when
+        List<ProjectStoryResponse> result = storyService.getProjectStories(projectId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getTitle()).isEqualTo(storyList.get(0).getTitle());
+        assertThat(result.get(1).getTitle()).isEqualTo(storyList.get(1).getTitle());
+        verify(projectService, times(1)).findProjectById(anyLong());
+        verify(storyRepository, times(1)).findProjectStories(any(Project.class));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/story/service/StoryServiceTest.java
@@ -9,6 +9,7 @@ import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.domain.Story;
 import kr.kro.colla.story.domain.repository.StoryRepository;
 import kr.kro.colla.story.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.story.presentation.dto.UpdateStoryPeriodRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -16,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -126,6 +128,26 @@ class StoryServiceTest {
         assertThat(result.get(1).getTitle()).isEqualTo(storyList.get(1).getTitle());
         verify(projectService, times(1)).findProjectById(anyLong());
         verify(storyRepository, times(1)).findProjectStories(any(Project.class));
+    }
+
+    @Test
+    void 스토리의_진행_기간을_설정한다() {
+        // given
+        Long storyId = 1L;
+        Project project = ProjectProvider.createProject(5L);
+        Story story = StoryProvider.createStory(project, "story title");
+        UpdateStoryPeriodRequest updateStoryPeriodRequest = new UpdateStoryPeriodRequest(LocalDate.of(2022, 3, 9), LocalDate.of(2022, 3, 12));
+
+        given(storyRepository.findById(eq(storyId)))
+                .willReturn(Optional.of(story));
+
+        // when
+        storyService.updateStoryPeriod(storyId, updateStoryPeriodRequest);
+
+        // then
+        assertThat(story.getStartAt()).isEqualTo(updateStoryPeriodRequest.getStartAt());
+        assertThat(story.getEndAt()).isEqualTo(updateStoryPeriodRequest.getEndAt());
+        verify(storyRepository, times(1)).findById(anyLong());
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -6,7 +6,7 @@ import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
-import kr.kro.colla.project.project.presentation.dto.ProjectStoryResponse;
+import kr.kro.colla.project.project.presentation.dto.ProjectStorySimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.ProjectStoryTaskResponse;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskSimpleResponse;
 import kr.kro.colla.task.task.presentation.dto.ProjectTaskRequest;
@@ -135,7 +135,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
+        ProjectStorySimpleResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
         Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle());
 
         given()
@@ -187,7 +187,7 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
+        ProjectStorySimpleResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "story title");
         task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), createdStory.getTitle());
 
         Map<String, String> formData = new HashMap<>();
@@ -222,7 +222,7 @@ public class AcceptanceTest {
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
         Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), null);
 
-        ProjectStoryResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
+        ProjectStorySimpleResponse createdStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
         createdTask.put("story", createdStory.getTitle());
 
         given()
@@ -246,10 +246,10 @@ public class AcceptanceTest {
         User registeredUser = user.가_로그인을_한다1();
         String accessToken = auth.토큰을_발급한다(registeredUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        ProjectStoryResponse oldStory = story.를_생성한다(createdProject.getId(), accessToken, "old story");
+        ProjectStorySimpleResponse oldStory = story.를_생성한다(createdProject.getId(), accessToken, "old story");
         Map<String, String> createdTask = task.를_생성한다(accessToken, registeredUser.getId(), createdProject.getId(), oldStory.getTitle());
 
-        ProjectStoryResponse newStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
+        ProjectStorySimpleResponse newStory = story.를_생성한다(createdProject.getId(), accessToken, "new story");
         createdTask.put("story", newStory.getTitle());
 
         given()
@@ -579,8 +579,8 @@ public class AcceptanceTest {
         String accessToken = auth.토큰을_발급한다(member.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
 
-        ProjectStoryResponse story1 = story.를_생성한다(createdProject.getId(), accessToken, "user can login with github");
-        ProjectStoryResponse story2 = story.를_생성한다(createdProject.getId(), accessToken, "set up CI/CD");
+        ProjectStorySimpleResponse story1 = story.를_생성한다(createdProject.getId(), accessToken, "user can login with github");
+        ProjectStorySimpleResponse story2 = story.를_생성한다(createdProject.getId(), accessToken, "set up CI/CD");
 
         task.를_생성한다(accessToken, member.getId(), createdProject.getId(), story1.getTitle());
         task.를_생성한다(accessToken, member.getId(), createdProject.getId(), null);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Kanban from './pages/Kanban';
 import Login from './pages/Login';
 import LoginProcessing from './pages/LoginProcessing';
 import NotFound from './pages/NotFound';
+import { Roadmap } from './pages/Roadmap';
 import GlobalStyle from './styles/global';
 
 const App = () => (
@@ -23,9 +24,10 @@ const App = () => (
                 <Switch>
                     <Route exact path="/" component={Login} />
                     <Route exact path="/login" component={LoginProcessing} />
-                    <ValidationRoute exact path="/kanban" component={Kanban} />
-                    <ValidationRoute exact path={'/backlog'} component={Backlog} />
                     <ValidationRoute exact path="/home" component={Home} />
+                    <ValidationRoute exact path="/kanban" component={Kanban} />
+                    <ValidationRoute exact path="/backlog" component={Backlog} />
+                    <ValidationRoute exact path="/roadmap" component={Roadmap} />
                     <Route component={NotFound} />
                 </Switch>
             </Router>

--- a/frontend/src/apis/story.ts
+++ b/frontend/src/apis/story.ts
@@ -1,0 +1,9 @@
+import { client } from './common';
+
+export const updateStoryPeriod = async (storyId: number, data: FormData) => {
+    const response = await client.patch(`/projects/stories/${storyId}/period`, data, {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+
+    return response;
+};

--- a/frontend/src/apis/story.ts
+++ b/frontend/src/apis/story.ts
@@ -1,4 +1,11 @@
+import { StoryType } from '../types/roadmap';
 import { client } from './common';
+
+export const getProjectStories = async (projectId: number) => {
+    const response = await client.get<Array<StoryType>>(`/projects/${projectId}/all-stories`);
+
+    return response;
+};
 
 export const updateStoryPeriod = async (storyId: number, data: FormData) => {
     const response = await client.patch(`/projects/stories/${storyId}/period`, data, {

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -1,3 +1,4 @@
+import { TaskType } from '../types/roadmap';
 import { SimpleTaskType, StoryTaskType, TaskResponseType } from '../types/task';
 import { client } from './common';
 
@@ -25,6 +26,12 @@ export const updateTask = async (taskId: number, data: FormData) => {
 
 export const updateTaskStatus = async (taskId: number, statusName: string) => {
     const response = await client.patch(`/projects/tasks/${taskId}`, { statusName });
+
+    return response;
+};
+
+export const getStoryTasks = async (projectId: number, storyId: number) => {
+    const response = await client.get<Array<TaskType>>(`/projects/${projectId}/stories/${storyId}/tasks`);
 
     return response;
 };

--- a/frontend/src/components/List/IssueList/index.tsx
+++ b/frontend/src/components/List/IssueList/index.tsx
@@ -5,11 +5,20 @@ import { TaskList } from '../TaskList';
 import { Container } from './style';
 
 export const IssueList = () => {
-    const [showStory, setShowStory] = useState(true);
+    const [story, setStory] = useState<number>(-1);
+    const [showStory, setShowStory] = useState<boolean>(true);
 
     const handleStoryVisible = () => {
         setShowStory((prev) => !prev);
     };
 
-    return <Container>{showStory ? <StoryList /> : <TaskList showStory={handleStoryVisible} />}</Container>;
+    return (
+        <Container>
+            {showStory ? (
+                <StoryList handleStoryVisible={handleStoryVisible} setStory={setStory} />
+            ) : (
+                <TaskList handleStoryVisible={handleStoryVisible} story={story} />
+            )}
+        </Container>
+    );
 };

--- a/frontend/src/components/List/IssueList/index.tsx
+++ b/frontend/src/components/List/IssueList/index.tsx
@@ -1,0 +1,15 @@
+import React, { useState } from 'react';
+
+import { StoryList } from '../StoryList';
+import { TaskList } from '../TaskList';
+import { Container } from './style';
+
+export const IssueList = () => {
+    const [showStory, setShowStory] = useState(true);
+
+    const handleStoryVisible = () => {
+        setShowStory((prev) => !prev);
+    };
+
+    return <Container>{showStory ? <StoryList /> : <TaskList showStory={handleStoryVisible} />}</Container>;
+};

--- a/frontend/src/components/List/IssueList/style.ts
+++ b/frontend/src/components/List/IssueList/style.ts
@@ -8,6 +8,7 @@ export const Container = styled.div`
     margin-left: auto;
     background-color: ${GREEN};
     overflow-y: scroll;
+    padding-bottom: 10px;
 
     &::-webkit-scrollbar {
         width: 8px;

--- a/frontend/src/components/List/IssueList/style.ts
+++ b/frontend/src/components/List/IssueList/style.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+import { GREEN } from '../../../styles/color';
+
+export const Container = styled.div`
+    width: 300px;
+    height: 600px;
+    border-radius: 20px;
+    margin-left: auto;
+    background-color: ${GREEN};
+    overflow-y: scroll;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #bbbbbb;
+        border-radius: 10px;
+    }
+`;
+
+export const Title = styled.div`
+    font-size: 20px;
+    margin: 30px 0 0 30px;
+`;
+
+export const Story = styled.div``;

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,29 +1,11 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
+import { getProjectStories } from '../../../apis/story';
+import { StateType } from '../../../types/project';
 import { StoryType } from '../../../types/roadmap';
 import { StoryPeriod } from '../../Modal/StoryPeriod';
 import { Issue, List, IssueContents, Title, IssueDetail } from './style';
-
-const dummy: Array<StoryType> = [
-    {
-        id: 1,
-        title: 'user can',
-        startAt: '2022-03-08',
-        endAt: '2022-03-09',
-    },
-    {
-        id: 2,
-        title: 'user can login with github',
-        startAt: null,
-        endAt: null,
-    },
-    {
-        id: 3,
-        title: 'user can login with githubuser can login with github user can login with github',
-        startAt: '2022-03-08',
-        endAt: '2022-03-09',
-    },
-];
 
 interface PropType {
     handleStoryVisible: Function;
@@ -31,6 +13,8 @@ interface PropType {
 }
 
 export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
+    const { state } = useLocation<StateType>();
+    const [storyList, setStoryList] = useState<Array<StoryType>>([]);
     const [selectedStory, setSelectedStory] = useState<StoryType | null>(null);
     const [storyPeriod, setStoryPeriod] = useState<boolean>(false);
 
@@ -44,11 +28,18 @@ export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
         setSelectedStory(story);
     };
 
+    useEffect(() => {
+        (async () => {
+            const res = await getProjectStories(state.projectId);
+            setStoryList(res.data);
+        })();
+    }, []);
+
     return (
         <>
             <Title>스토리 목록</Title>
             <List>
-                {dummy.map((story: StoryType, idx) => {
+                {storyList.map((story: StoryType, idx) => {
                     const { id, title, startAt, endAt } = story;
 
                     return (

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { Title } from './style';
+
+export const StoryList = () => <Title>스토리 목록</Title>;

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { List, Story, StoryContents, Title } from './style';
+import { Issue, List, IssueContents, Title } from './style';
 
 interface StoryType {
     id: number;
@@ -42,18 +42,18 @@ export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
     };
 
     return (
-        <div>
+        <>
             <Title>스토리 목록</Title>
             <List>
                 {dummy.map(({ id, title, startAt, endAt }, idx) => (
-                    <Story key={idx} onClick={() => handleStoryClick(id)}>
-                        <StoryContents>{title}</StoryContents>
-                        <StoryContents>
+                    <Issue key={idx} onClick={() => handleStoryClick(id)}>
+                        <IssueContents>{title}</IssueContents>
+                        <IssueContents>
                             {startAt} ~ {endAt}
-                        </StoryContents>
-                    </Story>
+                        </IssueContents>
+                    </Issue>
                 ))}
             </List>
-        </div>
+        </>
     );
 };

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,5 +1,59 @@
-import React from 'react';
+import React, { FC } from 'react';
 
-import { Title } from './style';
+import { List, Story, StoryContents, Title } from './style';
 
-export const StoryList = () => <Title>스토리 목록</Title>;
+interface StoryType {
+    id: number;
+    title: string;
+    startAt: string;
+    endAt: string;
+}
+
+const dummy: Array<StoryType> = [
+    {
+        id: 1,
+        title: 'user can',
+        startAt: '2022-03-08',
+        endAt: '2022-03-09',
+    },
+    {
+        id: 2,
+        title: 'user can login with github',
+        startAt: '2022-03-08',
+        endAt: '2022-03-09',
+    },
+    {
+        id: 3,
+        title: 'user can login with githubuser can login with github user can login with github',
+        startAt: '2022-03-08',
+        endAt: '2022-03-09',
+    },
+];
+
+interface PropType {
+    handleStoryVisible: Function;
+    setStory: Function;
+}
+
+export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
+    const handleStoryClick = (id: number) => {
+        handleStoryVisible();
+        setStory(id);
+    };
+
+    return (
+        <div>
+            <Title>스토리 목록</Title>
+            <List>
+                {dummy.map(({ id, title, startAt, endAt }, idx) => (
+                    <Story key={idx} onClick={() => handleStoryClick(id)}>
+                        <StoryContents>{title}</StoryContents>
+                        <StoryContents>
+                            {startAt} ~ {endAt}
+                        </StoryContents>
+                    </Story>
+                ))}
+            </List>
+        </div>
+    );
+};

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,12 +1,13 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 
-import { Issue, List, IssueContents, Title } from './style';
+import { StoryPeriod } from '../../Modal/StoryPeriod';
+import { Issue, List, IssueContents, Title, IssueDetail } from './style';
 
 interface StoryType {
     id: number;
     title: string;
-    startAt: string;
-    endAt: string;
+    startAt: string | null;
+    endAt: string | null;
 }
 
 const dummy: Array<StoryType> = [
@@ -19,8 +20,8 @@ const dummy: Array<StoryType> = [
     {
         id: 2,
         title: 'user can login with github',
-        startAt: '2022-03-08',
-        endAt: '2022-03-09',
+        startAt: null,
+        endAt: null,
     },
     {
         id: 3,
@@ -36,9 +37,15 @@ interface PropType {
 }
 
 export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
+    const [storyPeriod, setStoryPeriod] = useState<boolean>(false);
+
     const handleStoryClick = (id: number) => {
         handleStoryVisible();
         setStory(id);
+    };
+
+    const showStoryPeriodModal = () => {
+        setStoryPeriod((prev) => !prev);
     };
 
     return (
@@ -46,14 +53,17 @@ export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
             <Title>스토리 목록</Title>
             <List>
                 {dummy.map(({ id, title, startAt, endAt }, idx) => (
-                    <Issue key={idx} onClick={() => handleStoryClick(id)}>
+                    <Issue key={idx}>
                         <IssueContents>{title}</IssueContents>
-                        <IssueContents>
-                            {startAt} ~ {endAt}
-                        </IssueContents>
+                        <IssueContents>{startAt ? `${startAt} ~ ${endAt}` : ''}</IssueContents>
+                        <IssueDetail>
+                            <div onClick={showStoryPeriodModal}>기간 설정하기</div>
+                            <div onClick={() => handleStoryClick(id)}>태스크 확인하기</div>
+                        </IssueDetail>
                     </Issue>
                 ))}
             </List>
+            {storyPeriod ? <StoryPeriod showStoryPeriodModal={showStoryPeriodModal} /> : null}
         </>
     );
 };

--- a/frontend/src/components/List/StoryList/index.tsx
+++ b/frontend/src/components/List/StoryList/index.tsx
@@ -1,14 +1,8 @@
 import React, { FC, useState } from 'react';
 
+import { StoryType } from '../../../types/roadmap';
 import { StoryPeriod } from '../../Modal/StoryPeriod';
 import { Issue, List, IssueContents, Title, IssueDetail } from './style';
-
-interface StoryType {
-    id: number;
-    title: string;
-    startAt: string | null;
-    endAt: string | null;
-}
 
 const dummy: Array<StoryType> = [
     {
@@ -37,6 +31,7 @@ interface PropType {
 }
 
 export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
+    const [selectedStory, setSelectedStory] = useState<StoryType | null>(null);
     const [storyPeriod, setStoryPeriod] = useState<boolean>(false);
 
     const handleStoryClick = (id: number) => {
@@ -44,26 +39,31 @@ export const StoryList: FC<PropType> = ({ handleStoryVisible, setStory }) => {
         setStory(id);
     };
 
-    const showStoryPeriodModal = () => {
+    const showStoryPeriodModal = (story: StoryType) => {
         setStoryPeriod((prev) => !prev);
+        setSelectedStory(story);
     };
 
     return (
         <>
             <Title>스토리 목록</Title>
             <List>
-                {dummy.map(({ id, title, startAt, endAt }, idx) => (
-                    <Issue key={idx}>
-                        <IssueContents>{title}</IssueContents>
-                        <IssueContents>{startAt ? `${startAt} ~ ${endAt}` : ''}</IssueContents>
-                        <IssueDetail>
-                            <div onClick={showStoryPeriodModal}>기간 설정하기</div>
-                            <div onClick={() => handleStoryClick(id)}>태스크 확인하기</div>
-                        </IssueDetail>
-                    </Issue>
-                ))}
+                {dummy.map((story: StoryType, idx) => {
+                    const { id, title, startAt, endAt } = story;
+
+                    return (
+                        <Issue key={idx}>
+                            <IssueContents>{title}</IssueContents>
+                            <IssueContents>{startAt ? `${startAt} ~ ${endAt}` : ''}</IssueContents>
+                            <IssueDetail>
+                                <div onClick={() => showStoryPeriodModal(story)}>기간 설정하기</div>
+                                <div onClick={() => handleStoryClick(id)}>태스크 확인하기</div>
+                            </IssueDetail>
+                        </Issue>
+                    );
+                })}
             </List>
-            {storyPeriod ? <StoryPeriod showStoryPeriodModal={showStoryPeriodModal} /> : null}
+            {storyPeriod ? <StoryPeriod story={selectedStory} showStoryPeriodModal={showStoryPeriodModal} /> : null}
         </>
     );
 };

--- a/frontend/src/components/List/StoryList/style.ts
+++ b/frontend/src/components/List/StoryList/style.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const Title = styled.div`
+    font-size: 20px;
+    margin: 30px 0 0 30px;
+
+    &:hover {
+        cursor: pointer;
+        text-decoration: 3px solid #000 underline;
+    }
+`;

--- a/frontend/src/components/List/StoryList/style.ts
+++ b/frontend/src/components/List/StoryList/style.ts
@@ -19,7 +19,7 @@ export const List = styled.div`
     ${Column}
 `;
 
-export const Story = styled.div`
+export const Issue = styled.div`
     justify-content: space-around;
     width: 250px;
     min-height: 70px;
@@ -32,6 +32,6 @@ export const Story = styled.div`
     ${LiftUp}
 `;
 
-export const StoryContents = styled.div`
-    padding: 10px;
+export const IssueContents = styled.div`
+    padding: 10px 10px 10px 20px;
 `;

--- a/frontend/src/components/List/StoryList/style.ts
+++ b/frontend/src/components/List/StoryList/style.ts
@@ -1,4 +1,6 @@
 import styled from '@emotion/styled';
+import { LIGHT_GRAY } from '../../../styles/color';
+import { Column, LiftUp } from '../../../styles/common';
 
 export const Title = styled.div`
     font-size: 20px;
@@ -8,4 +10,28 @@ export const Title = styled.div`
         cursor: pointer;
         text-decoration: 3px solid #000 underline;
     }
+`;
+
+export const List = styled.div`
+    align-items: center;
+    justify-content: center;
+
+    ${Column}
+`;
+
+export const Story = styled.div`
+    justify-content: space-around;
+    width: 250px;
+    min-height: 70px;
+    border-radius: 20px;
+    margin: 20px 0 0 0;
+    background-color: ${LIGHT_GRAY};
+    cursor: pointer;
+
+    ${Column}
+    ${LiftUp}
+`;
+
+export const StoryContents = styled.div`
+    padding: 10px;
 `;

--- a/frontend/src/components/List/StoryList/style.ts
+++ b/frontend/src/components/List/StoryList/style.ts
@@ -35,3 +35,14 @@ export const Issue = styled.div`
 export const IssueContents = styled.div`
     padding: 10px 10px 10px 20px;
 `;
+
+export const IssueDetail = styled.div`
+    display: flex;
+    padding: 10px 10px 10px 20px;
+    justify-content: space-between;
+
+    div:hover {
+        cursor: pointer;
+        text-decoration: 3px solid #000 underline;
+    }
+`;

--- a/frontend/src/components/List/TaskList/index.tsx
+++ b/frontend/src/components/List/TaskList/index.tsx
@@ -1,18 +1,58 @@
 import React, { FC, useEffect } from 'react';
 
-import { Title } from './style';
+import { Issue, IssueContents, List } from '../StoryList/style';
+import { Tag, Title } from './style';
 
 interface PropType {
     handleStoryVisible: Function;
     story: number;
 }
 
+const dummy = [
+    {
+        title: 'task1',
+        manager: 'yeongkee',
+        tags: ['backend', 'refactoring', 'bug fix'],
+        priority: 5,
+    },
+    {
+        title: 'task2',
+        manager: null,
+        tags: ['backend', 'refactoring', 'bug fix', 'frontend', 'document'],
+        priority: 3,
+    },
+    {
+        title: 'task3',
+        manager: 'yeongkee',
+        tags: [],
+        priority: 2,
+    },
+];
+
 export const TaskList: FC<PropType> = ({ handleStoryVisible, story }) => {
     useEffect(() => {
         (async () => {
             // TODO: story에 해당하는 태스크 목록 조회하기
+            console.log(story);
         })();
     }, []);
 
-    return <Title onClick={() => handleStoryVisible()}>스토리 목록 보기</Title>;
+    return (
+        <>
+            <Title onClick={() => handleStoryVisible()}>스토리 목록 보기</Title>
+            <List>
+                {dummy.map(({ title, manager, tags }, idx) => (
+                    <Issue key={idx}>
+                        <IssueContents>{title}</IssueContents>
+                        <IssueContents>{manager ? manager : '담당자 없음'}</IssueContents>
+                        <IssueContents>
+                            {tags.map((tag, idx) => (
+                                <Tag key={idx}>{tag}</Tag>
+                            ))}
+                        </IssueContents>
+                    </Issue>
+                ))}
+            </List>
+        </>
+    );
 };

--- a/frontend/src/components/List/TaskList/index.tsx
+++ b/frontend/src/components/List/TaskList/index.tsx
@@ -1,9 +1,18 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import { Title } from './style';
 
 interface PropType {
-    showStory: Function;
+    handleStoryVisible: Function;
+    story: number;
 }
 
-export const TaskList: FC<PropType> = ({ showStory }) => <Title onClick={() => showStory()}> 스토리 목록 보기</Title>;
+export const TaskList: FC<PropType> = ({ handleStoryVisible, story }) => {
+    useEffect(() => {
+        (async () => {
+            // TODO: story에 해당하는 태스크 목록 조회하기
+        })();
+    }, []);
+
+    return <Title onClick={() => handleStoryVisible()}>스토리 목록 보기</Title>;
+};

--- a/frontend/src/components/List/TaskList/index.tsx
+++ b/frontend/src/components/List/TaskList/index.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+
+import { Title } from './style';
+
+interface PropType {
+    showStory: Function;
+}
+
+export const TaskList: FC<PropType> = ({ showStory }) => <Title onClick={() => showStory()}> 스토리 목록 보기</Title>;

--- a/frontend/src/components/List/TaskList/index.tsx
+++ b/frontend/src/components/List/TaskList/index.tsx
@@ -1,5 +1,9 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
+import { getStoryTasks } from '../../../apis/task';
+import { StateType } from '../../../types/project';
+import { TaskType } from '../../../types/roadmap';
 import { Issue, IssueContents, List } from '../StoryList/style';
 import { Tag, Title } from './style';
 
@@ -8,32 +12,14 @@ interface PropType {
     story: number;
 }
 
-const dummy = [
-    {
-        title: 'task1',
-        manager: 'yeongkee',
-        tags: ['backend', 'refactoring', 'bug fix'],
-        priority: 5,
-    },
-    {
-        title: 'task2',
-        manager: null,
-        tags: ['backend', 'refactoring', 'bug fix', 'frontend', 'document'],
-        priority: 3,
-    },
-    {
-        title: 'task3',
-        manager: 'yeongkee',
-        tags: [],
-        priority: 2,
-    },
-];
-
 export const TaskList: FC<PropType> = ({ handleStoryVisible, story }) => {
+    const { state } = useLocation<StateType>();
+    const [taskList, setTaskList] = useState<Array<TaskType>>([]);
+
     useEffect(() => {
         (async () => {
-            // TODO: story에 해당하는 태스크 목록 조회하기
-            console.log(story);
+            const res = await getStoryTasks(state.projectId, story);
+            setTaskList(res.data);
         })();
     }, []);
 
@@ -41,7 +27,7 @@ export const TaskList: FC<PropType> = ({ handleStoryVisible, story }) => {
         <>
             <Title onClick={() => handleStoryVisible()}>스토리 목록 보기</Title>
             <List>
-                {dummy.map(({ title, manager, tags }, idx) => (
+                {taskList.map(({ title, manager, tags }, idx) => (
                     <Issue key={idx}>
                         <IssueContents>{title}</IssueContents>
                         <IssueContents>{manager ? manager : '담당자 없음'}</IssueContents>

--- a/frontend/src/components/List/TaskList/style.ts
+++ b/frontend/src/components/List/TaskList/style.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const Title = styled.div`
+    font-size: 20px;
+    margin: 30px 0 0 30px;
+
+    &:hover {
+        cursor: pointer;
+        text-decoration: 3px solid #000 underline;
+    }
+`;

--- a/frontend/src/components/List/TaskList/style.ts
+++ b/frontend/src/components/List/TaskList/style.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { GREEN } from '../../../styles/color';
 
 export const Title = styled.div`
     font-size: 20px;
@@ -8,4 +9,13 @@ export const Title = styled.div`
         cursor: pointer;
         text-decoration: 3px solid #000 underline;
     }
+`;
+
+export const Tag = styled.div`
+    display: inline-block;
+    margin: 3px 7px 5px 0;
+    padding: 0 5px;
+    border-radius: 5px;
+    cursor: pointer;
+    background: ${GREEN};
 `;

--- a/frontend/src/components/Modal/StoryPeriod/index.tsx
+++ b/frontend/src/components/Modal/StoryPeriod/index.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react';
+
+import { ButtonContainer, CancelButton, CompleteButton } from '../Task/style';
+import { Container, DatePicker, Period } from './style';
+
+interface PropType {
+    showStoryPeriodModal: Function;
+}
+
+export const StoryPeriod: FC<PropType> = ({ showStoryPeriodModal }) => (
+    <Container>
+        <Period>
+            <span>스토리 기간 등록</span>
+            <div>
+                <DatePicker type="date" />
+                <span>부터</span>
+                <DatePicker type="date" />
+                <span>까지</span>
+            </div>
+        </Period>
+        <ButtonContainer>
+            <CancelButton onClick={() => showStoryPeriodModal()}>취소</CancelButton>
+            <CompleteButton>완료</CompleteButton>
+        </ButtonContainer>
+    </Container>
+);

--- a/frontend/src/components/Modal/StoryPeriod/index.tsx
+++ b/frontend/src/components/Modal/StoryPeriod/index.tsx
@@ -11,8 +11,8 @@ interface PropType {
 }
 
 export const StoryPeriod: FC<PropType> = ({ story, showStoryPeriodModal }) => {
-    const [startAt, setStartAt] = useState<string>(story!.startAt ? story!.startAt : '');
-    const [endAt, setEndAt] = useState<string>(story!.endAt ? story!.endAt : '');
+    const [startAt, setStartAt] = useState<string | null>(story!.startAt ? story!.startAt : null);
+    const [endAt, setEndAt] = useState<string | null>(story!.endAt ? story!.endAt : null);
 
     const changeStartAt = (e: React.ChangeEvent) => {
         setStartAt((e.target as HTMLInputElement).value);
@@ -24,10 +24,11 @@ export const StoryPeriod: FC<PropType> = ({ story, showStoryPeriodModal }) => {
 
     const updatePeriod = async () => {
         const formData = new FormData();
-        formData.append('startAt', startAt);
-        formData.append('endAt', endAt);
+        formData.append('startAt', startAt!);
+        formData.append('endAt', endAt!);
 
         await updateStoryPeriod(story!.id, formData);
+        window.location.replace(`/roadmap`);
     };
 
     return (
@@ -35,9 +36,9 @@ export const StoryPeriod: FC<PropType> = ({ story, showStoryPeriodModal }) => {
             <Period>
                 <span>스토리 기간 등록</span>
                 <div>
-                    <DatePicker type="date" value={startAt} onChange={changeStartAt} />
+                    <DatePicker type="date" value={startAt ? startAt : ''} onChange={changeStartAt} />
                     <span>부터</span>
-                    <DatePicker type="date" value={endAt} onChange={changeEndAt} />
+                    <DatePicker type="date" value={endAt ? endAt : ''} onChange={changeEndAt} />
                     <span>까지</span>
                 </div>
             </Period>

--- a/frontend/src/components/Modal/StoryPeriod/index.tsx
+++ b/frontend/src/components/Modal/StoryPeriod/index.tsx
@@ -1,26 +1,50 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 
+import { updateStoryPeriod } from '../../../apis/story';
+import { StoryType } from '../../../types/roadmap';
 import { ButtonContainer, CancelButton, CompleteButton } from '../Task/style';
 import { Container, DatePicker, Period } from './style';
 
 interface PropType {
+    story: StoryType | null;
     showStoryPeriodModal: Function;
 }
 
-export const StoryPeriod: FC<PropType> = ({ showStoryPeriodModal }) => (
-    <Container>
-        <Period>
-            <span>스토리 기간 등록</span>
-            <div>
-                <DatePicker type="date" />
-                <span>부터</span>
-                <DatePicker type="date" />
-                <span>까지</span>
-            </div>
-        </Period>
-        <ButtonContainer>
-            <CancelButton onClick={() => showStoryPeriodModal()}>취소</CancelButton>
-            <CompleteButton>완료</CompleteButton>
-        </ButtonContainer>
-    </Container>
-);
+export const StoryPeriod: FC<PropType> = ({ story, showStoryPeriodModal }) => {
+    const [startAt, setStartAt] = useState<string>(story!.startAt ? story!.startAt : '');
+    const [endAt, setEndAt] = useState<string>(story!.endAt ? story!.endAt : '');
+
+    const changeStartAt = (e: React.ChangeEvent) => {
+        setStartAt((e.target as HTMLInputElement).value);
+    };
+
+    const changeEndAt = (e: React.ChangeEvent) => {
+        setEndAt((e.target as HTMLInputElement).value);
+    };
+
+    const updatePeriod = async () => {
+        const formData = new FormData();
+        formData.append('startAt', startAt);
+        formData.append('endAt', endAt);
+
+        await updateStoryPeriod(story!.id, formData);
+    };
+
+    return (
+        <Container>
+            <Period>
+                <span>스토리 기간 등록</span>
+                <div>
+                    <DatePicker type="date" value={startAt} onChange={changeStartAt} />
+                    <span>부터</span>
+                    <DatePicker type="date" value={endAt} onChange={changeEndAt} />
+                    <span>까지</span>
+                </div>
+            </Period>
+            <ButtonContainer>
+                <CancelButton onClick={() => showStoryPeriodModal()}>취소</CancelButton>
+                <CompleteButton onClick={updatePeriod}>완료</CompleteButton>
+            </ButtonContainer>
+        </Container>
+    );
+};

--- a/frontend/src/components/Modal/StoryPeriod/style.ts
+++ b/frontend/src/components/Modal/StoryPeriod/style.ts
@@ -33,4 +33,8 @@ export const DatePicker = styled.input`
     width: 140px;
     background-color: transparent;
     outline: none;
+
+    &::-webkit-calendar-picker-indicator {
+        margin: 0;
+    }
 `;

--- a/frontend/src/components/Modal/StoryPeriod/style.ts
+++ b/frontend/src/components/Modal/StoryPeriod/style.ts
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import { ModalContainer } from '../../../styles/modal';
+
+export const Container = styled.div`
+    width: 400px;
+    height: 180px;
+    margin: 130px 0 0 235px;
+    top: 200px;
+    left: 500px;
+
+    ${ModalContainer}
+`;
+
+export const Period = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 30px 0 0 30px;
+
+    span {
+        margin-right: 15px;
+    }
+
+    span:first-child {
+        font-size: 18px;
+    }
+
+    div {
+        margin: 30px 0 15px 0;
+    }
+`;
+
+export const DatePicker = styled.input`
+    width: 140px;
+    background-color: transparent;
+    outline: none;
+`;

--- a/frontend/src/pages/Roadmap/index.tsx
+++ b/frontend/src/pages/Roadmap/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import Header from '../../components/Header';
+import { IssueList } from '../../components/List/IssueList';
+import { SideBar } from '../../components/SideBar';
+import { Container, Wrapper } from './style';
+
+export const Roadmap = () => (
+    <>
+        <Header />
+        <SideBar />
+        <Container>
+            <Wrapper>
+                <IssueList />
+            </Wrapper>
+        </Container>
+    </>
+);

--- a/frontend/src/pages/Roadmap/style.ts
+++ b/frontend/src/pages/Roadmap/style.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { LIGHT_GRAY } from '../../styles/color';
+import { Column } from '../../styles/common';
+
+export const Container = styled.div`
+    align-items: center;
+
+    ${Column}
+`;
+
+export const Wrapper = styled.div`
+    width: 1300px;
+    height: 600px;
+    border-radius: 20px;
+    overflow-y: scroll;
+    background: ${LIGHT_GRAY};
+    margin-top: 50px;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: #bbbbbb;
+        border-radius: 10px;
+    }
+
+    ${Column}
+`;

--- a/frontend/src/types/roadmap.ts
+++ b/frontend/src/types/roadmap.ts
@@ -1,0 +1,6 @@
+export interface StoryType {
+    id: number;
+    title: string;
+    startAt: string | null;
+    endAt: string | null;
+}

--- a/frontend/src/types/roadmap.ts
+++ b/frontend/src/types/roadmap.ts
@@ -4,3 +4,9 @@ export interface StoryType {
     startAt: string | null;
     endAt: string | null;
 }
+
+export interface TaskType {
+    title: string;
+    manager: string;
+    tags: Array<string>;
+}


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 스토리 목록
- 테스크 목록
- 스토리 기간 설정 모달
- 프로젝트에 속한 스토리 조회 API/테스트 코드
- 스토리 기간 지정 API/테스트 코드
- 스토리에 속한 태스크 조회 API/테스트 코드

### 📑 구현한 내용 목록
- [x] 스토리 목록
- [x] 테스크 목록
- [x] 스토리 기간 설정 모달
- [x] 프로젝트에 속한 스토리 조회 API/테스트 코드
- [x] 스토리 기간 지정 API/테스트 코드
- [x] 스토리에 속한 태스크 조회 API/테스트 코드

### 🚧 논의 사항
- 로드맵 페이지 스토리/테스크 목록 UI, API 구현하고 연동해두었습니다~
- 일부 테스트 코드에서 `assertThat()` 구문이 잘못 쓰여지고 있는 것 같습니다! 아래와 같은 테스트 코드를 발견한다면 수정 부탁드립니다~~!
```java
assertThat(managers.contains(task.getManagerId()));            // 수정 전
assertThat(managers).contains(task.getManagerId());            // 수정 후

assertThat(task.getProject().getId().equals(project.getId()));   // 수정 전
assertThat(task.getProject().getId()).isEqualTo(project.getId());  // 수정 후

assertThat(result.get(idx).getCreatedAt().isAfter(result.get(idx + 1).getCreatedAt())));  // 수정 전
assertThat(result.get(idx).getCreatedAt()).isAfter(result.get(idx + 1).getCreatedAt())); // 수정 후
```

- close #112 
