### PR TITLE
feat: JPA QueryCounter 구현

### DIFF
--- a/backend/src/test/java/kr/kro/colla/config/query_counter/Counter.java
+++ b/backend/src/test/java/kr/kro/colla/config/query_counter/Counter.java
@@ -1,0 +1,40 @@
+package kr.kro.colla.config.query_counter;
+
+public class Counter {
+
+    private int count;
+    private boolean flag;
+
+    public Counter() {
+    }
+
+    public void startQueryCount() {
+        this.flag = true;
+    }
+
+    public void countQuery() {
+        this.count += 1;
+    }
+
+    public int getQueryCount() {
+        return this.count;
+    }
+
+    public boolean getFlag() {
+        return this.flag;
+    }
+
+    public void printQueryCount() {
+        System.out.println("ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ");
+        System.out.println("Query Count : " + this.count + "번");
+        System.out.println("ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ");
+
+        clearQueryCount();
+    }
+
+    public void clearQueryCount() {
+        this.flag = false;
+        this.count = 0;
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountConfig.java
+++ b/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountConfig.java
@@ -1,0 +1,85 @@
+package kr.kro.colla.config.query_counter;
+
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
+@TestConfiguration
+public class QueryCountConfig {
+
+    @Bean
+    public DataSource dataSource() {
+        return DataSourceBuilder.create()
+                .driverClassName("org.h2.Driver")
+                .url("jdbc:h2:mem:testdb")
+                .username("sa")
+                .password("")
+                .build();
+    }
+
+    @Bean
+    public Counter counter() {
+        return new Counter();
+    }
+
+    @Bean
+    public DataSource queryCountDataSource() {
+        return new QueryCountDataSource(dataSource(), counter());
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(queryCountDataSource());
+        em.setPackagesToScan(
+                "kr.kro.colla.task.task.domain",
+                "kr.kro.colla.project.project.domain",
+                "kr.kro.colla.project.task_status.domain",
+                "kr.kro.colla.story.domain",
+                "kr.kro.colla.user.user.domain",
+                "kr.kro.colla.user.notice.domain",
+                "kr.kro.colla.comment.domain",
+                "kr.kro.colla.meeting_place.meeting_place.domain",
+                "kr.kro.colla.meeting_place.mentioned_post.domain",
+                "kr.kro.colla.task.history.domain",
+                "kr.kro.colla.task.tag.domain",
+                "kr.kro.colla.task.task_tag.domain",
+                "kr.kro.colla.user_project.domain",
+                "kr.kro.colla.task.task_status_log.domain"
+        );
+
+        HibernateJpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        vendorAdapter.setShowSql(true);
+        vendorAdapter.setGenerateDdl(true);
+
+        em.setJpaVendorAdapter(vendorAdapter);
+        em.setJpaPropertyMap(jpaProperties());
+
+        return em;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager() {
+        JpaTransactionManager transactionManager = new JpaTransactionManager();
+        transactionManager.setEntityManagerFactory(entityManagerFactory().getObject());
+
+        return transactionManager;
+    }
+
+    private Map<String, Object> jpaProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("hibernate.physical_naming_strategy", CamelCaseToUnderscoresNamingStrategy.class.getName());
+        return props;
+    }
+
+}

--- a/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountDataSource.java
+++ b/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountDataSource.java
@@ -1,0 +1,70 @@
+package kr.kro.colla.config.query_counter;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+public class QueryCountDataSource implements DataSource {
+
+    private DataSource dataSource;
+    private Counter counter;
+
+    public QueryCountDataSource(DataSource dataSource, Counter counter) {
+        this.dataSource = dataSource;
+        this.counter = counter;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        Connection conn = dataSource.getConnection();
+        return (Connection) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class[] { Connection.class },
+                new QueryCountHandler(conn, counter)
+        );
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return dataSource.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        dataSource.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        dataSource.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return dataSource.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return dataSource.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return dataSource.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return dataSource.isWrapperFor(iface);
+    }
+}

--- a/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountHandler.java
+++ b/backend/src/test/java/kr/kro/colla/config/query_counter/QueryCountHandler.java
@@ -1,0 +1,29 @@
+package kr.kro.colla.config.query_counter;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class QueryCountHandler implements InvocationHandler {
+
+    private Object target;
+    private Counter counter;
+
+    public QueryCountHandler(Object target, Counter counter) {
+        this.target = target;
+        this.counter = counter;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        try {
+            Object ret = method.invoke(target, args);
+            if (counter.getFlag() && method.getName().startsWith("prepareStatement")) {
+                counter.countQuery();
+            }
+            return ret;
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+}

--- a/backend/src/test/java/kr/kro/colla/config/redis/RedisTemplateTest.java
+++ b/backend/src/test/java/kr/kro/colla/config/redis/RedisTemplateTest.java
@@ -1,4 +1,4 @@
-package kr.kro.colla.config;
+package kr.kro.colla.config.redis;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
### 🔨 작업 내용 설명
JPA에서 발생하는 쿼리의 개수를 파악하는 QueryCounter 구현

### 📑 구현한 내용 목록
- [x] QueryCounter 구현

### 🚧 논의 사항
- JPA에서 발생하는 쿼리의 개수를 측정하는 QueryCounter 구현
- 사용법
```java
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
public class QueryCounterTest {

    @Autowired
    private Counter counter;

    @Test
    void testQueryCount() {
        counter.startQueryCount();

        // 쿼리의 개수를 측정하고 싶은 비즈니스 로직

        assertThat(counter.getQueryCount()).isEqualTo("발생하는 쿼리 개수");
        counter.printQueryCount();
    }

}
```
