### PR TITLE
[#124] feat: 바운더리 좌측 목록과 연동 및 모임 장소 삭제 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -41,4 +41,12 @@ public class MeetingPlaceController {
 
         return ResponseEntity.ok(meetingPlaceList);
     }
+
+    @DeleteMapping("/meeting-places/{meetingPlaceId}")
+    public ResponseEntity<Void> deleteMeetingPlace(@PathVariable Long meetingPlaceId) {
+        meetingPlaceService.deleteMeetingPlace(meetingPlaceId);
+
+        return ResponseEntity.ok()
+                .build();
+    }
 }

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/presentation/MeetingPlaceController.java
@@ -5,7 +5,6 @@ import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPl
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.MeetingPlaceResponse;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
-import kr.kro.colla.project.project.service.ProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
+++ b/backend/src/main/java/kr/kro/colla/meeting_place/meeting_place/service/MeetingPlaceService.java
@@ -1,5 +1,6 @@
 package kr.kro.colla.meeting_place.meeting_place.service;
 
+import kr.kro.colla.exception.exception.meeting_place.MeetingPlaceNotFoundException;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.domain.repository.MeetingPlaceRepository;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.CreateMeetingPlaceRequest;
@@ -54,4 +55,15 @@ public class MeetingPlaceService {
                 .map(MeetingPlaceResponse::new)
                 .collect(Collectors.toList());
     }
+
+    public void deleteMeetingPlace(Long meetingPlaceId) {
+        MeetingPlace meetingPlace = findMeetingPlaceById(meetingPlaceId);
+        meetingPlaceRepository.delete(meetingPlace);
+    }
+
+    public MeetingPlace findMeetingPlaceById(Long id) {
+        return meetingPlaceRepository.findById(id)
+                .orElseThrow(MeetingPlaceNotFoundException::new);
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/AcceptanceTest.java
@@ -179,4 +179,46 @@ public class AcceptanceTest {
                 });
     }
 
+    @Test
+    void 사용자가_특정_모임_장소를_목록에서_삭제한다() {
+        // given
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        모임_장소를_생성한다(accessToken, createdProject.getId(), 127.318, 37.769);
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .delete("api/projects/meeting-places/" + 1L)
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    void 사용자는_존재하지_않은_모임_장소를_삭제할_수_없다() {
+        // given
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+
+        given()
+                .contentType(ContentType.JSON)
+                .cookie("accessToken", accessToken)
+
+        // when
+        .when()
+                .delete("/api/projects/meeting-places/" + 1L)
+
+        // then
+        .then()
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body("status", equalTo(HttpStatus.NOT_FOUND.value()))
+                .body("message", equalTo("해당하는 모임 장소를 찾을 수 없습니다."));
+    }
+
 }

--- a/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/meeting_place/meeting_place/domain/repository/MeetingPlaceRepositoryTest.java
@@ -2,6 +2,7 @@ package kr.kro.colla.meeting_place.meeting_place.domain.repository;
 
 import kr.kro.colla.common.fixture.MeetingPlaceProvider;
 import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.exception.exception.meeting_place.MeetingPlaceNotFoundException;
 import kr.kro.colla.meeting_place.meeting_place.domain.MeetingPlace;
 import kr.kro.colla.meeting_place.meeting_place.presentation.dto.SearchByMapBoundaryRequest;
 import kr.kro.colla.project.project.domain.Project;
@@ -9,6 +10,7 @@ import kr.kro.colla.project.project.domain.repository.ProjectRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.test.context.ActiveProfiles;
 
 import javax.validation.ConstraintViolationException;
@@ -80,4 +82,27 @@ class MeetingPlaceRepositoryTest {
                 .isGreaterThanOrEqualTo(request.getMinLat())
                 .isLessThanOrEqualTo(request.getMaxLat());
     }
+
+    @Test
+    void 선택한_모임_장소를_삭제한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        meetingPlaceRepository.save(MeetingPlaceProvider.createMeetingPlace(project));
+
+        // when
+        meetingPlaceRepository.deleteById(1L);
+
+        // then
+        assertThatThrownBy(() -> meetingPlaceRepository.findById(1L)
+                .orElseThrow(MeetingPlaceNotFoundException::new)
+        ).isInstanceOf(MeetingPlaceNotFoundException.class);
+    }
+
+    @Test
+    void 삭제하려는_모임_장소가_없을_경우_예외가_발생한다() {
+        // when, then
+        assertThatThrownBy(() -> meetingPlaceRepository.deleteById(1L))
+                .isInstanceOf(EmptyResultDataAccessException.class);
+    }
+
 }

