### PR TITLE
[#121] feat: 지도 바운더리 처리 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/exception/meeting_place/MeetingPlaceNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/meeting_place/MeetingPlaceNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.kro.colla.exception.exception.meeting_place;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class MeetingPlaceNotFoundException extends NotFoundException {
+
+    public MeetingPlaceNotFoundException() {
+        super("해당하는 모임 장소를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.meeting_place.meeting_place.domain;
 
 import kr.kro.colla.meeting_place.mentioned_post.domain.MentionedPost;
+import kr.kro.colla.project.project.domain.Project;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,16 +40,21 @@ public class MeetingPlace {
     @Column
     private String address;
 
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_place_id")
     private List<MentionedPost> mentionedPosts = new ArrayList<>();
 
     @Builder
-    public MeetingPlace(String name, String image, Double longitude, Double latitude, String address) {
+    public MeetingPlace(String name, String image, Double longitude, Double latitude, String address, Project project) {
         this.name = name;
         this.image = image;
         this.longitude = longitude;
         this.latitude = latitude;
         this.address = address;
+        this.project = project;
     }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
@@ -1,7 +1,20 @@
 package kr.kro.colla.meeting_place.meeting_place.domain.repository;
 
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
+import kr.kro.colla.project.project.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MeetingPlaceRepository extends JpaRepository<MeetingPlace, Long> {
+
+    @Query("select m from MeetingPlace m " +
+            "where m.project = :project " +
+            "and :#{#boundary.minLongitude} <= m.longitude and m.longitude <= :#{#boundary.maxLongitude} " +
+            "and :#{#boundary.minLatitude} <= m.latitude and m.latitude <= :#{#boundary.maxLatitude}")
+    List<MeetingPlace> findMeetingPlacesByBoundary(@Param("project") Project project, @Param("boundary")SearchByMapBoundaryRequest request);
+
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
@@ -13,8 +13,8 @@ public interface MeetingPlaceRepository extends JpaRepository<MeetingPlace, Long
 
     @Query("select m from MeetingPlace m " +
             "where m.project = :project " +
-            "and :#{#boundary.minLongitude} <= m.longitude and m.longitude <= :#{#boundary.maxLongitude} " +
-            "and :#{#boundary.minLatitude} <= m.latitude and m.latitude <= :#{#boundary.maxLatitude}")
+            "and :#{#boundary.minLng} <= m.longitude and m.longitude <= :#{#boundary.maxLng} " +
+            "and :#{#boundary.minLat} <= m.latitude and m.latitude <= :#{#boundary.maxLat}")
     List<MeetingPlace> findMeetingPlacesByBoundary(@Param("project") Project project, @Param("boundary")SearchByMapBoundaryRequest request);
 
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -29,7 +29,7 @@ public class MeetingPlaceController {
 
     @GetMapping({"/{projectId}/meeting-places"})
     public ResponseEntity<List<MeetingPlaceResponse>> getSpecificAreaMeetingPlace(@PathVariable Long projectId,
-                                                                                  @Valid @RequestParam SearchByMapBoundaryRequest request) {
+                                                                                  @Valid SearchByMapBoundaryRequest request) {
         List<MeetingPlaceResponse> meetingPlaceList = meetingPlaceService.getSpecificAreaMeetingPlace(projectId, request);
 
         return ResponseEntity.ok(meetingPlaceList);

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -1,28 +1,37 @@
 package kr.kro.colla.meeting_place.meeting_place.presentation;
 
+import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
-import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/projects")
 public class MeetingPlaceController {
+
     private final MeetingPlaceService meetingPlaceService;
-    private final ProjectService projectService;
 
     @PostMapping("/{projectId}/meeting-places")
-    ResponseEntity<MeetingPlaceResponse> CreateMeetingPlace(@PathVariable Long projectId,
-                                                            @Valid @RequestBody CreateMeetingPlaceRequest request) {
-        MeetingPlaceResponse response = new MeetingPlaceResponse(meetingPlaceService.createMeetingPlace(projectId, request));
+    public ResponseEntity<MeetingPlaceResponse> createMeetingPlace(@PathVariable Long projectId,
+                                                                    @Valid @RequestBody CreateMeetingPlaceRequest request) {
+        MeetingPlace meetingPlace = meetingPlaceService.createMeetingPlace(projectId, request);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new MeetingPlaceResponse(meetingPlace));
+    }
+
+    @GetMapping({"/{projectId}/meeting-places"})
+    public ResponseEntity<List<MeetingPlaceResponse>> getSpecificAreaMeetingPlace(@PathVariable Long projectId,
+                                                                                  @Valid @RequestParam SearchByMapBoundaryRequest request) {
+        List<MeetingPlaceResponse> meetingPlaceList = meetingPlaceService.getSpecificAreaMeetingPlace(projectId, request);
+
+        return ResponseEntity.ok(meetingPlaceList);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
@@ -1,0 +1,26 @@
+package kr.kro.colla.meeting_place.meeting_place.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SearchByMapBoundaryRequest {
+
+    @NotNull
+    private Double minLongitude;
+
+    @NotNull
+    private Double maxLongitude;
+
+    @NotNull
+    private Double minLatitude;
+
+    @NotNull
+    private Double maxLatitude;
+
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
@@ -2,25 +2,23 @@ package kr.kro.colla.meeting_place.meeting_place.presentation.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
 @AllArgsConstructor
-@NoArgsConstructor
 @Getter
 public class SearchByMapBoundaryRequest {
 
     @NotNull
-    private Double minLongitude;
+    private Double minLng;
 
     @NotNull
-    private Double maxLongitude;
+    private Double maxLng;
 
     @NotNull
-    private Double minLatitude;
+    private Double minLat;
 
     @NotNull
-    private Double maxLatitude;
+    private Double maxLat;
 
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
@@ -3,6 +3,8 @@ package kr.kro.colla.meeting_place.meeting_place.service;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 
 import kr.kro.colla.project.project.service.ProjectService;
@@ -10,13 +12,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class MeetingPlaceService {
-    private final MeetingPlaceRepository meetingPlaceRepository;
 
+    private final MeetingPlaceRepository meetingPlaceRepository;
     private final ProjectService projectService;
 
     public MeetingPlace createMeetingPlace(Long projectId, CreateMeetingPlaceRequest request) {
@@ -28,12 +32,19 @@ public class MeetingPlaceService {
                 .longitude(request.getLongitude())
                 .latitude(request.getLatitude())
                 .address(request.getAddress())
+                .project(project)
                 .build();
 
-        MeetingPlace result = meetingPlaceRepository.save(meetingPlace);
-        project.addMeetingPlace(result);
+        return meetingPlaceRepository.save(meetingPlace);
+    }
 
-        return result;
+    public List<MeetingPlaceResponse> getSpecificAreaMeetingPlace(Long projectId, SearchByMapBoundaryRequest request) {
+        Project project = projectService.findProjectById(projectId);
+
+        return meetingPlaceRepository.findMeetingPlacesByBoundary(project, request)
+                .stream()
+                .map(MeetingPlaceResponse::new)
+                .collect(Collectors.toList());
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -58,8 +58,7 @@ public class Project {
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     private List<TaskTag> taskTags = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true)
-    @JoinColumn(name = "project_id")
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<MeetingPlace> meetingPlaces = new ArrayList<>();
 
     @Builder
@@ -83,5 +82,4 @@ public class Project {
 
     public void removeStatus(TaskStatus taskStatus) { this.taskStatuses.remove(taskStatus); }
 
-    public void addMeetingPlace(MeetingPlace meetingPlace) { this.meetingPlaces.add(meetingPlace); }
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
@@ -1,9 +1,33 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.http.ContentType;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.project.project.domain.Project;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
 
 public class MeetingPlaceProvider {
+
+    public static MeetingPlaceResponse 특정_좌표의_모임_장소를_생성한다(String accessToken, Long projectId, CreateMeetingPlaceRequest request) {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(request)
+        // when
+        .when()
+                .post("/api/projects/" + projectId + "/meeting-places")
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(MeetingPlaceResponse.class);
+    }
 
     public static MeetingPlace createMeetingPlace(Project project) {
         MeetingPlace meetingPlace = MeetingPlace.builder()

--- a/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
@@ -1,15 +1,29 @@
 package kr.kro.colla.common.fixture;
 
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.project.project.domain.Project;
 
 public class MeetingPlaceProvider {
 
-    public static MeetingPlace createMeetingPlace() {
+    public static MeetingPlace createMeetingPlace(Project project) {
         MeetingPlace meetingPlace = MeetingPlace.builder()
                 .name("이번 회의 장소")
                 .longitude(134.234)
                 .latitude(32.234)
                 .address("서울특별시 강남구 ~~로 ~~번길")
+                .project(project)
+                .build();
+
+        return meetingPlace;
+    }
+
+    public static MeetingPlace createMeetingPlaceWithCoordinate(Project project, Double longitude, Double latitude) {
+        MeetingPlace meetingPlace = MeetingPlace.builder()
+                .name("이번 회의 장소")
+                .longitude(longitude)
+                .latitude(latitude)
+                .address("서울특별시 강남구 ~~로 ~~번길")
+                .project(project)
                 .build();
 
         return meetingPlace;

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
@@ -1,11 +1,13 @@
 package kr.kro.colla.meeting_place.meeting_place;
 
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +19,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static kr.kro.colla.common.fixture.MeetingPlaceProvider.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -102,6 +108,37 @@ public class AcceptanceTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
                 .body("message", containsString("널이어서는 안됩니다"));
+    }
+
+    @Test
+    void 사용자가_드래그한_바운더리에_속하는_모임_장소들을_조회한다() {
+        // given
+        Double minLng = 127.022, maxLng = 127.918, minLat = 36.383, maxLat = 37.489;
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("caffebene", null , 127.992, 36.813, "caffebene address"));
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("starbucks", null , 127.52, 37.174, "starbucks address"));
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("ediya", null , 127.318, 37.769, "ediya address"));
+
+        List<MeetingPlaceResponse> response = given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + createdProject.getId() + "/meeting-places?minLng=" + minLng + "&maxLng=" + maxLng + "&minLat=" + minLat + "&maxLat=" + maxLat)
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<MeetingPlaceResponse>>() {});
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getLongitude()).isGreaterThanOrEqualTo(minLng).isLessThanOrEqualTo(maxLng);
+        assertThat(response.get(0).getLatitude()).isGreaterThanOrEqualTo(minLat).isLessThanOrEqualTo(maxLat);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
@@ -53,11 +53,11 @@ public class AcceptanceTest {
     void 사용자는_프로젝트의_모임_장소를_추가할_수_있다() {
         // given
         String placeName = "새로운 만날 장소 이름", placeImage = "https://image/url/of/place", placeAddress = "SeongNam";
-        Double placeLong = 23.4141, placeLa = 194.145;
+        Double placeLng = 23.4141, placeLat = 194.145;
         User loginUser = user.가_로그인을_한다2();
         String accessToken = auth.토큰을_발급한다(loginUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest(placeName, placeImage, placeLong, placeLa, placeAddress);
+        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest(placeName, placeImage, placeLng, placeLat, placeAddress);
 
         given()
                 .contentType(ContentType.JSON)
@@ -75,8 +75,8 @@ public class AcceptanceTest {
                 .body("name", equalTo(placeName))
                 .body("image", equalTo(placeImage))
                 .body("address", equalTo(placeAddress))
-                .body("longitude", equalTo(placeLong.floatValue()))
-                .body("latitude", equalTo(placeLa.floatValue()));
+                .body("longitude", equalTo(placeLng.floatValue()))
+                .body("latitude", equalTo(placeLat.floatValue()));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
@@ -8,41 +8,39 @@ import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.validation.ConstraintViolationException;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 
-@DataJpaTest
 @ActiveProfiles("test")
+@DataJpaTest
 class MeetingPlaceRepositoryTest {
 
     @Autowired
-    MeetingPlaceRepository meetingPlaceRepository;
+    private MeetingPlaceRepository meetingPlaceRepository;
 
     @Autowired
-    ProjectRepository projectRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
+    private ProjectRepository projectRepository;
 
     @Test
-    void 프로젝트의_모임_장소를_생성한다() throws Exception {
+    void 프로젝트의_모임_장소를_생성한다() {
         // given
         Project project = projectRepository.save(ProjectProvider.createProject(324091L));
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(project);
 
         // when
-        MeetingPlace meetingPlace = meetingPlaceRepository.save(MeetingPlaceProvider.createMeetingPlace());
-        project.addMeetingPlace(meetingPlace);
-
-        testEntityManager.flush();
-        testEntityManager.clear();
+        MeetingPlace result = meetingPlaceRepository.save(meetingPlace);
 
         // then
-        meetingPlaceRepository.findById(meetingPlace.getId()).orElseThrow(Exception::new);
-        assertThat(project.getMeetingPlaces().size()).isEqualTo(1);
+        assertThat(result.getName()).isEqualTo(meetingPlace.getName());
+        assertThat(result.getLongitude()).isEqualTo(meetingPlace.getLongitude());
+        assertThat(result.getLatitude()).isEqualTo(meetingPlace.getLatitude());
+        assertThat(result.getAddress()).isEqualTo(meetingPlace.getAddress());
+        assertThat(result.getProject().getId()).isEqualTo(project.getId());
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
@@ -3,6 +3,7 @@ package kr.kro.colla.meeting_place.meeting_place.domain.repository;
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
 import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import org.junit.jupiter.api.Test;
@@ -53,5 +54,30 @@ class MeetingPlaceRepositoryTest {
         assertThatThrownBy(() -> {
             meetingPlaceRepository.save(meetingPlace);
         }).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        meetingPlaceRepository.saveAll(List.of(
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.031, 37.491),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 128.521, 36.723),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.032, 37.487),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 126.684, 35.265)
+        ));
+        SearchByMapBoundaryRequest request = new SearchByMapBoundaryRequest(127.022, 127.918, 37.383, 37.489);
+
+        // when
+        List<MeetingPlace> meetingPlaceList = meetingPlaceRepository.findMeetingPlacesByBoundary(project, request);
+
+        // then
+        assertThat(meetingPlaceList).hasSize(1);
+        assertThat(meetingPlaceList.get(0).getLongitude())
+                .isGreaterThanOrEqualTo(request.getMinLng())
+                .isLessThanOrEqualTo(request.getMaxLng());
+        assertThat(meetingPlaceList.get(0).getLatitude())
+                .isGreaterThanOrEqualTo(request.getMinLat())
+                .isLessThanOrEqualTo(request.getMaxLat());
     }
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.meeting_place.meeting_place.presentation;
 
 import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
+import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import org.junit.jupiter.api.Test;
@@ -30,7 +31,7 @@ class MeetingPlaceControllerTest extends ControllerTest {
         // given
         Long projectId = 82425L, meetingPlaceId = 234241L;
         CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest("meeting place name", "preview image", 23.23, 3.5, "address to go!");
-        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace();
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(ProjectProvider.createProject(1L));
         ReflectionTestUtils.setField(meetingPlace, "id", meetingPlaceId);
 
         given(meetingPlaceService.createMeetingPlace(eq(projectId), any(CreateMeetingPlaceRequest.class)))

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
@@ -5,6 +5,9 @@ import kr.kro.colla.common.fixture.MeetingPlaceProvider;
 import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
+import kr.kro.colla.project.project.domain.Project;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
@@ -14,11 +17,16 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 
-import static org.hamcrest.Matchers.containsString;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -72,5 +80,51 @@ class MeetingPlaceControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message", containsString("must not be null")));
         verify(meetingPlaceService, never()).createMeetingPlace(anyLong(), any(CreateMeetingPlaceRequest.class));
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        Double minLng = 127.022, maxLng = 127.918, minLat = 36.383, maxLat = 37.489;
+        Project project = ProjectProvider.createProject(5L);
+        List<MeetingPlaceResponse> meetingPlaceList = Stream.of(MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.523, 37.024))
+                .map(MeetingPlaceResponse::new)
+                .collect(Collectors.toList());
+
+        given(meetingPlaceService.getSpecificAreaMeetingPlace(eq(projectId), any(SearchByMapBoundaryRequest.class)))
+                .willReturn(meetingPlaceList);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/meeting-places?minLng=" + minLng + "&maxLng=" + maxLng + "&minLat=" + minLat + "&maxLat=" + maxLat)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(meetingPlaceList.size()))
+                .andExpect(jsonPath("$[0].longitude").value(is(greaterThanOrEqualTo(minLng))))
+                .andExpect(jsonPath("$[0].longitude").value(is(lessThanOrEqualTo(maxLng))))
+                .andExpect(jsonPath("$[0].latitude").value(is(greaterThanOrEqualTo(minLat))))
+                .andExpect(jsonPath("$[0].latitude").value(is(lessThanOrEqualTo(maxLat))));
+        verify(meetingPlaceService, times(1)).getSpecificAreaMeetingPlace(anyLong(), any(SearchByMapBoundaryRequest.class));
+    }
+
+    @Test
+    void 지도_바운더리의_정보가_모두_오지_않으면_모임_장소를_조회할_수_없다() throws Exception {
+        // given
+        Long projectId = 1L;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/meeting-places?minLng=" + 127.052)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message", containsString("must not be null")));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
@@ -5,6 +5,8 @@ import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import org.junit.jupiter.api.Test;
@@ -13,8 +15,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -52,6 +57,38 @@ class MeetingPlaceServiceTest {
         assertThat(result.getLongitude()).isEqualTo(meetingPlace.getLongitude());
         assertThat(result.getAddress()).isEqualTo(meetingPlace.getAddress());
         verify(meetingPlaceRepository, times(1)).save(any(MeetingPlace.class));
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() {
+        // given
+        Long projectId = 5L;
+        Project project = ProjectProvider.createProject(3L);
+        SearchByMapBoundaryRequest request = new SearchByMapBoundaryRequest(127.022, 127.918, 36.383, 37.489);
+        List<MeetingPlace> meetingPlaceList = List.of(
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.523, 37.024),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.218, 36.938)
+        );
+
+        given(projectService.findProjectById(eq(projectId)))
+                .willReturn(project);
+        given(meetingPlaceRepository.findMeetingPlacesByBoundary(any(Project.class), any(SearchByMapBoundaryRequest.class)))
+                .willReturn(meetingPlaceList);
+
+        // when
+        List<MeetingPlaceResponse> result = meetingPlaceService.getSpecificAreaMeetingPlace(projectId, request);
+
+        // then
+        assertThat(result).hasSize(2);
+        result.forEach(meetingPlace -> {
+            assertThat(meetingPlace.getLongitude())
+                    .isGreaterThanOrEqualTo(request.getMinLng())
+                    .isLessThanOrEqualTo(request.getMaxLng());
+            assertThat(meetingPlace.getLatitude())
+                    .isGreaterThanOrEqualTo(request.getMinLat())
+                    .isLessThanOrEqualTo(request.getMaxLat());
+        });
+        verify(meetingPlaceRepository, times(1)).findMeetingPlacesByBoundary(any(Project.class), any(SearchByMapBoundaryRequest.class));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
@@ -23,26 +23,27 @@ import static org.mockito.Mockito.verify;
 class MeetingPlaceServiceTest {
 
     @Mock
-    MeetingPlaceRepository meetingPlaceRepository;
+    private MeetingPlaceRepository meetingPlaceRepository;
 
     @Mock
-    ProjectService projectService;
+    private ProjectService projectService;
 
     @InjectMocks
-    MeetingPlaceService meetingPlaceService;
+    private MeetingPlaceService meetingPlaceService;
 
     @Test
     void 프로젝트의_모임_장소를_생성한다() {
         // given
         Long projectId = 32492L;
         Project project = ProjectProvider.createProject(234912L);
-        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace();
-        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest();
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(project);
+        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest("이번 회의 장소", null, 132.234, 23.234, "서울특별시 강남구 ~~로 ~~번길");
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
         given(meetingPlaceRepository.save(any(MeetingPlace.class)))
                 .willReturn(meetingPlace);
+
         // when
         MeetingPlace result = meetingPlaceService.createMeetingPlace(projectId, request);
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -48,6 +48,7 @@
     "no-unneeded-ternary": "off",
     "dot-notation": "off",
     "no-new": "off",
+    "no-underscore-dangle": "off",
     "no-use-before-define": ["error", { "variables": false }],
     "import/prefer-default-export": "off",
     "@typescript-eslint/no-unused-vars": ["error"],

--- a/frontend/src/apis/meeting-place.ts
+++ b/frontend/src/apis/meeting-place.ts
@@ -1,0 +1,16 @@
+import { MeetingPlaceType } from '../types/meeting-place';
+import { client } from './common';
+
+export const getSpecificAreaMeetingPlace = async (
+    projectId: number,
+    minLng: number,
+    maxLng: number,
+    minLat: number,
+    maxLat: number,
+) => {
+    const response = await client.get<Array<MeetingPlaceType>>(
+        `/projects/${projectId}/meeting-places?minLng=${minLng}&maxLng=${maxLng}&minLat=${minLat}&maxLat=${maxLat}`,
+    );
+
+    return response;
+};

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 
+import { useLocation } from 'react-router-dom';
+import { getSpecificAreaMeetingPlace } from '../../apis/meeting-place';
 import { MeetingPlaceType } from '../../types/meeting-place';
+import { StateType } from '../../types/project';
 import { InfoWindow } from './InfoWindow';
 import { MapContainer } from './style';
 
@@ -35,6 +38,7 @@ export const Map = () => {
     let markers: Array<any> = [];
     let infoWindows: Array<any> = [];
     let timer: NodeJS.Timeout;
+    const { state } = useLocation<StateType>();
 
     const handleMarkerClick = (map: any, marker: any) => {
         const idx = markers.indexOf(marker);
@@ -74,9 +78,10 @@ export const Map = () => {
             clearTimeout(timer);
         }
 
-        timer = setTimeout(() => {
+        timer = setTimeout(async () => {
             const { _max, _min } = map.getBounds();
-            console.log(`${_min._lat} ${_min._lng} ${_max._lat} ${_max._lng}`);
+            const res = await getSpecificAreaMeetingPlace(state.projectId, _min._lng, _max._lng, _min._lat, _max._lat);
+            console.log(res.data); // TODO: 좌측 리스트와 연동
         }, 1000);
     };
 

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -34,6 +34,7 @@ const dummy: Array<MeetingPlaceType> = [
 export const Map = () => {
     let markers: Array<any> = [];
     let infoWindows: Array<any> = [];
+    let timer: NodeJS.Timeout;
 
     const handleMarkerClick = (map: any, marker: any) => {
         const idx = markers.indexOf(marker);
@@ -68,6 +69,17 @@ export const Map = () => {
         );
     };
 
+    const searchSpecificAreaMeetingPlace = (map: any) => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+
+        timer = setTimeout(() => {
+            const { _max, _min } = map.getBounds();
+            console.log(`${_min._lat} ${_min._lng} ${_max._lat} ${_max._lng}`);
+        }, 1000);
+    };
+
     useEffect(() => {
         const mapOptions = {
             center: new naver.maps.LatLng(37.511337, 127.012084),
@@ -83,6 +95,7 @@ export const Map = () => {
         markMeetingPlace(map);
         createInfoWindows();
         naver.maps.Event.addListener(map, 'click', () => handleClickOtherArea());
+        naver.maps.Event.addListener(map, 'drag', () => searchSpecificAreaMeetingPlace(map));
     }, []);
 
     return (


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 지도 드래그 바운더리에 따라 모임 장소 조회
- 모임 장소 조회 API 구현
- 모임 장소 조회 API 테스트 코드 작성

### 📑 구현한 내용 목록
- [x] 지도 드래그 바운더리에 따라 모임 장소 조회
- [x] 모임 장소 조회 API 구현
- [x] 모임 장소 조회 API 테스트 코드 작성

### 🚧 논의 사항
- 지도 바운더리로 조회하는 API에서 프로젝트를 where절에서 사용해야 해서 모임장소 엔티티에 project 필드를 추가하였습니다.
- 근데 생각해보니 처음 모임 장소 페이지 들어갈 때 모든 모임 장소 조회해오면 바운더리 처리도 프론트에서 할 수 있을 것 같은데 API를 괜히 만든 것 같기도 하네여....

- close #121 
