### PR TITLE
[#130] feat: TaskStatusLog 기능 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task/presentation/TaskController.java
@@ -35,16 +35,16 @@ public class TaskController {
     }
 
     @PutMapping("/tasks/{taskId}")
-    public ResponseEntity<Void> updateTask(@PathVariable Long taskId, @Valid UpdateTaskRequest updateTaskRequest) {
+    public ResponseEntity<Void> updateTask(@PathVariable(name = "taskId") Long taskId, @Valid UpdateTaskRequest updateTaskRequest) {
         taskService.updateTask(taskId, updateTaskRequest);
 
         return ResponseEntity.ok()
                 .build();
     }
 
-    @PatchMapping("/tasks/{taskId}")
-    public ResponseEntity<Void> updateTaskStatus(@PathVariable Long taskId, @Valid @RequestBody UpdateTaskStatusRequest request) {
-        taskService.updateTaskStatus(taskId, request.getStatusName());
+    @PatchMapping("/{projectId}/tasks/{taskId}")
+    public ResponseEntity<Void> updateTaskStatus(@PathVariable(name = "projectId") Long projectId, @PathVariable(name = "taskId") Long taskId, @Valid @RequestBody UpdateTaskStatusRequest request) {
+        taskService.updateTaskStatus(projectId, taskId, request.getStatusName());
 
         return ResponseEntity.ok()
                 .build();

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/TaskStatusLog.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/TaskStatusLog.java
@@ -1,0 +1,45 @@
+package kr.kro.colla.task.task_status_log.domain;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task.domain.Task;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TaskStatusLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String status;
+
+    @ManyToOne
+    @JoinColumn(name = "project_id")
+    private Project project;
+
+    @ManyToOne
+    @JoinColumn(name = "task_id")
+    private Task task;
+
+    @CreatedDate
+    private LocalDate createdAt;
+
+    @Builder
+    public TaskStatusLog(String status, Project project, Task task) {
+        this.status = status;
+        this.project = project;
+        this.task = task;
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepository.java
@@ -1,0 +1,14 @@
+package kr.kro.colla.task.task_status_log.domain.repository;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TaskStatusLogRepository extends JpaRepository<TaskStatusLog, Long> {
+
+    Optional<TaskStatusLog> findTaskStatusLogByProjectAndTaskAndStatus(Project project, Task task, String status);
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/service/TaskStatusLogService.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/service/TaskStatusLogService.java
@@ -1,0 +1,38 @@
+package kr.kro.colla.task.task_status_log.service;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+import kr.kro.colla.task.task_status_log.domain.repository.TaskStatusLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TaskStatusLogService {
+
+    private final String DONE = "Done";
+    private final TaskStatusLogRepository taskStatusLogRepository;
+
+    public void writeTaskStatusLog(Project project, Task task, TaskStatus prevStatus, TaskStatus newStatus) {
+        if (prevStatus == null || newStatus.getName().equalsIgnoreCase(DONE)) {
+            TaskStatusLog taskStatusLog = TaskStatusLog.builder()
+                    .status(newStatus.getName())
+                    .project(project)
+                    .task(task)
+                    .build();
+            taskStatusLogRepository.save(taskStatusLog);
+            return;
+        }
+
+        if (prevStatus.getName().equalsIgnoreCase(DONE)) {
+            taskStatusLogRepository.findTaskStatusLogByProjectAndTaskAndStatus(project, task, DONE)
+                    .ifPresent(taskStatusLogRepository::delete);
+        }
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusLogProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusLogProvider.java
@@ -1,0 +1,18 @@
+package kr.kro.colla.common.fixture;
+
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+
+public class TaskStatusLogProvider {
+
+    public static TaskStatusLog 태스크_상태_로그_생성(Project project, Task task, TaskStatus taskStatus) {
+        return TaskStatusLog.builder()
+                .status(taskStatus.getName())
+                .project(project)
+                .task(task)
+                .build();
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/AcceptanceTest.java
@@ -309,7 +309,7 @@ public class AcceptanceTest {
                 .body(request)
         // when
         .when()
-                .patch("/api/projects/tasks/" + 1L)
+                .patch("/api/projects/"+ createdProject.getId() +"/tasks/" + 1L)
         // then
         .then()
                 .statusCode(HttpStatus.OK.value());
@@ -332,7 +332,7 @@ public class AcceptanceTest {
                 .body(request)
         // when
         .when()
-                .patch("/api/projects/tasks/" + 1L)
+                .patch("/api/projects/" + createdProject.getId() + "/tasks/" + 1L)
         // then
         .then()
                 .statusCode(HttpStatus.BAD_REQUEST.value())

--- a/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/presentation/TaskControllerTest.java
@@ -101,12 +101,12 @@ class TaskControllerTest extends ControllerTest {
     @Test
     void 프로젝트에_속한_테스크의_상태값을_수정한다() throws Exception {
         // given
-        Long taskId = 13494L;
+        Long projectId = 1L, taskId = 13494L;
         String statusNameToUpdate = "새로운~상태~값~입니다~";
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest(statusNameToUpdate);
 
         // when
-        ResultActions perform = mockMvc.perform(patch("/projects/tasks/" + taskId)
+        ResultActions perform = mockMvc.perform(patch("/projects/" + projectId + "/tasks/" + taskId)
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -114,17 +114,17 @@ class TaskControllerTest extends ControllerTest {
         // then
         perform
                 .andExpect(status().isOk());
-        verify(taskService, times(1)).updateTaskStatus(taskId, statusNameToUpdate);
+        verify(taskService, times(1)).updateTaskStatus(projectId, taskId, statusNameToUpdate);
     }
 
     @Test
     void 상태값_이름이_부족하면_테스크_상태를_수정할_수_없다() throws Exception {
         // given
-        Long taskId = 13494L;
+        Long projectId = 1L, taskId = 13494L;
         UpdateTaskStatusRequest request = new UpdateTaskStatusRequest();
 
         // when
-        ResultActions perform = mockMvc.perform(patch("/projects/tasks/" + taskId)
+        ResultActions perform = mockMvc.perform(patch("/projects/" + projectId + "/tasks/" + taskId)
                 .cookie(new Cookie("accessToken", accessToken))
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)));
@@ -134,7 +134,7 @@ class TaskControllerTest extends ControllerTest {
                 .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
                     .andExpect(jsonPath("$.message").value("statusName : must not be null"));
-        verify(taskService, times(0)).updateTaskStatus(eq(taskId), anyString());
+        verify(taskService, times(0)).updateTaskStatus(eq(projectId), eq(taskId), anyString());
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task/service/TaskServiceTest.java
@@ -11,6 +11,7 @@ import kr.kro.colla.task.tag.domain.Tag;
 import kr.kro.colla.task.task.domain.Task;
 import kr.kro.colla.task.task.domain.repository.TaskRepository;
 import kr.kro.colla.task.task.presentation.dto.*;
+import kr.kro.colla.task.task_status_log.service.TaskStatusLogService;
 import kr.kro.colla.task.task_tag.domain.TaskTag;
 import kr.kro.colla.task.task_tag.service.TaskTagService;
 import kr.kro.colla.user.user.domain.User;
@@ -31,6 +32,7 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,6 +52,9 @@ class TaskServiceTest {
 
     @Mock
     private TaskStatusService taskStatusService;
+
+    @Mock
+    private TaskStatusLogService taskStatusLogService;
 
     @Mock
     private TaskRepository taskRepository;
@@ -88,6 +93,9 @@ class TaskServiceTest {
                 .willReturn(List.of(new TaskTag(task, new Tag("backend"))));
         given(taskRepository.save(any(Task.class)))
                 .willReturn(task);
+        willDoNothing()
+                .given(taskStatusLogService)
+                .writeTaskStatusLog(any(Project.class), any(Task.class), isNull(), any(TaskStatus.class));
 
         // when
         Long taskId = taskService.createTask(createTaskRequest);
@@ -98,6 +106,7 @@ class TaskServiceTest {
         verify(storyService, times(1)).findStoryByTitle(storyTitle);
         verify(taskStatusService, times(1)).findTaskStatusByName(taskStatusName);
         verify(taskRepository, times(1)).save(any(Task.class));
+        verify(taskStatusLogService, times(1)).writeTaskStatusLog(any(Project.class), any(Task.class), isNull(), any(TaskStatus.class));
     }
 
     @Test
@@ -361,21 +370,28 @@ class TaskServiceTest {
     @Test
     void 테스크의_상태값을_수정한다() {
         // given
-        Long taskId = 482593L;
+        Long projectId = 1L, taskId = 482593L;
+        Project project = ProjectProvider.createProject(5L);
         TaskStatus before = new TaskStatus("기존_상태값");
         TaskStatus after = new TaskStatus("변경_후_새로운_상태값");
         Task task = TaskProvider.createTaskForRepository(2345L, null, null, before);
 
+        given(projectService.findProjectById(projectId))
+                .willReturn(project);
         given(taskRepository.findById(taskId))
                 .willReturn(Optional.of(task));
         given(taskStatusService.findTaskStatusByName(after.getName()))
                 .willReturn(after);
+        willDoNothing()
+                .given(taskStatusLogService)
+                .writeTaskStatusLog(any(Project.class), any(Task.class), any(TaskStatus.class), any(TaskStatus.class));
 
         // when
-        taskService.updateTaskStatus(taskId, after.getName());
+        taskService.updateTaskStatus(projectId, taskId, after.getName());
 
         // then
         assertThat(task.getTaskStatus().getName()).isEqualTo(after.getName());
+        verify(taskStatusLogService, times(1)).writeTaskStatusLog(any(Project.class), any(Task.class), any(TaskStatus.class), any(TaskStatus.class));
     }
 
     @Test

--- a/backend/src/test/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepositoryTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepositoryTest.java
@@ -1,0 +1,81 @@
+package kr.kro.colla.task.task_status_log.domain.repository;
+
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.project.domain.repository.ProjectRepository;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task.domain.repository.TaskRepository;
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+
+import static kr.kro.colla.common.fixture.TaskStatusLogProvider.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@EnableJpaAuditing
+@DataJpaTest
+class TaskStatusLogRepositoryTest {
+
+    @Autowired
+    private TaskRepository taskRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private TaskStatusLogRepository taskStatusLogRepository;
+
+    @Test
+    void 태스크_상태_로그를_저장한다() {
+        // given
+        Project project = projectRepository.save(ProjectProvider.createProject(1L));
+        TaskStatus taskStatus = project.getTaskStatuses().get(0);
+        Task task = taskRepository.save(TaskProvider.createTaskForRepository(null, project, null, taskStatus));
+        TaskStatusLog taskStatusLog = 태스크_상태_로그_생성(project, task, taskStatus);
+
+        // when
+        TaskStatusLog result = taskStatusLogRepository.save(taskStatusLog);
+
+        // then
+        assertThat(result.getProject().getId()).isEqualTo(project.getId());
+        assertThat(result.getTask().getId()).isEqualTo(task.getId());
+        assertThat(result.getStatus()).isEqualTo(taskStatus.getName());
+        assertThat(result.getCreatedAt()).isEqualTo(LocalDate.now());
+    }
+
+    @Test
+    void 현재_프로젝트의_특정_태스크_상태_로그를_조회한다() {
+        // given
+        Project firstProject = projectRepository.save(ProjectProvider.createProject(1L));
+        Project secondProject = projectRepository.save(ProjectProvider.createProject(5L));
+        TaskStatus taskStatus1ForFirstProject = firstProject.getTaskStatuses().get(0);
+        TaskStatus taskStatus2ForFirstProject = firstProject.getTaskStatuses().get(2);
+        TaskStatus taskStatusForSecondProject = secondProject.getTaskStatuses().get(0);
+
+        Task task1 = taskRepository.save(TaskProvider.createTaskForRepository(null, firstProject, null, taskStatus1ForFirstProject));
+        Task task2 = taskRepository.save(TaskProvider.createTaskForRepository(null, secondProject, null, taskStatusForSecondProject));
+        Task task3 = taskRepository.save(TaskProvider.createTaskForRepository(null, firstProject, null, taskStatus2ForFirstProject));
+
+        taskStatusLogRepository.save(태스크_상태_로그_생성(firstProject, task1, task1.getTaskStatus()));
+        taskStatusLogRepository.save(태스크_상태_로그_생성(secondProject, task2, task2.getTaskStatus()));
+        taskStatusLogRepository.save(태스크_상태_로그_생성(firstProject, task3, task3.getTaskStatus()));
+
+        // when
+        TaskStatusLog result = taskStatusLogRepository.findTaskStatusLogByProjectAndTaskAndStatus(firstProject, task3, taskStatus2ForFirstProject.getName())
+                .orElseThrow(RuntimeException::new);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(taskStatus2ForFirstProject.getName());
+        assertThat(result.getProject().getId()).isEqualTo(firstProject.getId());
+        assertThat(result.getTask().getId()).isEqualTo(task3.getId());
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task_status_log/service/TaskStatusLogServiceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_status_log/service/TaskStatusLogServiceTest.java
@@ -1,0 +1,69 @@
+package kr.kro.colla.task.task_status_log.service;
+
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.TaskStatusProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.project.task_status.domain.TaskStatus;
+import kr.kro.colla.task.task.domain.Task;
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+import kr.kro.colla.task.task_status_log.domain.repository.TaskStatusLogRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static kr.kro.colla.common.fixture.TaskStatusLogProvider.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TaskStatusLogServiceTest {
+
+    @Mock
+    private TaskStatusLogRepository taskStatusLogRepository;
+
+    @InjectMocks
+    private TaskStatusLogService taskStatusLogService;
+
+    @Test
+    void 태스크_생성_및_수정_시_상태_로그를_기록한다() {
+        // given
+        Project project = ProjectProvider.createProject(5L);
+        Task task = TaskProvider.createTask(null, project, null);
+        TaskStatus taskStatus = TaskStatusProvider.createTaskStatus("To Do");
+
+        // when
+        taskStatusLogService.writeTaskStatusLog(project, task, null, taskStatus);
+
+        // then
+        verify(taskStatusLogRepository, times(1)).save(any(TaskStatusLog.class));
+        verify(taskStatusLogRepository, never()).findTaskStatusLogByProjectAndTaskAndStatus(any(Project.class), any(Task.class), anyString());
+    }
+
+    @Test
+    void 태스크_상태가_완료에서_다른_상태로_변경될_경우_완료_상태_로그를_삭제한다() {
+        // given
+        Project project = ProjectProvider.createProject(5L);
+        Task task = TaskProvider.createTask(null, project, null);
+        TaskStatus prevStatus = TaskStatusProvider.createTaskStatus("Done");
+        TaskStatus newStatus = TaskStatusProvider.createTaskStatus("In Progress");
+        TaskStatusLog taskStatusLog = 태스크_상태_로그_생성(project, task, prevStatus);
+
+        given(taskStatusLogRepository.findTaskStatusLogByProjectAndTaskAndStatus(any(Project.class), any(Task.class), anyString()))
+                .willReturn(Optional.ofNullable(taskStatusLog));
+
+        // when
+        taskStatusLogService.writeTaskStatusLog(project, task, prevStatus, newStatus);
+
+        // then
+        verify(taskStatusLogRepository, never()).save(any(TaskStatusLog.class));
+        verify(taskStatusLogRepository, times(1)).findTaskStatusLogByProjectAndTaskAndStatus(any(Project.class), any(Task.class), anyString());
+        verify(taskStatusLogRepository, times(1)).delete(any(TaskStatusLog.class));
+    }
+
+}

--- a/frontend/src/apis/task.ts
+++ b/frontend/src/apis/task.ts
@@ -24,8 +24,8 @@ export const updateTask = async (taskId: number, data: FormData) => {
     return response;
 };
 
-export const updateTaskStatus = async (taskId: number, statusName: string) => {
-    const response = await client.patch(`/projects/tasks/${taskId}`, { statusName });
+export const updateTaskStatus = async (projectId: number, taskId: number, statusName: string) => {
+    const response = await client.patch(`/projects/${projectId}/tasks/${taskId}`, { statusName });
 
     return response;
 };

--- a/frontend/src/components/KanbanCol/index.tsx
+++ b/frontend/src/components/KanbanCol/index.tsx
@@ -1,12 +1,14 @@
 import React, { FC, useState } from 'react';
 import { useDrop } from 'react-dnd';
 
+import { useLocation } from 'react-router-dom';
 import deleteIconImg from '../../../public/assets/images/close-circle.svg';
 import plusIconImg from '../../../public/assets/images/plus-circle.svg';
 import { updateTaskStatus } from '../../apis/task';
 import useInputTask from '../../hooks/useInputTask';
 import useModal from '../../hooks/useModal';
 import { ItemType, TaskType } from '../../types/kanban';
+import { StateType } from '../../types/project';
 import { TaskModal } from '../Modal/Task';
 import DeleteTaskStatusModal from '../Modal/TaskStatus/Delete';
 import Task from '../Task';
@@ -22,14 +24,16 @@ interface PropType {
 }
 
 const KanbanCol: FC<PropType> = ({ statuses, status, taskList, tasks, changeColumn, moveTaskHandler }) => {
+    const { state } = useLocation<StateType>();
     const { clearInputTask } = useInputTask();
     const [taskId, setTaskId] = useState<number | null>(null);
     const { Modal, setModal } = useModal();
     const { Modal: StatusModal, setModal: setStatusModal } = useModal();
 
     const handleUpdateTask = async (taskId: number, statusName: string) => {
-        await updateTaskStatus(taskId, statusName);
+        await updateTaskStatus(state.projectId, taskId, statusName);
     };
+
     const [, drop] = useDrop({
         accept: 'task_type',
         drop: (item: ItemType) => {


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 테이블 생성
- 태스크 상태값 변경에 따른 기록 등록 API 구현
- 테스트 코드 작성

### 📑 구현한 내용 목록
- [x] 테이블 생성
- [x] 태스크 상태값 변경에 따른 기록 등록 API 구현
- [x] 테스트 코드 작성

### 🚧 논의 사항
- `TaskStatusLog` 엔티티의 필드를 `project`, `task`, `status`, `createdAt`으로 구성하였습니다. `project`는 프로젝트마다 구분하기 위함이고, `task`는 추후에 막대 그래프에서 기능을 확장해볼 수 있을 것 같아 두었습니다! `status`는 막대 그래프를 그릴 때 특정 날짜를 조회해와서 `Done`인 것들의 개수와 아닌 것들의 개수로 그려주면 될 것 같아서 두었습니다!
- 태스크를 생성할 때와 태스크의 상태값을 변경시킬 때만 로그를 기록하도록 하였습니다.
```java
public void writeTaskStatusLog(Project project, Task task, TaskStatus prevStatus, TaskStatus newStatus) {
        if (prevStatus == null || newStatus.getName().equalsIgnoreCase(DONE)) {
            TaskStatusLog taskStatusLog = TaskStatusLog.builder()
                    .status(newStatus.getName())
                    .project(project)
                    .task(task)
                    .build();
            taskStatusLogRepository.save(taskStatusLog);
            return;
        }

        if (prevStatus.getName().equalsIgnoreCase(DONE)) {
            taskStatusLogRepository.findTaskStatusLogByProjectAndTaskAndStatus(project, task, DONE)
                    .ifPresent(taskStatusLogRepository::delete);
        }
    }
```
- 기록 로직은 태스크를 생성할 때이거나 태스크의 상태를 `Done`으로 변경시킬 때는 새로운 로그를 기록하도록 하였고, 만약 태스크의 상태값이 `Done`에서 다른 상태값으로 변경되는 경우에는 `Done` 로그를 삭제해주도록 구현하였습니다.
- 조금 고민이 되는 부분은 이슈 생성 대비 해결 그래프인 만큼 "해결" 상태의 태스크를 추적해야 하는데, 협업을 할 때 "해결" 상태를 `Done`으로 둘 수도 있고, `Complete`로 둘 수도 있는 등 다양한데, 이를 어떻게 통일해야 할지 고민이 되는 것 같습니다.

- close #130 
