### PR TITLE
[#137] feat: 태스크 상태값 기반 그래프 구현

### DIFF
--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepository.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/domain/repository/TaskStatusLogRepository.java
@@ -5,10 +5,13 @@ import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface TaskStatusLogRepository extends JpaRepository<TaskStatusLog, Long> {
 
     Optional<TaskStatusLog> findTaskStatusLogByProjectAndStatusAndCreatedAt(Project project, String status, LocalDate createdAt);
+
+    List<TaskStatusLog> findTaskStatusLogsByProjectAndCreatedAtBetween(Project project, LocalDate start, LocalDate end);
 
 }

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/TaskStatusLogController.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/TaskStatusLogController.java
@@ -1,0 +1,29 @@
+package kr.kro.colla.task.task_status_log.presentation;
+
+import kr.kro.colla.task.task_status_log.presentation.dto.TaskStatusLogResponse;
+import kr.kro.colla.task.task_status_log.service.TaskStatusLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+@RestController
+public class TaskStatusLogController {
+
+    private final TaskStatusLogService taskStatusLogService;
+
+    @GetMapping("/{projectId}/task-status-log")
+    public ResponseEntity<Map<String, List<TaskStatusLogResponse>>> getWeeklyTaskStatusLog(@PathVariable Long projectId) {
+        Map<String, List<TaskStatusLogResponse>> weeklyTaskStatusLog = taskStatusLogService.getWeeklyTaskStatusLog(projectId);
+
+        return ResponseEntity.ok(weeklyTaskStatusLog);
+    }
+
+}

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/dto/TaskStatusLogResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/dto/TaskStatusLogResponse.java
@@ -2,9 +2,11 @@ package kr.kro.colla.task.task_status_log.presentation.dto;
 
 import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+@NoArgsConstructor
 @Getter
 public class TaskStatusLogResponse {
 

--- a/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/dto/TaskStatusLogResponse.java
+++ b/backend/src/main/java/kr/kro/colla/task/task_status_log/presentation/dto/TaskStatusLogResponse.java
@@ -1,0 +1,20 @@
+package kr.kro.colla.task.task_status_log.presentation.dto;
+
+import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class TaskStatusLogResponse {
+
+    private Integer count;
+
+    private LocalDate createdAt;
+
+    public TaskStatusLogResponse(TaskStatusLog taskStatusLog) {
+        this.count = taskStatusLog.getCount();
+        this.createdAt = taskStatusLog.getCreatedAt();
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/common/ControllerTest.java
@@ -8,6 +8,7 @@ import kr.kro.colla.meeting_place.meeting_place.service.MeetingPlaceService;
 import kr.kro.colla.project.project.service.ProjectService;
 import kr.kro.colla.story.service.StoryService;
 import kr.kro.colla.task.task.service.TaskService;
+import kr.kro.colla.task.task_status_log.service.TaskStatusLogService;
 import kr.kro.colla.user.notice.service.NoticeService;
 import kr.kro.colla.user.user.service.UserService;
 import kr.kro.colla.user_project.service.UserProjectService;
@@ -60,6 +61,9 @@ public abstract class ControllerTest {
 
     @MockBean
     protected MeetingPlaceService meetingPlaceService;
+
+    @MockBean
+    protected TaskStatusLogService taskStatusLogService;
 
     protected String accessToken = "token";
     protected LoginUser loginUser;

--- a/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusLogProvider.java
+++ b/backend/src/test/java/kr/kro/colla/common/fixture/TaskStatusLogProvider.java
@@ -4,8 +4,6 @@ import kr.kro.colla.project.project.domain.Project;
 import kr.kro.colla.project.task_status.domain.TaskStatus;
 import kr.kro.colla.task.task_status_log.domain.TaskStatusLog;
 
-import java.time.LocalDate;
-
 public class TaskStatusLogProvider {
 
     public static TaskStatusLog 태스크_상태_로그_생성(Project project, TaskStatus taskStatus) {

--- a/backend/src/test/java/kr/kro/colla/task/task_status_log/AcceptanceTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_status_log/AcceptanceTest.java
@@ -1,0 +1,91 @@
+package kr.kro.colla.task.task_status_log;
+
+import io.restassured.RestAssured;
+import io.restassured.common.mapper.TypeRef;
+import io.restassured.http.ContentType;
+import kr.kro.colla.auth.service.JwtProvider;
+import kr.kro.colla.common.database.DatabaseCleaner;
+import kr.kro.colla.common.fixture.Auth;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskProvider;
+import kr.kro.colla.common.fixture.UserProvider;
+import kr.kro.colla.task.task_status_log.presentation.dto.TaskStatusLogResponse;
+import kr.kro.colla.user.user.domain.User;
+import kr.kro.colla.user.user.presentation.dto.UserProjectResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserProvider user;
+
+    @Autowired
+    private ProjectProvider project;
+
+    @Autowired
+    private TaskProvider task;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    private Auth auth;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        auth = new Auth(jwtProvider);
+        databaseCleaner.execute();
+    }
+
+    @Test
+    void 사용자가_대시_보드_페이지에서_상태_로그_그래프를_확인한다() {
+        // given
+        LocalDate end = LocalDate.now();
+        LocalDate start = end.minusDays(6);
+        User member = user.가_로그인을_한다1();
+        String accessToken = auth.토큰을_발급한다(member.getId());
+        UserProjectResponse createdProject = project.를_생성한다(accessToken);
+        task.를_특정_상태로_생성한다(accessToken, member.getId(), createdProject.getId(), null, "To Do");
+        task.를_특정_상태로_생성한다(accessToken, member.getId(), createdProject.getId(), null, "In Progress");
+
+        Map<String, List<TaskStatusLogResponse>> response = given()
+                .cookie("accessToken", accessToken)
+                .contentType(ContentType.JSON)
+
+        // when
+        .when()
+                .get("/api/projects/" + createdProject.getId() + "/task-status-log")
+
+        // then
+        .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<Map<String, List<TaskStatusLogResponse>>>() {});
+
+        assertThat(response).hasSize(3);
+        assertThat(response.get("To Do").get(0).getCreatedAt()).isAfterOrEqualTo(start).isBeforeOrEqualTo(end);
+        assertThat(response.get("In Progress").get(0).getCreatedAt()).isAfterOrEqualTo(start).isBeforeOrEqualTo(end);
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/task/task_status_log/presentation/TaskStatusLogControllerTest.java
+++ b/backend/src/test/java/kr/kro/colla/task/task_status_log/presentation/TaskStatusLogControllerTest.java
@@ -1,0 +1,62 @@
+package kr.kro.colla.task.task_status_log.presentation;
+
+import kr.kro.colla.common.ControllerTest;
+import kr.kro.colla.common.fixture.ProjectProvider;
+import kr.kro.colla.common.fixture.TaskStatusLogProvider;
+import kr.kro.colla.common.fixture.TaskStatusProvider;
+import kr.kro.colla.project.project.domain.Project;
+import kr.kro.colla.task.task_status_log.presentation.dto.TaskStatusLogResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.Cookie;
+
+import java.util.*;
+
+import static kr.kro.colla.common.fixture.TaskStatusLogProvider.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TaskStatusLogController.class)
+class TaskStatusLogControllerTest extends ControllerTest {
+
+    @Test
+    void 일주일_단위의_상태_로그를_조회한다() throws Exception {
+        // given
+        Long projectId = 1L;
+        Project project = ProjectProvider.createProject(5L);
+        Map<String, List<TaskStatusLogResponse>> weeklyTaskStatusLog = new HashMap<>();
+        weeklyTaskStatusLog.put("To Do", List.of(
+                new TaskStatusLogResponse(태스크_상태_로그_생성(project, TaskStatusProvider.createTaskStatus("To Do"))))
+        );
+        weeklyTaskStatusLog.put("In Progress", List.of(
+                new TaskStatusLogResponse(태스크_상태_로그_생성(project, TaskStatusProvider.createTaskStatus("In Progress"))))
+        );
+        weeklyTaskStatusLog.put("Done", new ArrayList<>());
+
+        given(taskStatusLogService.getWeeklyTaskStatusLog(eq(projectId)))
+                .willReturn(weeklyTaskStatusLog);
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/projects/" + projectId + "/task-status-log")
+                .cookie(new Cookie("accessToken", accessToken))
+                .contentType(MediaType.APPLICATION_JSON_VALUE));
+
+        // then
+        perform
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$['To Do'].length()").value(1))
+                .andExpect(jsonPath("$['In Progress'].length()").value(1))
+                .andExpect(jsonPath("$['Done'].length()").value(0));
+        verify(taskStatusLogService, times(1)).getWeeklyTaskStatusLog(anyLong());
+    }
+
+}

--- a/frontend/src/apis/project.ts
+++ b/frontend/src/apis/project.ts
@@ -1,4 +1,4 @@
-import { ProjectTagType, ProjectAllType } from '../types/project';
+import { ProjectTagType, ProjectAllType, WeeklyTaskStatusLogType } from '../types/project';
 import { client } from './common';
 
 export const getProject = async (projectId: number) => {
@@ -63,6 +63,12 @@ export const deleteTaskStatus = async (projectId: number, from: string, to: stri
 
 export const getProjectStatus = async (projectId: number) => {
     const response = await client.get(`/projects/${projectId}/statuses`);
+
+    return response;
+};
+
+export const getWeeklyTaskStatusLog = async (projectId: number) => {
+    const response = await client.get<WeeklyTaskStatusLogType>(`/projects/${projectId}/task-status-log`);
 
     return response;
 };

--- a/frontend/src/components/Chart/LineChart/index.tsx
+++ b/frontend/src/components/Chart/LineChart/index.tsx
@@ -1,21 +1,10 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 
-import { getColorFromColorMap } from '../../../utils/common';
+import { useLocation } from 'react-router-dom';
+import { getWeeklyTaskStatusLog } from '../../../apis/project';
+import { StateType, WeeklyTaskStatusLogType } from '../../../types/project';
+import { getColorFromColorMap, isSameDate } from '../../../utils/common';
 import { Container, Graph, GraphBorderLine, GraphLine } from './style';
-
-interface CountType {
-    count: number;
-}
-
-interface DummyType {
-    [key: string]: Array<CountType>;
-}
-
-const dummy: DummyType = {
-    'To Do': [{ count: 5 }, { count: 2 }, { count: 8 }, { count: 12 }, { count: 1 }, { count: 3 }, { count: 3 }],
-    'In Progress': [{ count: 10 }, { count: 4 }, { count: 0 }, { count: 0 }, { count: 11 }, { count: 8 }, { count: 7 }],
-    Done: [{ count: 0 }, { count: 1 }, { count: 5 }, { count: 3 }, { count: 2 }, { count: 7 }, { count: 10 }],
-};
 
 interface PropType {
     colors: Map<string, string>;
@@ -28,13 +17,23 @@ const LineChart: FC<PropType> = ({ colors }) => {
     const rowCnt = 8,
         columnCnt = 15;
     const offset = 12;
+    const { state } = useLocation<StateType>();
+    const weeklyDate: Array<Date> = [];
+    const [weeklyTaskStatusLog, setWeeklyTaskStatusLog] = useState<WeeklyTaskStatusLogType>({});
 
-    const calcDate = (i: number) => {
-        const today = new Date();
-        return new Date(today.setDate(today.getDate() - i)).getDate();
+    const calcDate = () => {
+        Array(rowCnt)
+            .fill(0)
+            .map((el, i) => i)
+            .map((i) => rowCnt - i - 2)
+            .forEach((i) => {
+                const today = new Date();
+                weeklyDate.push(new Date(today.setDate(today.getDate() - i)));
+            });
     };
 
-    const drawWeekDate = () => {
+    const drawWeeklyDate = () => {
+        calcDate();
         const weekDate = Array(rowCnt)
             .fill(0)
             .map((el, i) => i)
@@ -45,7 +44,7 @@ const LineChart: FC<PropType> = ({ colors }) => {
                     x={(width / (columnCnt - 1)) * i * 2}
                     y={height + 30}
                 >
-                    {calcDate(rowCnt - i - 2)}
+                    {weeklyDate[i].getDate()}
                 </text>
             ));
 
@@ -55,21 +54,26 @@ const LineChart: FC<PropType> = ({ colors }) => {
     const drawGraph = (status: string) => {
         const color = getColorFromColorMap(status, colors);
         let prevX = 0,
-            prevY = 0;
+            prevY = 0,
+            prevH = 0;
 
         return Array(columnCnt)
             .fill(0)
             .map((el, i) => i)
             .filter((i) => i % 2 === 0)
             .map((i, idx) => {
+                const dailyCount = weeklyTaskStatusLog[status].filter((el) =>
+                    isSameDate(new Date(el.createdAt), weeklyDate[idx]),
+                );
+                const count = dailyCount.length > 0 ? dailyCount[0].count : 0;
                 const x = (width / (columnCnt - 1)) * (idx < 7 ? i : i - 2) + offset;
                 const y = height + offset;
                 const max = height - offset;
-                const h = (max * dummy[status][idx < 7 ? idx : idx - 1].count) / maxCount;
+                const h = (max * count) / maxCount;
 
                 if (idx === 7) {
                     return (
-                        <text dominantBaseline="baseline" x={x + offset} y={y - h + 5} fill={color}>
+                        <text dominantBaseline="baseline" x={x + offset} y={y - prevH + 5} fill={color}>
                             {status}
                         </text>
                     );
@@ -88,39 +92,47 @@ const LineChart: FC<PropType> = ({ colors }) => {
                                 style={{ '--idx': idx } as React.CSSProperties}
                             />
                             <text dominantBaseline="baseline" x={x - 6} y={y - h - offset} fill={color}>
-                                {dummy[status][idx].count}
+                                {count}
                             </text>
                         </>
                     ) : (
                         <>
                             <circle cx={x} cy={y - h} r={5} fill={color} />
                             <text dominantBaseline="baseline" x={x - 6} y={y - h - offset} fill={color}>
-                                {dummy[status][idx].count}
+                                {count}
                             </text>
                         </>
                     );
 
                 prevX = x;
                 prevY = y - h;
+                prevH = h;
 
                 return graph;
             });
     };
 
     const drawStatusGraph = () => {
-        Object.values(dummy).forEach((status) => {
-            status.forEach((el) => (maxCount = Math.max(maxCount, el.count)));
+        Object.values(weeklyTaskStatusLog).forEach((statusLogs) => {
+            statusLogs.forEach((el) => (maxCount = Math.max(maxCount, el.count)));
         });
 
-        return Object.keys(dummy).map((status) => drawGraph(status));
+        return Object.keys(weeklyTaskStatusLog).map((status) => drawGraph(status));
     };
+
+    useEffect(() => {
+        (async () => {
+            const res = await getWeeklyTaskStatusLog(state.projectId);
+            setWeeklyTaskStatusLog(res.data);
+        })();
+    }, []);
 
     return (
         <Container>
             <Graph>
                 <GraphBorderLine x1={offset} y1={height + offset} x2={width + offset} y2={height + offset} />
                 <GraphBorderLine x1={offset} y1={offset} x2={offset} y2={height + offset} />
-                {drawWeekDate()}
+                {drawWeeklyDate()}
                 {drawStatusGraph()}
             </Graph>
         </Container>

--- a/frontend/src/components/Chart/LineChart/index.tsx
+++ b/frontend/src/components/Chart/LineChart/index.tsx
@@ -69,7 +69,7 @@ const LineChart: FC<PropType> = ({ colors }) => {
                 const x = (width / (columnCnt - 1)) * (idx < 7 ? i : i - 2) + offset;
                 const y = height + offset;
                 const max = height - offset;
-                const h = (max * count) / maxCount;
+                const h = maxCount > 0 ? (max * count) / maxCount : 0;
 
                 if (idx === 7) {
                     return (

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -29,3 +29,12 @@ export interface ProjectMemberType {
 export interface StateType {
     projectId: number;
 }
+
+export interface TaskStatusLogType {
+    count: number;
+    createdAt: string;
+}
+
+export interface WeeklyTaskStatusLogType {
+    [key: string]: Array<TaskStatusLogType>;
+}

--- a/frontend/src/utils/common.ts
+++ b/frontend/src/utils/common.ts
@@ -31,3 +31,8 @@ export const getColorFromColorMap = (key: string, colors: Map<string, string>) =
     colors.set(key, getRandomColor());
     return colors.get(key)!;
 };
+
+export const isSameDate = (date1: Date, date2: Date) =>
+    date1.getFullYear() === date2.getFullYear() &&
+    date1.getMonth() === date2.getMonth() &&
+    date1.getDate() === date2.getDate();


### PR DESCRIPTION
### 🔨 작업 내용 설명
- 상태값 개수 조회 API 구현
- 테스트 코드 작성
- 클라이언트 API 연동

### 📑 구현한 내용 목록
- [x] 상태값 개수 조회 API 구현
- [x] 테스트 코드 작성
- [x] 클라이언트 API 연동

### 🚧 논의 사항
- 주 단위 태스크 상태 로그 조회 API 구현 후 클라이언트와 연동해두었습니다!

- close #137 
