### PR TITLE
[#116] feat: 지도 API 연동 및 마커/info window 구현

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -47,6 +47,7 @@
     "no-unused-expressions": "off",
     "no-unneeded-ternary": "off",
     "dot-notation": "off",
+    "no-new": "off",
     "no-use-before-define": ["error", { "variables": false }],
     "import/prefer-default-export": "off",
     "@typescript-eslint/no-unused-vars": ["error"],

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+    <script type="text/javascript" src="<%=htmlWebpackPlugin.options.apiUrl%>"></script>
 </head>
 <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Home from './pages/Home';
 import Kanban from './pages/Kanban';
 import Login from './pages/Login';
 import LoginProcessing from './pages/LoginProcessing';
+import MeetingPlace from './pages/MeetingPlace';
 import NotFound from './pages/NotFound';
 import Roadmap from './pages/Roadmap';
 import GlobalStyle from './styles/global';
@@ -28,6 +29,7 @@ const App = () => (
                     <ValidationRoute exact path="/kanban" component={Kanban} />
                     <ValidationRoute exact path="/backlog" component={Backlog} />
                     <ValidationRoute exact path="/roadmap" component={Roadmap} />
+                    <ValidationRoute exact path="/meeting-place" component={MeetingPlace} />
                     <Route component={NotFound} />
                 </Switch>
             </Router>

--- a/frontend/src/components/Map/InfoWindow/index.ts
+++ b/frontend/src/components/Map/InfoWindow/index.ts
@@ -1,0 +1,9 @@
+import EmptyImg from '../../../../public/assets/images/empty.png';
+import { MeetingPlaceType } from '../../../types/meeting-place';
+import './style.scss';
+
+export const InfoWindow = (meetingPlace: MeetingPlaceType) => `<div class='Container'>
+                <img class='meeting-place-img' src=${EmptyImg}>
+                <div class='meeting-place-info'>${meetingPlace.name}</div>
+                <div class='meeting-place-info'>${meetingPlace.address}</div>
+            </div>`;

--- a/frontend/src/components/Map/InfoWindow/style.scss
+++ b/frontend/src/components/Map/InfoWindow/style.scss
@@ -1,0 +1,22 @@
+div.Container {
+    display: flex;
+    flex-direction: column;
+    width: 200px;
+    height: 260px;
+    border: 1px solid #bdbdbd;
+    border-radius: 10px;
+
+    div {
+        margin-left: 10px;
+    }
+}
+
+img.meeting-place-img {
+    width: 200px;
+    height: 180px;
+    margin-bottom: 10px;
+}
+
+div.meeting-place-info {
+    padding: 0 5px 5px 5px;
+}

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+
+import { MapContainer } from './style';
+
+export const Map = () => {
+    useEffect(() => {
+        const mapOptions = {
+            center: new naver.maps.LatLng(37.511337, 127.012084),
+            zoom: 13,
+            zoomControl: true,
+            zoomControlOptions: {
+                style: naver.maps.ZoomControlStyle.SMALL,
+                position: naver.maps.Position.TOP_RIGHT,
+            },
+        };
+        new naver.maps.Map('map', mapOptions);
+    }, []);
+
+    return (
+        <MapContainer>
+            <div id="map" />
+        </MapContainer>
+    );
+};

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,8 +1,72 @@
 import React, { useEffect } from 'react';
 
+import { MeetingPlaceType } from '../../types/meeting-place';
 import { MapContainer } from './style';
 
+const dummy: Array<MeetingPlaceType> = [
+    {
+        id: 1,
+        name: '컴포즈커피',
+        image: null,
+        longitude: 127.03187208216006,
+        latitude: 37.4918120829107,
+        address: '서울특별시 강남구 역삼동 강남대로66길 14',
+    },
+    {
+        id: 2,
+        name: '달커피',
+        image: null,
+        longitude: 127.03173245188478,
+        latitude: 37.49074981117741,
+        address: '서울특별시 강남구 역삼동 강남대로 308 1층',
+    },
+    {
+        id: 3,
+        name: '커피빈',
+        image: null,
+        longitude: 127.03229097297763,
+        latitude: 37.48765414782675,
+        address: '서울특별시 서초구 서초동 1361-9',
+    },
+];
+
 export const Map = () => {
+    let markers: Array<any> = [];
+    let infoWindows: Array<any> = [];
+
+    const handleMarkerClick = (map: any, marker: any) => {
+        const idx = markers.indexOf(marker);
+        handleClickOtherArea();
+        infoWindows[idx].open(map, marker);
+    };
+
+    const handleClickOtherArea = () => {
+        infoWindows.forEach((infoWindow) => infoWindow.close());
+    };
+
+    const markMeetingPlace = (map: any) => {
+        markers = dummy.map(({ latitude, longitude }) => {
+            const marker = new naver.maps.Marker({
+                position: new naver.maps.LatLng(latitude, longitude),
+                map,
+            });
+
+            naver.maps.Event.addListener(marker, 'click', () => handleMarkerClick(map, marker));
+            return marker;
+        });
+    };
+
+    const createInfoWindows = () => {
+        infoWindows = dummy.map(
+            (meetingPlace, idx) =>
+                new naver.maps.InfoWindow({
+                    position: markers[idx],
+                    content: `<div>장소정보</div>`,
+                    borderWidth: 0,
+                }),
+        );
+    };
+
     useEffect(() => {
         const mapOptions = {
             center: new naver.maps.LatLng(37.511337, 127.012084),
@@ -13,7 +77,11 @@ export const Map = () => {
                 position: naver.maps.Position.TOP_RIGHT,
             },
         };
-        new naver.maps.Map('map', mapOptions);
+
+        const map = new naver.maps.Map('map', mapOptions);
+        markMeetingPlace(map);
+        createInfoWindows();
+        naver.maps.Event.addListener(map, 'click', () => handleClickOtherArea());
     }, []);
 
     return (

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { MeetingPlaceType } from '../../types/meeting-place';
+import { InfoWindow } from './InfoWindow';
 import { MapContainer } from './style';
 
 const dummy: Array<MeetingPlaceType> = [
@@ -61,7 +62,7 @@ export const Map = () => {
             (meetingPlace, idx) =>
                 new naver.maps.InfoWindow({
                     position: markers[idx],
-                    content: `<div>장소정보</div>`,
+                    content: InfoWindow(meetingPlace),
                     borderWidth: 0,
                 }),
         );

--- a/frontend/src/components/Map/style.ts
+++ b/frontend/src/components/Map/style.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const MapContainer = styled.div`
+    display: flex;
+    width: 49%;
+    height: 70vh;
+
+    div#map {
+        width: 100%;
+        height: 100%;
+        border-radius: 40px;
+    }
+`;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -29,7 +29,7 @@ const MENU = [
     },
     { name: '백로그', path: '/backlog' },
     { name: '대시보드', path: '/dashboard' },
-    { name: '지도', path: '/map' },
+    { name: '모임장소', path: '/meeting-place' },
 ];
 
 export const SideBar = ({ props, project }: Props) => {

--- a/frontend/src/pages/MeetingPlace/index.tsx
+++ b/frontend/src/pages/MeetingPlace/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import Header from '../../components/Header';
+import { Map } from '../../components/Map';
+import { SideBar } from '../../components/SideBar';
+import { Container, Temp, Wrapper } from './style';
+
+const MeetingPlace = () => (
+    <>
+        <Header />
+        <SideBar />
+        <Container>
+            <Wrapper>
+                <Temp />
+                <Map />
+            </Wrapper>
+        </Container>
+    </>
+);
+
+export default MeetingPlace;

--- a/frontend/src/pages/MeetingPlace/style.ts
+++ b/frontend/src/pages/MeetingPlace/style.ts
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import { Column } from '../../styles/common';
+
+export const Container = styled.div`
+    align-items: center;
+    margin-top: 70px;
+    ${Column}
+`;
+
+export const Wrapper = styled.div`
+    display: flex;
+    width: 80vw;
+    height: 500px;
+    border-radius: 20px;
+    justify-content: space-between;
+`;
+
+export const Temp = styled.div`
+    width: 49%;
+    border: 2px solid black;
+`;

--- a/frontend/src/types/meeting-place.ts
+++ b/frontend/src/types/meeting-place.ts
@@ -1,0 +1,8 @@
+export interface MeetingPlaceType {
+    id: number;
+    name: string;
+    image: string;
+    latitude: number;
+    longitude: number;
+    address: string;
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -40,6 +40,7 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin({
             template: './public/index.html',
+            apiUrl: `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.CLIENT_ID}`,
         }),
         new EslintWebpackPlugin({
             extensions: ['js', 'jsx', 'ts', 'tsx'],


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 지도 API 연동
- 마커 구현
- info window 구현

### 📑 구현한 내용 목록
- [x] 지도 API 연동
- [x] 마커 구현
- [x] info window 구현

### 🚧 논의 사항
- 더미데이터를 이용해서 지도에 마커와 info window를 구현하였습니다.
- 지도 API 연동 시 `html`에 `script`를 선언해주어야 하는데, 여기에 환경 변수가 들어가서 `webpack`을 이용하여 처리해두었습니다~
- info window 들어가는 contents에 string 밖에 들어가지 않는 거 같아 Function component를 사용하지 못하고, 템플릿 리터럴로 구현해두었습니다! (`InfoWindow/index.ts`)

- close #116 