--- a/frontend/src/apis/meeting-place.ts
+++ b/frontend/src/apis/meeting-place.ts
@@ -26,3 +26,9 @@ export const getMeetingPlaces = async (projectId: number) => {
 
     return response;
 };
+
+export const deleteMeetingPlace = async (meetingPlaceId: number) => {
+    const response = await client.delete(`/projects/meeting-places/${meetingPlaceId}`);
+
+    return response;
+};

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { FC, useEffect } from 'react';
 
 import { useLocation } from 'react-router-dom';
 import { getSpecificAreaMeetingPlace } from '../../apis/meeting-place';
@@ -7,34 +7,12 @@ import { StateType } from '../../types/project';
 import { InfoWindow } from './InfoWindow';
 import { MapContainer } from './style';
 
-const dummy: Array<MeetingPlaceType> = [
-    {
-        id: 1,
-        name: '컴포즈커피',
-        image: null,
-        longitude: 127.03187208216006,
-        latitude: 37.4918120829107,
-        address: '서울특별시 강남구 역삼동 강남대로66길 14',
-    },
-    {
-        id: 2,
-        name: '달커피',
-        image: null,
-        longitude: 127.03173245188478,
-        latitude: 37.49074981117741,
-        address: '서울특별시 강남구 역삼동 강남대로 308 1층',
-    },
-    {
-        id: 3,
-        name: '커피빈',
-        image: null,
-        longitude: 127.03229097297763,
-        latitude: 37.48765414782675,
-        address: '서울특별시 서초구 서초동 1361-9',
-    },
-];
+interface PropType {
+    meetingPlaces: Array<MeetingPlaceType>;
+    setSpecificMeetingPlaces: Function;
+}
 
