### PR TITLE
[#120] feat: 프로젝트 모임 장소 목록 조회 및 키워드 기반 장소 검색 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/exception/exception/meeting_place/MeetingPlaceNotFoundException.java
+++ b/backend/src/main/java/kr/kro/colla/exception/exception/meeting_place/MeetingPlaceNotFoundException.java
@@ -1,0 +1,10 @@
+package kr.kro.colla.exception.exception.meeting_place;
+
+import kr.kro.colla.exception.exception.NotFoundException;
+
+public class MeetingPlaceNotFoundException extends NotFoundException {
+
+    public MeetingPlaceNotFoundException() {
+        super("해당하는 모임 장소를 찾을 수 없습니다.");
+    }
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/MeetingPlace.java
@@ -1,6 +1,7 @@
 package kr.kro.colla.meeting_place.meeting_place.domain;
 
 import kr.kro.colla.meeting_place.mentioned_post.domain.MentionedPost;
+import kr.kro.colla.project.project.domain.Project;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,16 +40,21 @@ public class MeetingPlace {
     @Column
     private String address;
 
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
     @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "meeting_place_id")
     private List<MentionedPost> mentionedPosts = new ArrayList<>();
 
     @Builder
-    public MeetingPlace(String name, String image, Double longitude, Double latitude, String address) {
+    public MeetingPlace(String name, String image, Double longitude, Double latitude, String address, Project project) {
         this.name = name;
         this.image = image;
         this.longitude = longitude;
         this.latitude = latitude;
         this.address = address;
+        this.project = project;
     }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepository.java
@@ -1,7 +1,20 @@
 package kr.kro.colla.meeting_place.meeting_place.domain.repository;
 
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
+import kr.kro.colla.project.project.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MeetingPlaceRepository extends JpaRepository<MeetingPlace, Long> {
+
+    @Query("select m from MeetingPlace m " +
+            "where m.project = :project " +
+            "and :#{#boundary.minLng} <= m.longitude and m.longitude <= :#{#boundary.maxLng} " +
+            "and :#{#boundary.minLat} <= m.latitude and m.latitude <= :#{#boundary.maxLat}")
+    List<MeetingPlace> findMeetingPlacesByBoundary(@Param("project") Project project, @Param("boundary")SearchByMapBoundaryRequest request);
+
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -3,7 +3,6 @@ package kr.kro.colla.meeting_place.meeting_place.presentation;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
-import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +18,7 @@ public class MeetingPlaceController {
     private final ProjectService projectService;
 
     @PostMapping("/{projectId}/meeting-places")
-    ResponseEntity<MeetingPlaceResponse> CreateMeetingPlace(@PathVariable Long projectId,
+    ResponseEntity<MeetingPlaceResponse> createMeetingPlace(@PathVariable Long projectId,
                                                             @Valid @RequestBody CreateMeetingPlaceRequest request) {
         MeetingPlaceResponse response = new MeetingPlaceResponse(meetingPlaceService.createMeetingPlace(projectId, request));
 

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -1,6 +1,5 @@
 package kr.kro.colla.meeting_place.meeting_place.presentation;
 
-import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
@@ -11,7 +10,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -1,28 +1,37 @@
 package kr.kro.colla.meeting_place.meeting_place.presentation;
 
+import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
-import kr.kro.colla.project.project.domain.Project;
-import kr.kro.colla.project.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/projects")
 public class MeetingPlaceController {
+
     private final MeetingPlaceService meetingPlaceService;
-    private final ProjectService projectService;
 
     @PostMapping("/{projectId}/meeting-places")
-    ResponseEntity<MeetingPlaceResponse> CreateMeetingPlace(@PathVariable Long projectId,
-                                                            @Valid @RequestBody CreateMeetingPlaceRequest request) {
-        MeetingPlaceResponse response = new MeetingPlaceResponse(meetingPlaceService.createMeetingPlace(projectId, request));
+    public ResponseEntity<MeetingPlaceResponse> createMeetingPlace(@PathVariable Long projectId,
+                                                                    @Valid @RequestBody CreateMeetingPlaceRequest request) {
+        MeetingPlace meetingPlace = meetingPlaceService.createMeetingPlace(projectId, request);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(new MeetingPlaceResponse(meetingPlace));
+    }
+
+    @GetMapping({"/{projectId}/meeting-places"})
+    public ResponseEntity<List<MeetingPlaceResponse>> getSpecificAreaMeetingPlace(@PathVariable Long projectId,
+                                                                                  @Valid SearchByMapBoundaryRequest request) {
+        List<MeetingPlaceResponse> meetingPlaceList = meetingPlaceService.getSpecificAreaMeetingPlace(projectId, request);
+
+        return ResponseEntity.ok(meetingPlaceList);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.meeting_place.meeting_place.presentation;
 
+import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
@@ -9,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,5 +26,12 @@ public class MeetingPlaceController {
         MeetingPlaceResponse response = new MeetingPlaceResponse(meetingPlaceService.createMeetingPlace(projectId, request));
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{projectId}/meeting-places")
+    ResponseEntity<List<MeetingPlaceResponse>> getMeetingPlaces(@PathVariable Long projectId) {
+        List<MeetingPlaceResponse> meetingPlaceList = meetingPlaceService.getMeetingPlaces(projectId);
+
+        return ResponseEntity.ok(meetingPlaceList);
     }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/dto/SearchByMapBoundaryRequest.java
@@ -1,0 +1,24 @@
+package kr.kro.colla.meeting_place.meeting_place.presentation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@AllArgsConstructor
+@Getter
+public class SearchByMapBoundaryRequest {
+
+    @NotNull
+    private Double minLng;
+
+    @NotNull
+    private Double maxLng;
+
+    @NotNull
+    private Double minLat;
+
+    @NotNull
+    private Double maxLat;
+
+}

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
@@ -3,6 +3,7 @@ package kr.kro.colla.meeting_place.meeting_place.service;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.project.project.domain.Project;
 
 import kr.kro.colla.project.project.service.ProjectService;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
@@ -36,4 +39,12 @@ public class MeetingPlaceService {
         return result;
     }
 
+    public List<MeetingPlaceResponse> getMeetingPlaces(Long projectId) {
+        Project project = projectService.findProjectById(projectId);
+
+        List<MeetingPlaceResponse> meetingPlaces =  project.getMeetingPlaces().stream()
+                .map(MeetingPlaceResponse::new)
+                .collect(Collectors.toList());
+        return meetingPlaces;
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
@@ -3,6 +3,8 @@ package kr.kro.colla.meeting_place.meeting_place.service;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 
 import kr.kro.colla.project.project.service.ProjectService;
@@ -10,13 +12,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
 @Service
 public class MeetingPlaceService {
-    private final MeetingPlaceRepository meetingPlaceRepository;
 
+    private final MeetingPlaceRepository meetingPlaceRepository;
     private final ProjectService projectService;
 
     public MeetingPlace createMeetingPlace(Long projectId, CreateMeetingPlaceRequest request) {
@@ -28,12 +32,19 @@ public class MeetingPlaceService {
                 .longitude(request.getLongitude())
                 .latitude(request.getLatitude())
                 .address(request.getAddress())
+                .project(project)
                 .build();
 
-        MeetingPlace result = meetingPlaceRepository.save(meetingPlace);
-        project.addMeetingPlace(result);
+        return meetingPlaceRepository.save(meetingPlace);
+    }
 
-        return result;
+    public List<MeetingPlaceResponse> getSpecificAreaMeetingPlace(Long projectId, SearchByMapBoundaryRequest request) {
+        Project project = projectService.findProjectById(projectId);
+
+        return meetingPlaceRepository.findMeetingPlacesByBoundary(project, request)
+                .stream()
+                .map(MeetingPlaceResponse::new)
+                .collect(Collectors.toList());
     }
 
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
@@ -42,9 +42,8 @@ public class MeetingPlaceService {
     public List<MeetingPlaceResponse> getMeetingPlaces(Long projectId) {
         Project project = projectService.findProjectById(projectId);
 
-        List<MeetingPlaceResponse> meetingPlaces =  project.getMeetingPlaces().stream()
+       return project.getMeetingPlaces().stream()
                 .map(MeetingPlaceResponse::new)
                 .collect(Collectors.toList());
-        return meetingPlaces;
     }
 }

--- a/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
+++ b/backend/src/main/java/kr/kro/colla/project/project/domain/Project.java
@@ -58,8 +58,7 @@ public class Project {
     @OneToMany(mappedBy = "project", fetch = FetchType.LAZY)
     private List<TaskTag> taskTags = new ArrayList<>();
 
-    @OneToMany(fetch = FetchType.LAZY, orphanRemoval = true)
-    @JoinColumn(name = "project_id")
+    @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, orphanRemoval = true)
     private List<MeetingPlace> meetingPlaces = new ArrayList<>();
 
     @Builder
@@ -83,5 +82,4 @@ public class Project {
 
     public void removeStatus(TaskStatus taskStatus) { this.taskStatuses.remove(taskStatus); }
 
-    public void addMeetingPlace(MeetingPlace meetingPlace) { this.meetingPlaces.add(meetingPlace); }
 }

--- a/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
@@ -1,12 +1,50 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 
+import static io.restassured.RestAssured.given;
+
+@Component
 public class MeetingPlaceProvider {
+
+    public MeetingPlaceResponse 를_생성한다(String accessToken, Long projectId, Double longitude, Double latitude) {
+        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest("name", "image", longitude, latitude, "address");
+
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(request)
+        .when()
+                .post("/api/projects/" + projectId + "/meeting-places")
+        .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<MeetingPlaceResponse>() {});
+    }
 
     public static MeetingPlace createMeetingPlace() {
         MeetingPlace meetingPlace = MeetingPlace.builder()
                 .name("이번 회의 장소")
+                .longitude(134.234)
+                .latitude(32.234)
+                .address("서울특별시 강남구 ~~로 ~~번길")
+                .build();
+
+        return meetingPlace;
+    }
+
+    public static MeetingPlace createMeetingPlaceWithName(String name) {
+        MeetingPlace meetingPlace = MeetingPlace.builder()
+                .name(name)
                 .longitude(134.234)
                 .latitude(32.234)
                 .address("서울특별시 강남구 ~~로 ~~번길")

--- a/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/MeetingPlaceProvider.java
@@ -1,15 +1,53 @@
 package kr.kro.colla.common.fixture;
 
+import io.restassured.http.ContentType;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.project.project.domain.Project;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
 
 public class MeetingPlaceProvider {
 
-    public static MeetingPlace createMeetingPlace() {
+    public static MeetingPlaceResponse 특정_좌표의_모임_장소를_생성한다(String accessToken, Long projectId, CreateMeetingPlaceRequest request) {
+        return given()
+                .contentType(ContentType.JSON)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .cookie("accessToken", accessToken)
+                .body(request)
+        // when
+        .when()
+                .post("/api/projects/" + projectId + "/meeting-places")
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(MeetingPlaceResponse.class);
+    }
+
+    public static MeetingPlace createMeetingPlace(Project project) {
         MeetingPlace meetingPlace = MeetingPlace.builder()
                 .name("이번 회의 장소")
                 .longitude(134.234)
                 .latitude(32.234)
                 .address("서울특별시 강남구 ~~로 ~~번길")
+                .project(project)
+                .build();
+
+        return meetingPlace;
+    }
+
+    public static MeetingPlace createMeetingPlaceWithCoordinate(Project project, Double longitude, Double latitude) {
+        MeetingPlace meetingPlace = MeetingPlace.builder()
+                .name("이번 회의 장소")
+                .longitude(longitude)
+                .latitude(latitude)
+                .address("서울특별시 강남구 ~~로 ~~번길")
+                .project(project)
                 .build();
 
         return meetingPlace;

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
@@ -1,11 +1,13 @@
 package kr.kro.colla.meeting_place.meeting_place;
 
 import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import kr.kro.colla.auth.service.JwtProvider;
 import kr.kro.colla.common.database.DatabaseCleaner;
 import kr.kro.colla.common.fixture.*;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.user.user.domain.User;
 import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,7 +19,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static kr.kro.colla.common.fixture.MeetingPlaceProvider.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -53,11 +59,11 @@ public class AcceptanceTest {
     void 사용자는_프로젝트의_모임_장소를_추가할_수_있다() {
         // given
         String placeName = "새로운 만날 장소 이름", placeImage = "https://image/url/of/place", placeAddress = "SeongNam";
-        Double placeLong = 23.4141, placeLa = 194.145;
+        Double placeLng = 23.4141, placeLat = 194.145;
         User loginUser = user.가_로그인을_한다2();
         String accessToken = auth.토큰을_발급한다(loginUser.getId());
         UserProjectResponse createdProject = project.를_생성한다(accessToken);
-        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest(placeName, placeImage, placeLong, placeLa, placeAddress);
+        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest(placeName, placeImage, placeLng, placeLat, placeAddress);
 
         given()
                 .contentType(ContentType.JSON)
@@ -75,8 +81,8 @@ public class AcceptanceTest {
                 .body("name", equalTo(placeName))
                 .body("image", equalTo(placeImage))
                 .body("address", equalTo(placeAddress))
-                .body("longitude", equalTo(placeLong.floatValue()))
-                .body("latitude", equalTo(placeLa.floatValue()));
+                .body("longitude", equalTo(placeLng.floatValue()))
+                .body("latitude", equalTo(placeLat.floatValue()));
     }
 
     @Test
@@ -102,6 +108,37 @@ public class AcceptanceTest {
                 .statusCode(HttpStatus.BAD_REQUEST.value())
                 .body("status", equalTo(HttpStatus.BAD_REQUEST.value()))
                 .body("message", containsString("널이어서는 안됩니다"));
+    }
+
+    @Test
+    void 사용자가_드래그한_바운더리에_속하는_모임_장소들을_조회한다() {
+        // given
+        Double minLng = 127.022, maxLng = 127.918, minLat = 36.383, maxLat = 37.489;
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("caffebene", null , 127.992, 36.813, "caffebene address"));
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("starbucks", null , 127.52, 37.174, "starbucks address"));
+        특정_좌표의_모임_장소를_생성한다(accessToken, createdProject.getId(), new CreateMeetingPlaceRequest("ediya", null , 127.318, 37.769, "ediya address"));
+
+        List<MeetingPlaceResponse> response = given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .get("/api/projects/" + createdProject.getId() + "/meeting-places?minLng=" + minLng + "&maxLng=" + maxLng + "&minLat=" + minLat + "&maxLat=" + maxLat)
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<List<MeetingPlaceResponse>>() {});
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getLongitude()).isGreaterThanOrEqualTo(minLng).isLessThanOrEqualTo(maxLng);
+        assertThat(response.get(0).getLatitude()).isGreaterThanOrEqualTo(minLat).isLessThanOrEqualTo(maxLat);
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
@@ -3,46 +3,45 @@ package kr.kro.colla.meeting_place.meeting_place.domain.repository;
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
 import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.validation.ConstraintViolationException;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 
-@DataJpaTest
 @ActiveProfiles("test")
+@DataJpaTest
 class MeetingPlaceRepositoryTest {
 
     @Autowired
-    MeetingPlaceRepository meetingPlaceRepository;
+    private MeetingPlaceRepository meetingPlaceRepository;
 
     @Autowired
-    ProjectRepository projectRepository;
-
-    @Autowired
-    private TestEntityManager testEntityManager;
+    private ProjectRepository projectRepository;
 
     @Test
-    void 프로젝트의_모임_장소를_생성한다() throws Exception {
+    void 프로젝트의_모임_장소를_생성한다() {
         // given
         Project project = projectRepository.save(ProjectProvider.createProject(324091L));
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(project);
 
         // when
-        MeetingPlace meetingPlace = meetingPlaceRepository.save(MeetingPlaceProvider.createMeetingPlace());
-        project.addMeetingPlace(meetingPlace);
-
-        testEntityManager.flush();
-        testEntityManager.clear();
+        MeetingPlace result = meetingPlaceRepository.save(meetingPlace);
 
         // then
-        meetingPlaceRepository.findById(meetingPlace.getId()).orElseThrow(Exception::new);
-        assertThat(project.getMeetingPlaces().size()).isEqualTo(1);
+        assertThat(result.getName()).isEqualTo(meetingPlace.getName());
+        assertThat(result.getLongitude()).isEqualTo(meetingPlace.getLongitude());
+        assertThat(result.getLatitude()).isEqualTo(meetingPlace.getLatitude());
+        assertThat(result.getAddress()).isEqualTo(meetingPlace.getAddress());
+        assertThat(result.getProject().getId()).isEqualTo(project.getId());
     }
 
     @Test
@@ -55,5 +54,30 @@ class MeetingPlaceRepositoryTest {
         assertThatThrownBy(() -> {
             meetingPlaceRepository.save(meetingPlace);
         }).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        meetingPlaceRepository.saveAll(List.of(
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.031, 37.491),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 128.521, 36.723),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.032, 37.487),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 126.684, 35.265)
+        ));
+        SearchByMapBoundaryRequest request = new SearchByMapBoundaryRequest(127.022, 127.918, 37.383, 37.489);
+
+        // when
+        List<MeetingPlace> meetingPlaceList = meetingPlaceRepository.findMeetingPlacesByBoundary(project, request);
+
+        // then
+        assertThat(meetingPlaceList).hasSize(1);
+        assertThat(meetingPlaceList.get(0).getLongitude())
+                .isGreaterThanOrEqualTo(request.getMinLng())
+                .isLessThanOrEqualTo(request.getMaxLng());
+        assertThat(meetingPlaceList.get(0).getLatitude())
+                .isGreaterThanOrEqualTo(request.getMinLat())
+                .isLessThanOrEqualTo(request.getMaxLat());
     }
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
@@ -4,6 +4,8 @@ import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
@@ -13,12 +15,16 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -71,5 +77,30 @@ class MeetingPlaceControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message", containsString("must not be null")));
         verify(meetingPlaceService, never()).createMeetingPlace(anyLong(), any(CreateMeetingPlaceRequest.class));
+    }
+
+    @Test
+    void 프로젝트의_모임_장소들을_조회한다() throws Exception {
+        // given
+        Long projectId = 82425L;
+        List<String> placeNames = List.of("모임장소__", "테스트__", "짜는 중__");
+        List<MeetingPlaceResponse> places = placeNames.stream()
+                        .map(name-> new MeetingPlaceResponse(MeetingPlaceProvider.createMeetingPlaceWithName(name)))
+                        .collect(Collectors.toList());
+
+        given(meetingPlaceService.getMeetingPlaces(projectId))
+                .willReturn(places);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/meeting-places")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(placeNames.size()))
+                .andExpect(jsonPath("$[*].name").value(containsInAnyOrder(placeNames.get(0), placeNames.get(1), placeNames.get(2))));
+        verify(meetingPlaceService, times(1)).getMeetingPlaces(anyLong());
     }
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceControllerTest.java
@@ -2,8 +2,12 @@ package kr.kro.colla.meeting_place.meeting_place.presentation;
 
 import kr.kro.colla.common.ControllerTest;
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
+import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
+import kr.kro.colla.project.project.domain.Project;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.HttpStatus;
@@ -13,11 +17,16 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import javax.servlet.http.Cookie;
 
-import static org.hamcrest.Matchers.containsString;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,7 +39,7 @@ class MeetingPlaceControllerTest extends ControllerTest {
         // given
         Long projectId = 82425L, meetingPlaceId = 234241L;
         CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest("meeting place name", "preview image", 23.23, 3.5, "address to go!");
-        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace();
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(ProjectProvider.createProject(1L));
         ReflectionTestUtils.setField(meetingPlace, "id", meetingPlaceId);
 
         given(meetingPlaceService.createMeetingPlace(eq(projectId), any(CreateMeetingPlaceRequest.class)))
@@ -71,5 +80,51 @@ class MeetingPlaceControllerTest extends ControllerTest {
                 .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message", containsString("must not be null")));
         verify(meetingPlaceService, never()).createMeetingPlace(anyLong(), any(CreateMeetingPlaceRequest.class));
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        Double minLng = 127.022, maxLng = 127.918, minLat = 36.383, maxLat = 37.489;
+        Project project = ProjectProvider.createProject(5L);
+        List<MeetingPlaceResponse> meetingPlaceList = Stream.of(MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.523, 37.024))
+                .map(MeetingPlaceResponse::new)
+                .collect(Collectors.toList());
+
+        given(meetingPlaceService.getSpecificAreaMeetingPlace(eq(projectId), any(SearchByMapBoundaryRequest.class)))
+                .willReturn(meetingPlaceList);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/meeting-places?minLng=" + minLng + "&maxLng=" + maxLng + "&minLat=" + minLat + "&maxLat=" + maxLat)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(meetingPlaceList.size()))
+                .andExpect(jsonPath("$[0].longitude").value(is(greaterThanOrEqualTo(minLng))))
+                .andExpect(jsonPath("$[0].longitude").value(is(lessThanOrEqualTo(maxLng))))
+                .andExpect(jsonPath("$[0].latitude").value(is(greaterThanOrEqualTo(minLat))))
+                .andExpect(jsonPath("$[0].latitude").value(is(lessThanOrEqualTo(maxLat))));
+        verify(meetingPlaceService, times(1)).getSpecificAreaMeetingPlace(anyLong(), any(SearchByMapBoundaryRequest.class));
+    }
+
+    @Test
+    void 지도_바운더리의_정보가_모두_오지_않으면_모임_장소를_조회할_수_없다() throws Exception {
+        // given
+        Long projectId = 1L;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/meeting-places?minLng=" + 127.052)
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                .andExpect(jsonPath("$.message", containsString("must not be null")));
     }
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
@@ -5,6 +5,8 @@ import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import org.junit.jupiter.api.Test;
@@ -13,8 +15,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,26 +28,27 @@ import static org.mockito.Mockito.verify;
 class MeetingPlaceServiceTest {
 
     @Mock
-    MeetingPlaceRepository meetingPlaceRepository;
+    private MeetingPlaceRepository meetingPlaceRepository;
 
     @Mock
-    ProjectService projectService;
+    private ProjectService projectService;
 
     @InjectMocks
-    MeetingPlaceService meetingPlaceService;
+    private MeetingPlaceService meetingPlaceService;
 
     @Test
     void 프로젝트의_모임_장소를_생성한다() {
         // given
         Long projectId = 32492L;
         Project project = ProjectProvider.createProject(234912L);
-        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace();
-        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest();
+        MeetingPlace meetingPlace = MeetingPlaceProvider.createMeetingPlace(project);
+        CreateMeetingPlaceRequest request = new CreateMeetingPlaceRequest("이번 회의 장소", null, 132.234, 23.234, "서울특별시 강남구 ~~로 ~~번길");
 
         given(projectService.findProjectById(projectId))
                 .willReturn(project);
         given(meetingPlaceRepository.save(any(MeetingPlace.class)))
                 .willReturn(meetingPlace);
+
         // when
         MeetingPlace result = meetingPlaceService.createMeetingPlace(projectId, request);
 
@@ -51,6 +57,38 @@ class MeetingPlaceServiceTest {
         assertThat(result.getLongitude()).isEqualTo(meetingPlace.getLongitude());
         assertThat(result.getAddress()).isEqualTo(meetingPlace.getAddress());
         verify(meetingPlaceRepository, times(1)).save(any(MeetingPlace.class));
+    }
+
+    @Test
+    void 지도_바운더리에_해당하는_모임_장소들을_조회한다() {
+        // given
+        Long projectId = 5L;
+        Project project = ProjectProvider.createProject(3L);
+        SearchByMapBoundaryRequest request = new SearchByMapBoundaryRequest(127.022, 127.918, 36.383, 37.489);
+        List<MeetingPlace> meetingPlaceList = List.of(
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.523, 37.024),
+                MeetingPlaceProvider.createMeetingPlaceWithCoordinate(project, 127.218, 36.938)
+        );
+
+        given(projectService.findProjectById(eq(projectId)))
+                .willReturn(project);
+        given(meetingPlaceRepository.findMeetingPlacesByBoundary(any(Project.class), any(SearchByMapBoundaryRequest.class)))
+                .willReturn(meetingPlaceList);
+
+        // when
+        List<MeetingPlaceResponse> result = meetingPlaceService.getSpecificAreaMeetingPlace(projectId, request);
+
+        // then
+        assertThat(result).hasSize(2);
+        result.forEach(meetingPlace -> {
+            assertThat(meetingPlace.getLongitude())
+                    .isGreaterThanOrEqualTo(request.getMinLng())
+                    .isLessThanOrEqualTo(request.getMaxLng());
+            assertThat(meetingPlace.getLatitude())
+                    .isGreaterThanOrEqualTo(request.getMinLat())
+                    .isLessThanOrEqualTo(request.getMaxLat());
+        });
+        verify(meetingPlaceRepository, times(1)).findMeetingPlacesByBoundary(any(Project.class), any(SearchByMapBoundaryRequest.class));
     }
 
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceServiceTest.java
@@ -5,6 +5,7 @@ import kr.kro.colla.common.fixture.ProjectProvider;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
+import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.project.service.ProjectService;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,4 +58,26 @@ class MeetingPlaceServiceTest {
         verify(meetingPlaceRepository, times(1)).save(any(MeetingPlace.class));
     }
 
+    @Test
+    void 프로젝트의_모임_장소들을_조회한다() {
+        // given
+        Long projectId = 52514L;
+        Project project = ProjectProvider.createProject(3205L);
+        List<MeetingPlace> meetingPlaces = List.of(
+                MeetingPlaceProvider.createMeetingPlaceWithName("모임 장소 검색시 이미지 조회.."),
+                MeetingPlaceProvider.createMeetingPlaceWithName("모임 장소 검색시 현재 좌표 반영.."),
+                MeetingPlaceProvider.createMeetingPlaceWithName("모임 장소 저장시 기존 존재 장소 식별..")
+        );
+        ReflectionTestUtils.setField(project, "meetingPlaces", meetingPlaces);
+
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
+        // when
+        List<MeetingPlaceResponse> response = meetingPlaceService.getMeetingPlaces(projectId);
+
+        // then
+        assertThat(response.size()).isEqualTo(meetingPlaces.size());
+        IntStream.range(0, response.size())
+                .forEach(i -> assertThat(response.get(i).getName()).isEqualTo(meetingPlaces.get(i).getName()));
+    }
 }

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -48,6 +48,7 @@
     "no-unneeded-ternary": "off",
     "dot-notation": "off",
     "no-new": "off",
+    "no-underscore-dangle": "off",
     "no-use-before-define": ["error", { "variables": false }],
     "import/prefer-default-export": "off",
     "@typescript-eslint/no-unused-vars": ["error"],

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
-    <script type="text/javascript" src="<%=htmlWebpackPlugin.options.apiUrl%>"></script>
+    <script type="text/javascript" src="<%=htmlWebpackPlugin.options.naverApiUrl%>"></script>
+    <script type="text/javascript" src="<%=htmlWebpackPlugin.options.kakaoApiUrl%>"></script>
 </head>
 <body>
     <div id="root"></div>

--- a/frontend/src/apis/meeting-place.ts
+++ b/frontend/src/apis/meeting-place.ts
@@ -6,3 +6,9 @@ export const createMeetingPlace = async (projectId: number, place: SearchPlaceTy
 
     return response;
 };
+
+export const getMeetingPlaces = async (projectId: number) => {
+    const response = await client.get<Array<MeetingPlaceType>>(`/projects/${projectId}/meeting-places`);
+
+    return response;
+};

--- a/frontend/src/apis/meeting-place.ts
+++ b/frontend/src/apis/meeting-place.ts
@@ -1,0 +1,16 @@
+import { MeetingPlaceType } from '../types/meeting-place';
+import { client } from './common';
+
+export const getSpecificAreaMeetingPlace = async (
+    projectId: number,
+    minLng: number,
+    maxLng: number,
+    minLat: number,
+    maxLat: number,
+) => {
+    const response = await client.get<Array<MeetingPlaceType>>(
+        `/projects/${projectId}/meeting-places?minLng=${minLng}&maxLng=${maxLng}&minLat=${minLat}&maxLat=${maxLat}`,
+    );
+
+    return response;
+};

--- a/frontend/src/apis/meeting-place.ts
+++ b/frontend/src/apis/meeting-place.ts
@@ -1,0 +1,8 @@
+import { MeetingPlaceType, SearchPlaceType } from '../types/meeting-place';
+import { client } from './common';
+
+export const createMeetingPlace = async (projectId: number, place: SearchPlaceType) => {
+    const response = await client.post<MeetingPlaceType>(`/projects/${projectId}/meeting-places`, place);
+
+    return response;
+};

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 
+import { useLocation } from 'react-router-dom';
+import { getSpecificAreaMeetingPlace } from '../../apis/meeting-place';
 import { MeetingPlaceType } from '../../types/meeting-place';
+import { StateType } from '../../types/project';
 import { InfoWindow } from './InfoWindow';
 import { MapContainer } from './style';
 
@@ -34,6 +37,8 @@ const dummy: Array<MeetingPlaceType> = [
 export const Map = () => {
     let markers: Array<any> = [];
     let infoWindows: Array<any> = [];
+    let timer: NodeJS.Timeout;
+    const { state } = useLocation<StateType>();
 
     const handleMarkerClick = (map: any, marker: any) => {
         const idx = markers.indexOf(marker);
@@ -68,6 +73,18 @@ export const Map = () => {
         );
     };
 
+    const searchSpecificAreaMeetingPlace = (map: any) => {
+        if (timer) {
+            clearTimeout(timer);
+        }
+
+        timer = setTimeout(async () => {
+            const { _max, _min } = map.getBounds();
+            const res = await getSpecificAreaMeetingPlace(state.projectId, _min._lng, _max._lng, _min._lat, _max._lat);
+            console.log(res.data); // TODO: 좌측 리스트와 연동
+        }, 1000);
+    };
+
     useEffect(() => {
         const mapOptions = {
             center: new naver.maps.LatLng(37.511337, 127.012084),
@@ -83,6 +100,7 @@ export const Map = () => {
         markMeetingPlace(map);
         createInfoWindows();
         naver.maps.Event.addListener(map, 'click', () => handleClickOtherArea());
+        naver.maps.Event.addListener(map, 'drag', () => searchSpecificAreaMeetingPlace(map));
     }, []);
 
     return (

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -31,7 +31,7 @@ const dummy: Array<MeetingPlaceType> = [
     },
 ];
 
-export const Map = () => {
+const Map = () => {
     let markers: Array<any> = [];
     let infoWindows: Array<any> = [];
 
@@ -91,3 +91,5 @@ export const Map = () => {
         </MapContainer>
     );
 };
+
+export default Map;

--- a/frontend/src/components/Modal/Place/index.tsx
+++ b/frontend/src/components/Modal/Place/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { MeetingPlaceType } from '../../../types/meeting-place';
+import { SearchPlaceType } from '../../../types/meeting-place';
 import Place from '../../Place';
 import { Wrapper, SearchInput, SearchList } from './style';
 
@@ -15,7 +15,7 @@ interface KakaoPlaceType {
 
 const PlaceModal = () => {
     const [keyword, setKeyword] = useState('');
-    const [places, setPlaces] = useState<MeetingPlaceType[]>([]);
+    const [places, setPlaces] = useState<SearchPlaceType[]>([]);
 
     const handleInput = (e: any) => setKeyword(e.target.value);
 
@@ -36,26 +36,25 @@ const PlaceModal = () => {
     const handleSearchResult = (result: KakaoPlaceType[], status: any) => {
         if (status !== kakao.maps.services.Status.OK) return;
 
-        setPlaces([
-            ...result.map(
+        setPlaces(
+            result.map(
                 ({ place_name: name, road_address_name: address, x: longitude, y: latitude }) =>
                     ({
                         name,
                         address,
                         longitude,
                         latitude,
-                    } as MeetingPlaceType),
+                    } as SearchPlaceType),
             ),
-        ]);
-        console.log(places);
+        );
     };
 
     return (
         <Wrapper>
             <SearchInput value={keyword} onChange={handleInput} onKeyPress={handleKeyPress} />
             <SearchList>
-                {places.map(({ name, address }, idx) => (
-                    <Place key={idx} name={name} address={address} />
+                {places.map((place, idx) => (
+                    <Place key={idx} info={place} />
                 ))}
             </SearchList>
         </Wrapper>

--- a/frontend/src/components/Modal/Place/index.tsx
+++ b/frontend/src/components/Modal/Place/index.tsx
@@ -1,19 +1,62 @@
 import React, { useState } from 'react';
 
-import { Wrapper, SearchInput, SearchList, Place } from './style';
+import { MeetingPlaceType } from '../../../types/meeting-place';
+import Place from '../../Place';
+import { Wrapper, SearchInput, SearchList } from './style';
+
+interface KakaoPlaceType {
+    place_name: string;
+    place_url: string;
+    address_name: string;
+    road_address_name: string;
+    x: number;
+    y: number;
+}
 
 const PlaceModal = () => {
-    const [input, setInput] = useState('');
+    const [keyword, setKeyword] = useState('');
+    const [places, setPlaces] = useState<MeetingPlaceType[]>([]);
 
-    const handleInput = (e: any) => setInput(e.value);
+    const handleInput = (e: any) => setKeyword(e.target.value);
+
+    const handleKeyPress = (e: React.KeyboardEvent) => {
+        if (e.key !== 'Enter') return;
+        searchKeyword();
+    };
+
+    const ps = new kakao.maps.services.Places();
+
+    const searchKeyword = () => {
+        console.log(keyword);
+        if (keyword === '') return;
+
+        ps.keywordSearch(keyword, handleSearchResult);
+    };
+
+    const handleSearchResult = (result: KakaoPlaceType[], status: any) => {
+        if (status !== kakao.maps.services.Status.OK) return;
+
+        setPlaces([
+            ...result.map(
+                ({ place_name: name, road_address_name: address, x: longitude, y: latitude }) =>
+                    ({
+                        name,
+                        address,
+                        longitude,
+                        latitude,
+                    } as MeetingPlaceType),
+            ),
+        ]);
+        console.log(places);
+    };
 
     return (
         <Wrapper>
-            <SearchInput value={input} onChange={handleInput} />
+            <SearchInput value={keyword} onChange={handleInput} onKeyPress={handleKeyPress} />
             <SearchList>
-                <Place>장소1</Place>
-                <Place>장소2</Place>
-                <Place>장소3</Place>
+                {places.map(({ name, address }, idx) => (
+                    <Place key={idx} name={name} address={address} />
+                ))}
             </SearchList>
         </Wrapper>
     );

--- a/frontend/src/components/Modal/Place/index.tsx
+++ b/frontend/src/components/Modal/Place/index.tsx
@@ -27,7 +27,6 @@ const PlaceModal = () => {
     const ps = new kakao.maps.services.Places();
 
     const searchKeyword = () => {
-        console.log(keyword);
         if (keyword === '') return;
 
         ps.keywordSearch(keyword, handleSearchResult);

--- a/frontend/src/components/Modal/Place/index.tsx
+++ b/frontend/src/components/Modal/Place/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { FC, useState } from 'react';
 
 import { SearchPlaceType } from '../../../types/meeting-place';
 import Place from '../../Place';
@@ -13,7 +13,11 @@ interface KakaoPlaceType {
     y: number;
 }
 
-const PlaceModal = () => {
+interface PropType {
+    updatePlaces: Function;
+}
+
+const PlaceModal: FC<PropType> = ({ updatePlaces }) => {
     const [keyword, setKeyword] = useState('');
     const [places, setPlaces] = useState<SearchPlaceType[]>([]);
 
@@ -53,7 +57,7 @@ const PlaceModal = () => {
             <SearchInput value={keyword} onChange={handleInput} onKeyPress={handleKeyPress} />
             <SearchList>
                 {places.map((place, idx) => (
-                    <Place key={idx} info={place} />
+                    <Place key={idx} info={place} updatePlaces={updatePlaces} />
                 ))}
             </SearchList>
         </Wrapper>

--- a/frontend/src/components/Modal/Place/style.ts
+++ b/frontend/src/components/Modal/Place/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { GRAY, LIGHT_GRAY } from '../../../styles/color';
+import { GRAY } from '../../../styles/color';
 import { Column, Modal } from '../../../styles/common';
 
 export const Wrapper = styled.div`
@@ -28,13 +28,4 @@ export const SearchList = styled.div`
     align-items: center;
 
     ${Column}
-`;
-
-export const Place = styled.div`
-    width: 400px;
-    height: 120px;
-    border-radius: 20px;
-    margin: 5px 10px 5px 10px;
-    padding: 10px;
-    background: ${LIGHT_GRAY};
 `;

--- a/frontend/src/components/Place/index.tsx
+++ b/frontend/src/components/Place/index.tsx
@@ -1,0 +1,18 @@
+import React, { FC } from 'react';
+import { Wrapper } from './style';
+
+interface PropType {
+    name: string;
+    address: string;
+    image?: string;
+}
+
+const Place: FC<PropType> = ({ name, address, image }) => (
+    <Wrapper>
+        {image ? <img src={image} /> : null}
+        <div>{name}</div>
+        <div>{address}</div>
+    </Wrapper>
+);
+
+export default Place;

--- a/frontend/src/components/Place/index.tsx
+++ b/frontend/src/components/Place/index.tsx
@@ -1,18 +1,32 @@
 import React, { FC } from 'react';
+import { useLocation } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+import { createMeetingPlace } from '../../apis/meeting-place';
+import { SearchPlaceType } from '../../types/meeting-place';
+import { StateType } from '../../types/project';
 import { Wrapper } from './style';
 
 interface PropType {
-    name: string;
-    address: string;
-    image?: string;
+    info: SearchPlaceType;
 }
 
-const Place: FC<PropType> = ({ name, address, image }) => (
-    <Wrapper>
-        {image ? <img src={image} /> : null}
-        <div>{name}</div>
-        <div>{address}</div>
-    </Wrapper>
-);
+const Place: FC<PropType> = ({ info }) => {
+    const { state } = useLocation<StateType>();
+
+    const handleClick = async () => {
+        await createMeetingPlace(state.projectId, info);
+        toast.success('모임 장소 추가에 성공했습니다!');
+        dispatchEvent(new Event('click'));
+    };
+
+    return (
+        <Wrapper onClick={handleClick}>
+            {info.image ? <img src={info.image} /> : null}
+            <div>{info.name}</div>
+            <div>{info.address}</div>
+        </Wrapper>
+    );
+};
 
 export default Place;

--- a/frontend/src/components/Place/index.tsx
+++ b/frontend/src/components/Place/index.tsx
@@ -9,19 +9,24 @@ import { Wrapper } from './style';
 
 interface PropType {
     info: SearchPlaceType;
+    meetingPlace?: boolean;
+    updatePlaces?: Function;
 }
 
-const Place: FC<PropType> = ({ info }) => {
+const Place: FC<PropType> = ({ info, meetingPlace, updatePlaces }) => {
     const { state } = useLocation<StateType>();
 
     const handleClick = async () => {
+        if (meetingPlace) return;
+
         await createMeetingPlace(state.projectId, info);
         toast.success('모임 장소 추가에 성공했습니다!');
         dispatchEvent(new Event('click'));
+        updatePlaces ? updatePlaces(state.projectId) : null;
     };
 
     return (
-        <Wrapper onClick={handleClick}>
+        <Wrapper onClick={handleClick} meetingPlace={meetingPlace}>
             {info.image ? <img src={info.image} /> : null}
             <div>{info.name}</div>
             <div>{info.address}</div>

--- a/frontend/src/components/Place/style.ts
+++ b/frontend/src/components/Place/style.ts
@@ -1,14 +1,18 @@
 import styled from '@emotion/styled';
 
-import { LIGHT_GRAY } from '../../styles/color';
+import { GRAY, LIGHT_GRAY } from '../../styles/color';
 
-export const Wrapper = styled.button`
+interface PropType {
+    meetingPlace?: boolean;
+}
+
+export const Wrapper = styled.button<PropType>`
     width: 400px;
     height: 120px;
     border-radius: 20px;
     margin: 5px 10px 5px 10px;
     padding: 10px;
-    background: ${LIGHT_GRAY};
+    background: ${({ meetingPlace }) => (meetingPlace === true ? GRAY : LIGHT_GRAY)};
 
     &:hover {
         opacity: 0.3;

--- a/frontend/src/components/Place/style.ts
+++ b/frontend/src/components/Place/style.ts
@@ -2,11 +2,15 @@ import styled from '@emotion/styled';
 
 import { LIGHT_GRAY } from '../../styles/color';
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.button`
     width: 400px;
     height: 120px;
     border-radius: 20px;
     margin: 5px 10px 5px 10px;
     padding: 10px;
     background: ${LIGHT_GRAY};
+
+    &:hover {
+        opacity: 0.3;
+    }
 `;

--- a/frontend/src/components/Place/style.ts
+++ b/frontend/src/components/Place/style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+import { LIGHT_GRAY } from '../../styles/color';
+
+export const Wrapper = styled.div`
+    width: 400px;
+    height: 120px;
+    border-radius: 20px;
+    margin: 5px 10px 5px 10px;
+    padding: 10px;
+    background: ${LIGHT_GRAY};
+`;

--- a/frontend/src/components/SideBar/index.tsx
+++ b/frontend/src/components/SideBar/index.tsx
@@ -32,7 +32,7 @@ const MENU = [
     { name: '모임장소', path: '/meeting-place' },
 ];
 
-export const SideBar = ({ props, project }: Props) => {
+const SideBar = ({ props, project }: Props) => {
     const history = useHistory();
     const { state } = useLocation<StateType>();
     const setProjectState = useSetRecoilState(projectState);
@@ -87,3 +87,5 @@ export const SideBar = ({ props, project }: Props) => {
         </>
     );
 };
+
+export default SideBar;

--- a/frontend/src/components/Template/index.tsx
+++ b/frontend/src/components/Template/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import Header from '../Header';
-import { SideBar } from '../SideBar';
+import SideBar from '../SideBar';
 import { Contents } from './style';
 
 const Template: FC = ({ children }) => (

--- a/frontend/src/pages/Backlog/index.tsx
+++ b/frontend/src/pages/Backlog/index.tsx
@@ -8,7 +8,7 @@ import { BacklogFeature } from '../../components/BacklogFeature';
 import Header from '../../components/Header';
 import Issue from '../../components/Issue';
 import { TaskModal } from '../../components/Modal/Task';
-import { SideBar } from '../../components/SideBar';
+import SideBar from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { projectState } from '../../stores/projectState';
 import { StateType } from '../../types/project';

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -4,7 +4,7 @@ import HomeImageSrc from '../../../public/assets/images/home-image.png';
 import { getUserProjects } from '../../apis/user';
 import Header from '../../components/Header';
 import ProjectModal from '../../components/Modal/Project';
-import { SideBar } from '../../components/SideBar';
+import SideBar from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { Container, HomeImage, ProjectNotice } from './style';
 

--- a/frontend/src/pages/Kanban/index.tsx
+++ b/frontend/src/pages/Kanban/index.tsx
@@ -7,7 +7,7 @@ import { getProject } from '../../apis/project';
 import Header from '../../components/Header';
 import KanbanCol from '../../components/KanbanCol';
 import CreateTaskStatusModal from '../../components/Modal/TaskStatus/Create';
-import { SideBar } from '../../components/SideBar';
+import SideBar from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { projectState } from '../../stores/projectState';
 import { TaskType } from '../../types/kanban';

--- a/frontend/src/pages/MeetingPlace/index.tsx
+++ b/frontend/src/pages/MeetingPlace/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import Header from '../../components/Header';
-import { Map } from '../../components/Map';
+import Map from '../../components/Map';
 import PlaceModal from '../../components/Modal/Place';
-import { SideBar } from '../../components/SideBar';
+import SideBar from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
 import { Container, Wrapper, AddPlace, Place, PlaceList, PlaceContainer } from './style';
 

--- a/frontend/src/pages/MeetingPlace/index.tsx
+++ b/frontend/src/pages/MeetingPlace/index.tsx
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 
+import { getMeetingPlaces } from '../../apis/meeting-place';
 import Header from '../../components/Header';
 import Map from '../../components/Map';
 import PlaceModal from '../../components/Modal/Place';
+import Place from '../../components/Place';
 import SideBar from '../../components/SideBar';
 import useModal from '../../hooks/useModal';
-import { Container, Wrapper, AddPlace, Place, PlaceList, PlaceContainer } from './style';
+import { MeetingPlaceType } from '../../types/meeting-place';
+import { StateType } from '../../types/project';
+import { Container, Wrapper, AddPlace, PlaceList, PlaceContainer } from './style';
 
 const MeetingPlace = () => {
+    const { state } = useLocation<StateType>();
     const { Modal, setModal } = useModal();
+    const [meetingPlaces, setMeetingPlaces] = useState<Array<MeetingPlaceType>>([]);
 
+    const updateMeetingPlaces = async (projectId: number) => {
+        const response = await getMeetingPlaces(projectId);
+        setMeetingPlaces(response.data);
+    };
+
+    useEffect(() => {
+        updateMeetingPlaces(state.projectId);
+    }, []);
     return (
         <>
             <Header />
@@ -19,15 +34,13 @@ const MeetingPlace = () => {
                     <PlaceContainer>
                         <AddPlace onClick={setModal}>모임 장소 추가</AddPlace>
                         <PlaceList>
-                            <Place>장소1</Place>
-                            <Place>장소2</Place>
-                            <Place>장소3</Place>
-                            <Place>장소3</Place>
-                            <Place>장소3</Place>
+                            {meetingPlaces.map((place: MeetingPlaceType, idx: number) => (
+                                <Place meetingPlace key={idx} info={place} />
+                            ))}
                         </PlaceList>
                     </PlaceContainer>
                     <Modal>
-                        <PlaceModal />
+                        <PlaceModal updatePlaces={updateMeetingPlaces} />
                     </Modal>
                     <Map />
                 </Wrapper>

--- a/frontend/src/pages/MeetingPlace/style.ts
+++ b/frontend/src/pages/MeetingPlace/style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { GRAY, LIGHT_GRAY } from '../../styles/color';
+import { LIGHT_GRAY } from '../../styles/color';
 import { Column } from '../../styles/common';
 
 export const Container = styled.div`
@@ -29,7 +29,7 @@ export const AddPlace = styled.button`
     width: 150px;
     height: 50px;
     position: relative;
-    right: -40%;
+    right: -30%;
     margin-top: 10px;
     margin-bottom: 20px;
     background: ${LIGHT_GRAY};
@@ -44,24 +44,16 @@ export const PlaceList = styled.div`
     align-items: center;
     width: 38vw;
     min-width: fit-content;
-    height: 600px;
+    height: 70vh;
     overflow-y: scroll;
     background: ${LIGHT_GRAY};
     border-radius: 20px;
     padding: 10px;
+    margin-right: 15px;
 
     &::-webkit-scrollbar {
         display: none;
     }
 
     ${Column}
-`;
-
-export const Place = styled.div`
-    width: 400px;
-    min-height: 150px;
-    border-radius: 20px;
-    margin: 5px 10px 5px 10px;
-    padding: 10px;
-    background: ${GRAY};
 `;

--- a/frontend/src/pages/Roadmap/index.tsx
+++ b/frontend/src/pages/Roadmap/index.tsx
@@ -5,7 +5,7 @@ import { getProjectStories } from '../../apis/story';
 import Header from '../../components/Header';
 import { IssueList } from '../../components/List/IssueList';
 import RoadmapStory from '../../components/RoadmapStory';
-import { SideBar } from '../../components/SideBar';
+import SideBar from '../../components/SideBar';
 import { StateType } from '../../types/project';
 import { StoryType } from '../../types/roadmap';
 import { Container, Wrapper, RoadmapArea } from './style';

--- a/frontend/src/types/meeting-place.ts
+++ b/frontend/src/types/meeting-place.ts
@@ -1,8 +1,11 @@
-export interface MeetingPlaceType {
-    id: number;
+export interface SearchPlaceType {
     name: string;
-    image: string | null;
+    image?: string;
     latitude: number;
     longitude: number;
     address: string;
+}
+
+export interface MeetingPlaceType extends SearchPlaceType {
+    id: number;
 }

--- a/frontend/src/types/meeting-place.ts
+++ b/frontend/src/types/meeting-place.ts
@@ -1,7 +1,7 @@
 export interface MeetingPlaceType {
     id: number;
     name: string;
-    image: string;
+    image: string | null;
     latitude: number;
     longitude: number;
     address: string;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin({
             template: './public/index.html',
-            apiUrl: `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.CLIENT_ID}`,
+            naverApiUrl: `https://openapi.map.naver.com/openapi/v3/maps.js?ncpClientId=${process.env.NAVER_CLIENT_ID}`,
+            kakaoApiUrl: `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.KAKAO_CLIENT_ID}&libraries=services`,
         }),
         new EslintWebpackPlugin({
             extensions: ['js', 'jsx', 'ts', 'tsx'],


### PR DESCRIPTION
### 🔨 작업 내용 설명
키워드 기반으로 지도의 장소를 검색하는 기능을 추가했습니다!
이미지 처리와 현재 위치 기반으로 기본 좌표 지정할 수 있도록 처리는 아직 진행하지 않았어요 😹
(현재 좌표 상관없이 키워드 기반으로만 검색)

프로젝트의 모든 모임 장소를 조회하는 API도 구현하고 테스트까지 완료해놓았습니다~

### 📑 구현한 내용 목록

- [x] 프로젝트 모임 장소 목록 조회 API 구현
- [x] 모임 장소 목록 조회 관련 테스트 추가
- [x] 키워드 기반 장소 검색 지도 API 연동해 기능 구현
- [x] 모임 장소 추가 API와 검색 모달 연동 완료 

### 🚧 논의 사항
- 네이버 지도 API는 좌표 -> 장소 / 장소 -> 좌표 밖에 지원하지 않아서 카카오 지도 API의 키워드 기반 장소 검색을 사용했습니다
 기존 환경 변수 네이밍을 헷갈릴 수 있을 거 같아서 `NAVER_CLIENT_ID` `KAKAO_CLIENT_ID`의 네이밍으로 변경했습니다.
(노션에 카카오 지도 키 추가해놓겠습니다 🙃  )
 장소 검색에서 이미지를 기본 정보에 포함하지 않아서 추가적인 처리로 가져오도록 해야할 것 같아요 (아직 방식 고민중)
 현재 좌표 기반 검색으로 만들고 싶은데 추가적인 라이브러리 사용해야할 거 같아서 좀 더 알아보고 도입해보겠습니다~

- 모달에서 검색된 장소 목록의 장소와 저장된 모임 장소의 장소 모두 Place 컴포넌트로 처리할 수 있도록 했습니다 (`meetingPlace` 프롭스 true/false(undefined) 기반 구분)
    ```
  <Place updatePlaces ={Function} /> 
   // 검색된 장소 
   // background 컬러 밝은 회색 /  컴포넌트 클릭시 모임 장소 추가 API 요청 / updatePlaces 함수로 모임 장소 추가후 모임 장소 목록 갱신
   <Place meetingPlace /> 
  // 모임 장소 
  // background 컬러 짙은 회색 / 컴포넌트 클릭시 무시
    ```
- 프로젝트의 모든 모임 장소들을 조회하기 위해서 Project.getMeetingPlaces()를 이용해 
 서비스단에서 Response로 변환해 반환하도록 했습니다! 
(최대한 수정 없도록 구현하긴 했지만 Meeting Place가 Project 가지도록 머지하고 나서 일부 수정은 필요할 거 같아요~)

- close #120 