-const Map = () => {
+const Map: FC<PropType> = ({ meetingPlaces, setSpecificMeetingPlaces }) => {
     let markers: Array<any> = [];
     let infoWindows: Array<any> = [];
     let timer: NodeJS.Timeout;
@@ -51,7 +29,7 @@ const Map = () => {
     };
 
     const markMeetingPlace = (map: any) => {
-        markers = dummy.map(({ latitude, longitude }) => {
+        markers = meetingPlaces.map(({ latitude, longitude }) => {
             const marker = new naver.maps.Marker({
                 position: new naver.maps.LatLng(latitude, longitude),
                 map,
@@ -63,7 +41,7 @@ const Map = () => {
     };
 
     const createInfoWindows = () => {
-        infoWindows = dummy.map(
+        infoWindows = meetingPlaces.map(
             (meetingPlace, idx) =>
                 new naver.maps.InfoWindow({
                     position: markers[idx],
@@ -81,8 +59,8 @@ const Map = () => {
         timer = setTimeout(async () => {
             const { _max, _min } = map.getBounds();
             const res = await getSpecificAreaMeetingPlace(state.projectId, _min._lng, _max._lng, _min._lat, _max._lat);
-            console.log(res.data); // TODO: 좌측 리스트와 연동
-        }, 1000);
+            setSpecificMeetingPlaces(res.data);
+        }, 500);
     };
 
     useEffect(() => {
@@ -101,7 +79,7 @@ const Map = () => {
         createInfoWindows();
         naver.maps.Event.addListener(map, 'click', () => handleClickOtherArea());
         naver.maps.Event.addListener(map, 'drag', () => searchSpecificAreaMeetingPlace(map));
-    }, []);
+    }, [meetingPlaces]);
 
     return (
         <MapContainer>

--- a/frontend/src/components/Place/index.tsx
+++ b/frontend/src/components/Place/index.tsx
@@ -2,13 +2,14 @@ import React, { FC } from 'react';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
-import { createMeetingPlace } from '../../apis/meeting-place';
-import { SearchPlaceType } from '../../types/meeting-place';
+import DeleteIconImg from '../../../public/assets/images/delete.png';
+import { createMeetingPlace, deleteMeetingPlace } from '../../apis/meeting-place';
+import { MeetingPlaceType, SearchPlaceType } from '../../types/meeting-place';
 import { StateType } from '../../types/project';
-import { Wrapper } from './style';
+import { DeleteButton, Wrapper } from './style';
 
 interface PropType {
-    info: SearchPlaceType;
+    info: SearchPlaceType | MeetingPlaceType;
     meetingPlace?: boolean;
     updatePlaces?: Function;
 }
@@ -25,9 +26,15 @@ const Place: FC<PropType> = ({ info, meetingPlace, updatePlaces }) => {
         updatePlaces ? updatePlaces(state.projectId) : null;
     };
 
+    const handleDeleteBtn = async () => {
+        await deleteMeetingPlace((info as MeetingPlaceType).id);
+        window.location.replace(`/meeting-place`);
+    };
+
     return (
         <Wrapper onClick={handleClick} meetingPlace={meetingPlace}>
             {info.image ? <img src={info.image} /> : null}
+            {meetingPlace ? <DeleteButton src={DeleteIconImg} onClick={handleDeleteBtn} /> : null}
             <div>{info.name}</div>
             <div>{info.address}</div>
         </Wrapper>

--- a/frontend/src/components/Place/style.ts
+++ b/frontend/src/components/Place/style.ts
@@ -1,12 +1,14 @@
 import styled from '@emotion/styled';
 
-import { GRAY, LIGHT_GRAY } from '../../styles/color';
+import { BLACK, GRAY, LIGHT_GRAY } from '../../styles/color';
+import { LiftUp } from '../../styles/common';
 
 interface PropType {
     meetingPlace?: boolean;
 }
 
 export const Wrapper = styled.button<PropType>`
+    position: relative;
     width: 400px;
     height: 120px;
     border-radius: 20px;
@@ -15,6 +17,18 @@ export const Wrapper = styled.button<PropType>`
     background: ${({ meetingPlace }) => (meetingPlace === true ? GRAY : LIGHT_GRAY)};
 
     &:hover {
-        opacity: 0.3;
+        opacity: 1;
+        ${LiftUp}
+    }
+`;
+
+export const DeleteButton = styled.img`
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    margin: -20px 0 0 165px;
+
+    &:hover {
+        border-bottom: 2px solid ${BLACK};
     }
 `;

--- a/frontend/src/pages/MeetingPlace/index.tsx
+++ b/frontend/src/pages/MeetingPlace/index.tsx
@@ -16,15 +16,18 @@ const MeetingPlace = () => {
     const { state } = useLocation<StateType>();
     const { Modal, setModal } = useModal();
     const [meetingPlaces, setMeetingPlaces] = useState<Array<MeetingPlaceType>>([]);
+    const [specificMeetingPlaces, setSpecificMeetingPlaces] = useState<Array<MeetingPlaceType>>([]);
 
     const updateMeetingPlaces = async (projectId: number) => {
         const response = await getMeetingPlaces(projectId);
         setMeetingPlaces(response.data);
+        setSpecificMeetingPlaces(response.data);
     };
 
     useEffect(() => {
         updateMeetingPlaces(state.projectId);
     }, []);
+
     return (
         <>
             <Header />
@@ -34,7 +37,7 @@ const MeetingPlace = () => {
                     <PlaceContainer>
                         <AddPlace onClick={setModal}>모임 장소 추가</AddPlace>
                         <PlaceList>
-                            {meetingPlaces.map((place: MeetingPlaceType, idx: number) => (
+                            {specificMeetingPlaces.map((place: MeetingPlaceType, idx: number) => (
                                 <Place meetingPlace key={idx} info={place} />
                             ))}
                         </PlaceList>
@@ -42,7 +45,7 @@ const MeetingPlace = () => {
                     <Modal>
                         <PlaceModal updatePlaces={updateMeetingPlaces} />
                     </Modal>
-                    <Map />
+                    <Map meetingPlaces={meetingPlaces} setSpecificMeetingPlaces={setSpecificMeetingPlaces} />
                 </Wrapper>
             </Container>
         </>


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 바운더리 좌측 목록과 연동
- 모임 장소 삭제 구현

### 📑 구현한 내용 목록
- [x] 바운더리 좌측 목록과 연동
- [x] 모임 장소 삭제 API 구현
- [x] 모임 장소 삭제 API 테스트 코드 작성

### 🚧 논의 사항
- 바운더리에 따른 모임장소를 좌측 리스트에 렌더링할 때 지도에는 여전히 모든 모임장소가 마킹되어야 할 것 같아서 좌측 리스트는 `SpecificMeetingPlaces` 상태로, 우측 지도는 `meetingPlaces` 상태로 렌더링 해주었습니다~

- close #124 
